### PR TITLE
[WIP] Native feel of Browser Action popups

### DIFF
--- a/add-on/src/popup/browser-action/header.js
+++ b/add-on/src/popup/browser-action/header.js
@@ -8,7 +8,7 @@ const isJsIpfsEnabled = require('../../lib/is-js-ipfs-enabled')()
 
 module.exports = function header ({ ipfsNodeType, onToggleNodeType, isIpfsOnline }) {
   return html`
-    <div class="pv3 br2 br--top ba bw1 b--white" style="background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%,#043b55 100%); background-size: auto 100%">
+    <div class="pv3 ba bw1 bt-0 br-0 bl-0" style="background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%,#043b55 100%); background-size: auto 100%">
       <div class="tc mb2" title="${isIpfsOnline ? '' : 'offline'}">
         ${logo({
           size: 52,

--- a/add-on/src/popup/browser-action/index.html
+++ b/add-on/src/popup/browser-action/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width" />
   </head>
-  <body style="width: 320px; overflow: hidden; background: white;">
+  <body style="width: 320px; overflow: hidden;">
     <div id="root"></div>
     <script src="../../ipfs-companion-common.js"></script>
     <script src="browser-action.js"></script>

--- a/add-on/src/popup/browser-action/page.css
+++ b/add-on/src/popup/browser-action/page.css
@@ -8,3 +8,8 @@
 .outline-0--focus:focus {
   outline: 0;
 }
+
+html,
+body {
+  background: #041727 linear-gradient(to bottom, #041727, white 50%);
+}

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -30,7 +30,7 @@ module.exports = function browserActionPage (state, emit) {
   const gwStatusProps = Object.assign({}, state)
 
   return html`
-    <div class="helvetica">
+    <div class="helvetica bg-white">
       ${header(headerProps)}
       ${contextActions(contextActionsProps)}
       ${operations(opsProps)}


### PR DESCRIPTION
The goal of this PR is to make the little triangle at the top of the popup feel "native" (where possible).
I am not sure if we can make it work across all browsers, so this is kind of an "exploratory PR".

Rationale:  
- Better UX with dark themes
- Native look-and-feel increases  trust <sup>(tm)</sup>
- Future features (eg. https://github.com/ipfs/ipfs-companion/issues/330)  will require us to display permission dialogs.  Lost likely via browser action popup. We want it to look real, not like a phishing attack. (well, we could just use white background, but still..)

## Remaining work

- [x] Firefox
- [ ] Chrome (if possible)
- [ ] Brave (if possible)

