### PR TITLE
Protocol handlers without web+ prefix in Firefox 59

### DIFF
--- a/add-on/manifest.firefox-58.json
+++ b/add-on/manifest.firefox-58.json
@@ -1,0 +1,38 @@
+{
+  "browser_action": {
+    "browser_style": false
+  },
+  "options_ui": {
+    "browser_style": false
+  },
+  "applications": {
+    "gecko": {
+      "id": "ipfs-firefox-addon@lidel.org",
+      "strict_min_version": "58.0"
+    }
+  },
+  "page_action": {
+    "default_icon": {
+      "128": "icons/ipfs-logo-off.svg"
+    },
+    "default_title": "__MSG_pageAction_titleNonIpfs__",
+    "default_popup": "dist/popup/page-action/index.html"
+  },
+  "protocol_handlers": [
+    {
+      "protocol": "web+dweb",
+      "name": "IPFS Companion: DWEB Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
+    },
+    {
+      "protocol": "web+ipns",
+      "name": "IPFS Companion: IPNS Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
+    },
+    {
+      "protocol": "web+ipfs",
+      "name": "IPFS Companion: IPFS Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
+    }
+  ]
+}

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "ipfs-firefox-addon@lidel.org",
-      "strict_min_version": "58.0"
+      "strict_min_version": "59.0"
     }
   },
   "page_action": {
@@ -21,18 +21,33 @@
   "protocol_handlers": [
     {
       "protocol": "web+dweb",
-      "name": "IPFS Add-On: DWEB protocol handler",
-      "uriTemplate": "https://ipfs.io/%s"
+      "name": "IPFS Companion: DWEB Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
     },
     {
       "protocol": "web+ipns",
-      "name": "IPFS Add-On: IPNS protocol handler",
-      "uriTemplate": "https://ipfs.io/%s"
+      "name": "IPFS Companion: IPNS Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
     },
     {
       "protocol": "web+ipfs",
-      "name": "IPFS Add-On: IPFS protocol handler",
-      "uriTemplate": "https://ipfs.io/%s"
+      "name": "IPFS Companion: IPFS Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
+    },
+    {
+      "protocol": "dweb",
+      "name": "IPFS Companion: DWEB Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
+    },
+    {
+      "protocol": "ipns",
+      "name": "IPFS Companion: IPNS Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
+    },
+    {
+      "protocol": "ipfs",
+      "name": "IPFS Companion: IPFS Protocol Handler",
+      "uriTemplate": "https://ipfs.io/#redirect/%s"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bundle:generic": "shx cp add-on/manifest.common.json add-on/manifest.json && web-ext build -a build/generic",
     "bundle:firefox": "shx cat add-on/manifest.common.json add-on/manifest.firefox.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/",
     "bundle:firefox:beta": "shx cat add-on/manifest.common.json add-on/manifest.firefox.json add-on/manifest.firefox-beta.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/beta/",
+    "bundle:firefox:58": "shx cat add-on/manifest.common.json add-on/manifest.firefox-58.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/58/",
     "watch": "npm-run-all build:copy --parallel watch:*",
     "watch:js": "watchify -p prundupify -t [ browserify-package-json --global ] add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action/index.js add-on/src/popup/page-action/index.js add-on/src/popup/quick-upload.js add-on/src/pages/proxy-acl/index.js add-on/src/pages/proxy-access-dialog/index.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action/browser-action.js -o add-on/dist/popup/page-action/page-action.js -o add-on/dist/popup/quick-upload.js -o add-on/dist/pages/proxy-acl/proxy-acl.js -o add-on/dist/pages/proxy-access-dialog/proxy-access-dialog.js ] -o add-on/dist/ipfs-companion-common.js -v",
     "watch:content-scripts": "run-p watch:content-scripts:*",

--- a/test/functional/lib/ipfs-request.test.js
+++ b/test/functional/lib/ipfs-request.test.js
@@ -153,47 +153,83 @@ describe('modifyRequest', function () {
       state.ipfsNodeType = nodeType
     })
     describe(`with ${nodeType} node:`, function () {
-      describe('request made via "web+" handler from manifest.json/protocol_handlers', function () {
-        // requests done with custom protocol handler are always  normalized to public gateway
+      describe('request made via redirect-based protocol handler from manifest.json/protocol_handlers', function () {
+        // Note: requests done with custom protocol handler are always  normalized to public gateway
         // (if external node is enabled, redirect will happen in next iteration of modifyRequest)
+
+        // without web+ prefix (Firefox > 59: https://github.com/ipfs-shipyard/ipfs-companion/issues/164#issuecomment-356301174)
+        it('should not be normalized if ipfs:/{CID}', function () {
+          const request = url2request('https://ipfs.io/#redirect/ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          expect(modifyRequest(request)).to.equal(undefined)
+        })
+        it('should be normalized if ipfs://{CID}', function () {
+          const request = url2request('https://ipfs.io/#redirect/ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          expect(modifyRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+        })
+        it('should not be normalized if ipns:/{foo}', function () {
+          const request = url2request('https://ipfs.io/#redirect/ipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          expect(modifyRequest(request)).to.equal(undefined)
+        })
+        it('should be normalized if ipns://{foo}', function () {
+          const request = url2request('https://ipfs.io/#redirect/ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          expect(modifyRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+        })
+        it('should be normalized if dweb:/ipfs/{CID}', function () {
+          const request = url2request('https://ipfs.io/#redirect/dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          expect(modifyRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+        })
+        it('should not be normalized if dweb://ipfs/{CID}', function () {
+          const request = url2request('https://ipfs.io/#redirect/dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          expect(modifyRequest(request)).to.equal(undefined)
+        })
+        it('should be normalized if dweb:/ipns/{foo}', function () {
+          const request = url2request('https://ipfs.io/#redirect/dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          expect(modifyRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
+        })
+        it('should not be normalized if dweb://ipns/{foo}', function () {
+          const request = url2request('https://ipfs.io/#redirect/dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          expect(modifyRequest(request)).to.equal(undefined)
+        })
+
+        // web+ prefixed versions (Firefox < 59 and Chrome)
         it('should not be normalized if web+ipfs:/{CID}', function () {
-          const request = url2request('https://ipfs.io/web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipfs://{CID}', function () {
-          const request = url2request('https://ipfs.io/web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+ipns:/{foo}', function () {
-          const request = url2request('https://ipfs.io/web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipns://{foo}', function () {
-          const request = url2request('https://ipfs.io/web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if web+dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://ipfs.io/web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipfs/{CID}', function () {
-          const request = url2request('https://ipfs.io/web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+dweb:/ipns/{foo}', function () {
-          const request = url2request('https://ipfs.io/web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipns/{foo}', function () {
-          const request = url2request('https://ipfs.io/web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}:/bar', function () {
-          const request = url2request('https://ipfs.io/web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}://bar', function () {
-          const request = url2request('https://ipfs.io/web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://ipfs.io/#redirect/web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,9 +112,13 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.2.1, acorn@^5.4.0, acorn@^5.4.1:
+acorn@^5.0.0, acorn@^5.4.0, acorn@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+
+acorn@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
 
 adbkit-logcat@^1.1.0:
   version "1.1.0"
@@ -2343,8 +2347,8 @@ epimetheus@^1.0.55:
     prom-client "^10.0.0"
 
 errno@^0.1.3, errno@~0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
   dependencies:
     prr "~1.0.1"
 
@@ -9069,11 +9073,11 @@ trough@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.1.tgz#a9fd8b0394b0ae8fff82e0633a0a36ccad5b5f86"
 
-tty-browserify@0.0.0:
+tty-browserify@0.0.0, tty-browserify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
 
-tty-browserify@0.0.1, tty-browserify@~0.0.0:
+tty-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
 


### PR DESCRIPTION
This PR implements changes described in https://github.com/ipfs-shipyard/ipfs-companion/issues/164#issuecomment-355708883, namely support for simplified (redirect-based) protocol handlers for  `dweb:` and `ipfs://` without `web+` prefix.  

It works perfectly fine with latest Firefox Nightly (59a1), but fails to load in Firefox <59:

```
$ web-ext run -s add-on/ --browser-console --verbose
[firefox/index.js][debug] Firefox stdout: 1516628484552	addons.webextension.<unknown>	ERROR	Loading extension 'null': Reading manifest: Error processing protocol_handlers.3.protocol: Value "dweb" must either: be one of ["bitcoin", "geo", "gopher", "im", "irc", "ircs", "magnet", "mailto", "mms", "news", "nntp", "sip", "sms", "smsto", "ssh", "tel", "urn", "webcal", "wtai", "xmpp"], or match the pattern /^(ext|web)\+[a-z0-9.+-]+$/
```

Due to this and a false-positive error in addon-linter (https://github.com/mozilla/addons-linter/issues/1783) I am parking this PR until Firefox 59 is released to Beta (it may even wait til Stable).