### PR TITLE
Fixes and docs related to Firefox for Android

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ Submit PR with a new locale or improve existing ones via [Crowdin](https://crowd
 
 You will need [NodeJS](https://nodejs.org/) and [Firefox](https://www.mozilla.org/en-US/firefox/developer/). Make sure `npm` and `firefox` are in your `PATH`.
 
+It may be a good idea to use `yarn` instead of `npm`. We provide `yarn.lock` if you choose to do so.
+
 ### Installing Dependencies
 
 To install all dependencies into to `node_modules` directory, execute:
@@ -51,6 +53,38 @@ npm run build
 ```
 
 Then open up `chrome://extensions` in Chromium-based browser, enable "Developer mode", click "Load unpacked extension..." and point it at `add-on/manifest.json`
+
+### Firefox for Android
+
+To run your extension in [Firefox for Android](https://www.mozilla.org/en-US/firefox/mobile/), follow these instructions:
+
+- [Set up your computer and Android emulator or device](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android#Set_up_your_computer_and_Android_emulator_or_device) (enable Developer Mode, USB Debugging etc)
+
+With device connected to your development computer, run:
+
+```
+web-ext run -s add-on --target=firefox-android
+```
+
+It will list all connected devices with their IDs. If the list is empty, go back to the setup step.
+
+Next, deploy extension to the specific device:
+
+```
+web-ext run --target=firefox-android --android-device=<device ID>
+```
+
+The first time you run this command there may be a popup on your Android device asking if you want to grant access over USB.
+
+#### Debugging in Firefox for Android
+
+Remote debug port will be printed to console right after successful deployment:
+
+```
+You can connect to this Android device on TCP port <debug PORT>
+```
+
+The fastest way to connect is to open `chrome://devtools/content/framework/connect/connect.xhtml` in Firefox the same machine you run web-ext from.
 
 ## Useful Tasks
 

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -55,9 +55,14 @@ function createContextMenus (getState, ipfsPathValidator, { onUploadToIpfs, onCo
       onclick: onCopyAddressAtPublicGw
     })
   } catch (err) {
-    // documentUrlPatterns is not supported in brave
+    // documentUrlPatterns is not supported in Brave
     if (err.message.indexOf('createProperties.documentUrlPatterns of contextMenus.create is not supported yet') > -1) {
       console.warn('[ipfs-companion] Context menus disabled - createProperties.documentUrlPatterns of contextMenus.create is not supported yet')
+      return { update: () => Promise.resolve() }
+    }
+    // contextMenus are not supported in Firefox for Android
+    if (err.message === 'browser.contextMenus is undefined' || typeof browser.contextMenus === 'undefined') {
+      console.warn('[ipfs-companion] Context menus disabled - browser.contextMenus is undefined')
       return { update: () => Promise.resolve() }
     }
     throw err

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -400,6 +400,11 @@ module.exports = async function init () {
   // -------------------------------------------------------------------
 
   async function updateBrowserActionBadge () {
+   if (typeof browser.browserAction.setBadgeBackgroundColor === 'undefined') {
+     // Firefox for Android does not have this UI, so we just skip it
+     return;
+   }
+
     let badgeText, badgeColor, badgeIcon
     badgeText = state.peerCount.toString()
     if (state.peerCount > 0) {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -400,10 +400,10 @@ module.exports = async function init () {
   // -------------------------------------------------------------------
 
   async function updateBrowserActionBadge () {
-   if (typeof browser.browserAction.setBadgeBackgroundColor === 'undefined') {
+    if (typeof browser.browserAction.setBadgeBackgroundColor === 'undefined') {
      // Firefox for Android does not have this UI, so we just skip it
-     return;
-   }
+      return
+    }
 
     let badgeText, badgeColor, badgeIcon
     badgeText = state.peerCount.toString()

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "sinon-chrome": "2.2.1",
     "standard": "10.0.3",
     "watchify": "3.9.0",
-    "web-ext": "2.3.1"
+    "web-ext": "2.3.2"
   },
   "dependencies": {
     "choo": "6.6.1",

--- a/test/functional/lib/ipfs-companion.test.js
+++ b/test/functional/lib/ipfs-companion.test.js
@@ -7,7 +7,8 @@ const { optionDefaults } = require('../../../add-on/src/lib/options')
 describe('init', () => {
   let init
 
-  before(() => {
+  before(function () {
+    this.timeout = 1000 * 10
     global.window = {}
     global.browser = browser
     global.URL = URL

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,16 +113,16 @@ adbkit@2.11.0:
     node-forge "^0.7.1"
     split "~0.3.3"
 
-addons-linter@0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/addons-linter/-/addons-linter-0.32.0.tgz#0c273bae8b6e06312f830d6f3d5a40a665b63f83"
+addons-linter@0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/addons-linter/-/addons-linter-0.33.0.tgz#0b2a75a6650e743fe22a34ec7cfd4647fd062efc"
   dependencies:
     ajv "5.5.2"
     babel-register "6.26.0"
     chalk "2.3.0"
     cheerio "1.0.0-rc.2"
     columnify "1.5.4"
-    common-tags "1.6.0"
+    common-tags "1.7.2"
     crx-parser "0.1.2"
     dispensary "0.12.0"
     doctoc "1.3.0"
@@ -132,14 +132,18 @@ addons-linter@0.32.0:
     esprima "3.1.3"
     first-chunk-stream "2.0.0"
     fluent "0.4.1"
+    glob "7.1.2"
     jed "1.1.1"
     pino "4.10.3"
+    po2json "0.4.5"
     postcss "6.0.14"
     probe-image-size "3.2.0"
     relaxed-json "1.0.1"
     semver "5.4.1"
-    source-map-support "0.4.18"
+    shelljs "0.8.0"
+    source-map-support "0.5.1"
     strip-bom-stream "3.0.0"
+    tosource "1.0.0"
     upath "1.0.2"
     whatwg-url "6.3.0"
     xmldom "0.1.27"
@@ -234,6 +238,10 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 any-promise@^1.0.0, any-promise@^1.1.0, any-promise@^1.3.0, any-promise@~1.3.0:
   version "1.3.0"
@@ -1519,6 +1527,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
+
 character-entities-html4@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.1.tgz#359a2a4a0f7e29d3dc2ac99bdbe21ee39438ea50"
@@ -1747,9 +1763,9 @@ commander@^2.11.0, commander@^2.3.0, commander@^2.6.0, commander@^2.9, commander
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
-common-tags@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.6.0.tgz#788e4bcc582f16993e5b2c92f76b1ccb80731537"
+common-tags@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
   dependencies:
     babel-runtime "^6.26.0"
 
@@ -2051,7 +2067,13 @@ debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@1.2.0, decamelize@^1.0.0, decamelize@^1.1.1:
+decamelize@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
+  dependencies:
+    xregexp "4.0.0"
+
+decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -2390,6 +2412,12 @@ elliptic@^6.0.0, elliptic@^6.2.3:
 emoji-regex@~6.1.0:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -3364,6 +3392,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gettext-parser@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.1.0.tgz#2c5a6638d893934b9b55037d0ad82cb7004b2679"
+  dependencies:
+    encoding "^0.1.11"
+
 git-rev-sync@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/git-rev-sync/-/git-rev-sync-1.9.1.tgz#a0c2e3dd392abcf6b76962e27fc75fb3223449ce"
@@ -3584,6 +3618,10 @@ has-binary2@~1.0.2:
   dependencies:
     isarray "2.0.1"
 
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
+
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
@@ -3762,7 +3800,7 @@ hyperx@^2.3.0:
   dependencies:
     hyperscript-attribute-to-property "^1.0.0"
 
-iconv-lite@^0.4.17:
+iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -6039,14 +6077,14 @@ node-forge@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
 
-node-notifier@5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
+node-notifier@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
     growly "^1.3.0"
-    semver "^5.3.0"
-    shellwords "^0.1.0"
-    which "^1.2.12"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
 
 node-pre-gyp@^0.6.36, node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -6074,6 +6112,13 @@ nodeify@^1.0.1:
   dependencies:
     is-promise "~1.0.0"
     promise "~1.3.0"
+
+nomnom@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 noop-logger@^0.1.1:
   version "0.1.1"
@@ -6624,6 +6669,13 @@ pluralize@^1.2.1:
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
+
+po2json@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/po2json/-/po2json-0.4.5.tgz#47bb2952da32d58a1be2f256a598eebc0b745118"
+  dependencies:
+    gettext-parser "1.1.0"
+    nomnom "1.8.1"
 
 podium@^1.3.0:
   version "1.3.0"
@@ -7599,6 +7651,14 @@ shelljs@0.7.7:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shelljs@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.0.tgz#12f561c52ec5d0d3315af15616c011a18ff80d59"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shelljs@^0.7.3, shelljs@^0.7.5:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
@@ -7607,7 +7667,7 @@ shelljs@^0.7.3, shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shellwords@^0.1.0:
+shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
@@ -7799,12 +7859,6 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
-source-map-support@0.4.18, source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  dependencies:
-    source-map "^0.5.6"
-
 source-map-support@0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.6.tgz#32552aa64b458392a85eab3b0b5ee61527167aeb"
@@ -7816,6 +7870,24 @@ source-map-support@0.5.0:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
   dependencies:
     source-map "^0.6.0"
+
+source-map-support@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.1.tgz#72291517d1fd0cb9542cee6c27520884b5da1a07"
+  dependencies:
+    source-map "^0.6.0"
+
+source-map-support@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.2.tgz#1a6297fd5b2e762b39688c7fc91233b60984f0a5"
+  dependencies:
+    source-map "^0.6.0"
+
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  dependencies:
+    source-map "^0.5.6"
 
 source-map-url@~0.3.0:
   version "0.3.0"
@@ -8100,6 +8172,10 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
 
 strip-bom-buf@^1.0.0:
   version "1.0.0"
@@ -8411,6 +8487,10 @@ topo@3.x.x:
   dependencies:
     hoek "5.x.x"
 
+tosource@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tosource/-/tosource-1.0.0.tgz#42d88dd116618bcf00d6106dd5446f3427902ff1"
+
 tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
@@ -8515,6 +8595,10 @@ ultron@~1.1.0:
 umd@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 underscore@~1.8.3:
   version "1.8.3"
@@ -8729,18 +8813,18 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-web-ext@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/web-ext/-/web-ext-2.3.1.tgz#b5b2cdd0d9a486d2f43fe29f9881e1f42f2f28d0"
+web-ext@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/web-ext/-/web-ext-2.3.2.tgz#45c7cb50cbea90d6127a3c4bb128802a67f67c93"
   dependencies:
     adbkit "2.11.0"
-    addons-linter "0.32.0"
+    addons-linter "0.33.0"
     babel-polyfill "6.26.0"
     babel-runtime "6.26.0"
     bunyan "1.8.12"
     camelcase "4.1.0"
     debounce "1.1.0"
-    decamelize "1.2.0"
+    decamelize "2.0.0"
     es6-error "4.1.1"
     es6-promisify "5.0.0"
     event-to-promise "0.8.0"
@@ -8751,13 +8835,13 @@ web-ext@2.3.1:
     mkdirp "0.5.1"
     mz "2.7.0"
     node-firefox-connect "1.2.0"
-    node-notifier "5.1.2"
+    node-notifier "5.2.1"
     open "0.0.5"
     parse-json "4.0.0"
     regenerator-runtime "0.11.1"
     require-uncached "1.0.3"
     sign-addon "0.2.2"
-    source-map-support "0.5.0"
+    source-map-support "0.5.2"
     stream-to-promise "2.2.0"
     tmp "0.0.33"
     update-notifier "2.3.0"
@@ -8927,6 +9011,10 @@ xmlhttprequest-ssl@~1.5.4:
 xor-distance@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xor-distance/-/xor-distance-1.0.0.tgz#da735d9b24fcca8dbcd9b374d16d2a01ee9541c6"
+
+xregexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
 
 xtend@4.0.1, "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This PR:

-  fixes init errors caused by missing APIs on Android (there are no context menus, no browserAction icorn/badge)
- updates `web-ext` to v2.3.1 which supports [hot-deploy to emulator,  over USB  and remote debug](https://www.youtube.com/watch?v=fs-mSrap6a8&feature=youtu.be)
- documents how to develop/debug on Android: [CONTRIBUTING.md#firefox-for-android](https://github.com/ipfs-shipyard/ipfs-companion/blob/c49286a71152e2275ea3959d824882e8103a0b7e/CONTRIBUTING.md#firefox-for-android)

Question:

- Should we move development-related instructions from [CONTRIBUTING.md#development](https://github.com/ipfs-shipyard/ipfs-companion/blob/c49286a71152e2275ea3959d824882e8103a0b7e/CONTRIBUTING.md#development) to a section in README, or it good as-is?