### PR TITLE
Updates ipfs-postmsg-proxy with proper streaming support

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "file-type": "7.3.0",
     "ipfs": "0.27.6",
     "ipfs-api": "17.2.7",
-    "ipfs-postmsg-proxy": "2.0.0",
+    "ipfs-postmsg-proxy": "2.1.0",
     "is-ipfs": "0.3.2",
     "is-svg": "2.1.0",
     "lru_map": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4056,9 +4056,9 @@ ipfs-multipart@~0.1.0:
     content "^3.0.0"
     dicer "^0.2.5"
 
-ipfs-postmsg-proxy@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.0.0.tgz#c1fa0f11815fff67950d0f880dcc6d5fd797828d"
+ipfs-postmsg-proxy@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.1.0.tgz#98375532a5359e807ff87d3139d040eccb0fc92f"
   dependencies:
     callbackify "^1.1.0"
     cids "^0.5.2"
@@ -4067,12 +4067,14 @@ ipfs-postmsg-proxy@2.0.0:
     is-stream "^1.1.0"
     peer-id "^0.10.4"
     peer-info "^0.11.4"
-    postmsg-rpc "^2.1.1"
+    postmsg-rpc "^2.2.0"
     prepost "^1.0.0"
-    pull-buffer "^1.0.0"
+    pull-abortable "^4.1.1"
     pull-defer "^0.2.2"
+    pull-postmsg-stream "^1.1.3"
     pull-stream "^3.6.1"
     pull-stream-to-stream "^1.3.4"
+    shortid "^2.2.8"
     stream-to-pull-stream "^1.7.2"
 
 ipfs-repo@~0.18.2, ipfs-repo@~0.18.4:
@@ -6645,6 +6647,12 @@ postmsg-rpc@^2.1.1:
   dependencies:
     shortid "^2.2.8"
 
+postmsg-rpc@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/postmsg-rpc/-/postmsg-rpc-2.3.0.tgz#b355afabff1371457af831fe439dd84804229392"
+  dependencies:
+    shortid "^2.2.8"
+
 prebuild-install@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.0.tgz#6fdd8436069971c76688071f4847d4c891a119f4"
@@ -6673,7 +6681,7 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-prepost@^1.0.0:
+prepost@^1.0.0, prepost@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prepost/-/prepost-1.0.1.tgz#62c55d1ced516127e40ce2e3d8fc1a390cd86c7b"
 
@@ -6799,13 +6807,6 @@ pull-block@^1.4.0:
   dependencies:
     pull-through "^1.0.18"
 
-pull-buffer@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pull-buffer/-/pull-buffer-1.0.2.tgz#e80d44cc178c1835d2f5d93775d4864eee7ca640"
-  dependencies:
-    pull-defer "^0.2.2"
-    pull-stream "^3.6.1"
-
 pull-cat@^1.1.11, pull-cat@^1.1.9:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/pull-cat/-/pull-cat-1.1.11.tgz#b642dd1255da376a706b6db4fa962f5fdb74c31b"
@@ -6869,6 +6870,13 @@ pull-paramap@^1.2.2:
 pull-pause@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/pull-pause/-/pull-pause-0.0.2.tgz#19d45be8faa615fa556f14a96fd733462c37fba3"
+
+pull-postmsg-stream@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/pull-postmsg-stream/-/pull-postmsg-stream-1.1.3.tgz#1318f4a7a64d7378e5c44db0627f19d29b9f41f1"
+  dependencies:
+    postmsg-rpc "^2.1.1"
+    prepost "^1.0.1"
 
 pull-pushable@^2.0.0, pull-pushable@^2.0.1, pull-pushable@^2.1.1, pull-pushable@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Previously `ipfs-postmsg-proxy` faked streaming by buffering into memory and then "streaming" a single chunk. It meant that the streaming interfaces worked, but not properly! This PR updates `ipfs-postmsg-proxy` to 2.1.0 which implements proper streaming over `window.postMessage` - hooray \o/