### PR TITLE
Adds scoped permissions

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -413,13 +413,8 @@
     }
   },
   "page_proxyAccessDialog_wildcardCheckbox_label": {
-    "message": "Apply to all permissions for $SCOPE$",
-    "description": "Label for the apply permissions to all checkbox (page_proxyAccessDialog_wildcardCheckbox_label)",
-    "placeholders": {
-      "scope": {
-        "content": "$1"
-      }
-    }
+    "message": "Apply this decision to all permissions in this scope",
+    "description": "Label for the apply permissions to all checkbox (page_proxyAccessDialog_wildcardCheckbox_label)"
   },
   "page_proxyAcl_revoke_all_button_title": {
     "message": "Revoke all permissions",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -355,22 +355,22 @@
     "description": "Message displayed when no permissions have been granted (page_proxyAcl_no_perms)"
   },
   "page_proxyAcl_confirm_revoke": {
-    "message": "Revoke permission $PERMISSION$ for $ORIGIN$?",
-    "description": "Confirmation message for revoking a permission for an origin (page_proxyAcl_confirm_revoke)",
+    "message": "Revoke permission $PERMISSION$ for $SCOPE$?",
+    "description": "Confirmation message for revoking a permission for a scope (page_proxyAcl_confirm_revoke)",
     "placeholders": {
       "permission": {
         "content": "$1"
       },
-      "origin": {
+      "scope": {
         "content": "$2"
       }
     }
   },
   "page_proxyAcl_confirm_revoke_all": {
-    "message": "Revoke all permissions for $ORIGIN$?",
-    "description": "Confirmation message for revoking all permissions for an origin (page_proxyAcl_confirm_revoke_all)",
+    "message": "Revoke all permissions for $SCOPE$?",
+    "description": "Confirmation message for revoking all permissions for an scope (page_proxyAcl_confirm_revoke_all)",
     "placeholders": {
-      "origin": {
+      "scope": {
         "content": "$1"
       }
     }
@@ -401,10 +401,10 @@
     }
   },
   "page_proxyAccessDialog_title": {
-    "message": "Allow $ORIGIN$ to access ipfs.$PERMISSION$?",
+    "message": "Allow $SCOPE$ to access ipfs.$PERMISSION$?",
     "description": "Main title of the access permission dialog (page_proxyAccessDialog_title)",
     "placeholders": {
-      "origin": {
+      "scope": {
         "content": "$1"
       },
       "permission": {
@@ -413,10 +413,10 @@
     }
   },
   "page_proxyAccessDialog_wildcardCheckbox_label": {
-    "message": "Apply to all permissions for $ORIGIN$",
+    "message": "Apply to all permissions for $SCOPE$",
     "description": "Label for the apply permissions to all checkbox (page_proxyAccessDialog_wildcardCheckbox_label)",
     "placeholders": {
-      "origin": {
+      "scope": {
         "content": "$1"
       }
     }

--- a/add-on/src/lib/ipfs-proxy/access-control.js
+++ b/add-on/src/lib/ipfs-proxy/access-control.js
@@ -26,7 +26,7 @@ class AccessControl extends EventEmitter {
     // Map { scope => Map { permission => allow } }
     this.emit('change', aclChangeKeys.reduce((aclChanges, key) => {
       return aclChanges.set(
-        key.slice(prefix.length + 1),
+        key.slice(prefix.length + ('.access'.length) + 1),
         new Map(JSON.parse(changes[key].newValue))
       )
     }, new Map()))
@@ -48,7 +48,7 @@ class AccessControl extends EventEmitter {
     const scopes = await this._getScopes()
     scopes.add(scope)
 
-    const key = this._getScopeKey()
+    const key = this._getScopesKey()
     await this._storage.local.set({ [key]: JSON.stringify(Array.from(scopes)) })
   }
 

--- a/add-on/src/lib/ipfs-proxy/access-control.js
+++ b/add-on/src/lib/ipfs-proxy/access-control.js
@@ -110,25 +110,19 @@ class AccessControl extends EventEmitter {
     if (!isBoolean(allow)) throw new TypeError('Invalid allow')
 
     return this._writeQ.add(async () => {
-      const matchingScopes = await this._getMatchingScopes(scope)
+      const allAccess = await this._getAllAccess(scope)
 
-      for (let matchingScope of matchingScopes) {
-        const allAccess = await this._getAllAccess(matchingScope)
-
-        // Trying to set access for non-wildcard permission, when wildcard
-        // permission is already granted?
-        if (allAccess.has('*') && permission !== '*') {
-          if (allAccess.get('*') === allow) {
-            // Noop if requested access is the same as access for wildcard grant
-            return { scope: matchingScope, permission, allow }
-          } else {
-            // Fail if requested access is the different to access for wildcard grant
-            throw new Error(`Illegal set access for ${permission} when wildcard exists`)
-          }
+      // Trying to set access for non-wildcard permission, when wildcard
+      // permission is already granted?
+      if (allAccess.has('*') && permission !== '*') {
+        if (allAccess.get('*') === allow) {
+          // Noop if requested access is the same as access for wildcard grant
+          return { scope, permission, allow }
+        } else {
+          // Fail if requested access is the different to access for wildcard grant
+          throw new Error(`Illegal set access for ${permission} when wildcard exists`)
         }
       }
-
-      const allAccess = await this._getAllAccess(scope)
 
       // If setting a wildcard permission, remove existing grants
       if (permission === '*') {

--- a/add-on/src/lib/ipfs-proxy/index.js
+++ b/add-on/src/lib/ipfs-proxy/index.js
@@ -20,14 +20,15 @@ function createIpfsProxy (getIpfs, getState) {
   const onPortConnect = (port) => {
     if (port.name !== 'ipfs-proxy') return
 
-    const { origin } = new URL(port.sender.url)
+    const { origin, pathname } = new URL(port.sender.url)
+    const scope = origin + pathname
 
     const proxy = createProxyServer(getIpfs, {
       addListener: (_, handler) => port.onMessage.addListener(handler),
       removeListener: (_, handler) => port.onMessage.removeListener(handler),
       postMessage: (data) => port.postMessage(data),
       getMessageData: (d) => d,
-      pre: (fnName) => createPreAcl(getState, accessControl, origin, fnName, requestAccess)
+      pre: (fnName) => createPreAcl(getState, accessControl, scope, fnName, requestAccess)
     })
 
     const close = () => {

--- a/add-on/src/lib/ipfs-proxy/pre-acl.js
+++ b/add-on/src/lib/ipfs-proxy/pre-acl.js
@@ -5,7 +5,7 @@ const ACL_WHITELIST = Object.freeze(require('./acl-whitelist.json'))
 // Creates a "pre" function that is called prior to calling a real function
 // on the IPFS instance. It will throw if access is denied, and ask the user if
 // no access decision has been made yet.
-function createPreAcl (getState, accessControl, origin, permission, requestAccess) {
+function createPreAcl (getState, accessControl, getScope, permission, requestAccess) {
   return async (...args) => {
     // Check if all access to the IPFS node is disabled
     if (!getState().ipfsProxy) throw new Error('User disabled access to IPFS')
@@ -13,11 +13,12 @@ function createPreAcl (getState, accessControl, origin, permission, requestAcces
     // No need to verify access if permission is on the whitelist
     if (ACL_WHITELIST.includes(permission)) return args
 
-    let access = await accessControl.getAccess(origin, permission)
+    const scope = await getScope()
+    let access = await accessControl.getAccess(scope, permission)
 
     if (!access) {
-      const { allow, wildcard } = await requestAccess(origin, permission)
-      access = await accessControl.setAccess(origin, wildcard ? '*' : permission, allow)
+      const { allow, wildcard } = await requestAccess(scope, permission)
+      access = await accessControl.setAccess(scope, wildcard ? '*' : permission, allow)
     }
 
     if (!access.allow) throw new Error(`User denied access to ${permission}`)

--- a/add-on/src/lib/ipfs-proxy/request-access.js
+++ b/add-on/src/lib/ipfs-proxy/request-access.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const DIALOG_WIDTH = 540
-const DIALOG_HEIGHT = 200
+const DIALOG_HEIGHT = 220
 const DIALOG_PATH = 'dist/pages/proxy-access-dialog/index.html'
 const DIALOG_PORT_NAME = 'proxy-access-dialog'
 

--- a/add-on/src/pages/proxy-access-dialog/index.html
+++ b/add-on/src/pages/proxy-access-dialog/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="proxy-access-dialog.css">
 </head>
 
-<body class="bg-snow-muted h-100 overflow-hidden">
+<body class="bg-snow-muted h-100">
   <div id="root"></div>
   <script src="../../ipfs-companion-common.js"></script>
   <script src="proxy-access-dialog.js"></script>

--- a/add-on/src/pages/proxy-access-dialog/page.js
+++ b/add-on/src/pages/proxy-access-dialog/page.js
@@ -8,7 +8,7 @@ function createProxyAccessDialogPage (i18n) {
     const onDeny = () => emit('deny')
     const onWildcardToggle = () => emit('wildcardToggle')
 
-    const { loading, origin, permission } = state
+    const { loading, scope, permission } = state
 
     return html`
       <div class="flex flex-column pa3 h-100">
@@ -16,12 +16,12 @@ function createProxyAccessDialogPage (i18n) {
           ${loading ? null : html`
             <div>
               <h1 class="sans-serif f5 lh-copy charcoal mt0">
-                ${i18n.getMessage('page_proxyAccessDialog_title', [origin, permission])}
+                ${i18n.getMessage('page_proxyAccessDialog_title', [scope, permission])}
               </h1>
               <p class="sans-serif f6 lh-copy charcoal-muted">
                 <label>
                   <input type="checkbox" checked=${state.wildcard} onclick=${onWildcardToggle} class="mr1" />
-                  ${i18n.getMessage('page_proxyAccessDialog_wildcardCheckbox_label', origin)}
+                  ${i18n.getMessage('page_proxyAccessDialog_wildcardCheckbox_label', scope)}
                 </label>
               </p>
             </div>

--- a/add-on/src/pages/proxy-access-dialog/page.js
+++ b/add-on/src/pages/proxy-access-dialog/page.js
@@ -15,7 +15,7 @@ function createProxyAccessDialogPage (i18n) {
         <div class="flex-auto" style="min-height:auto">
           ${loading ? null : html`
             <div>
-              <h1 class="sans-serif f5 lh-copy charcoal mt0">
+              <h1 class="sans-serif f5 lh-copy charcoal mt0" style="word-break:break-word">
                 ${i18n.getMessage('page_proxyAccessDialog_title', [scope, permission])}
               </h1>
               <p class="sans-serif f6 lh-copy charcoal-muted">

--- a/add-on/src/pages/proxy-access-dialog/page.js
+++ b/add-on/src/pages/proxy-access-dialog/page.js
@@ -12,7 +12,7 @@ function createProxyAccessDialogPage (i18n) {
 
     return html`
       <div class="flex flex-column pa3 h-100">
-        <div class="flex-auto">
+        <div class="flex-auto" style="min-height:auto">
           ${loading ? null : html`
             <div>
               <h1 class="sans-serif f5 lh-copy charcoal mt0">

--- a/add-on/src/pages/proxy-access-dialog/store.js
+++ b/add-on/src/pages/proxy-access-dialog/store.js
@@ -2,7 +2,7 @@
 
 function createProxyAccessDialogStore (i18n, runtime) {
   return function proxyAccessDialogStore (state, emitter) {
-    state.origin = null
+    state.scope = null
     state.permission = null
     state.loading = true
     state.wildcard = false
@@ -10,10 +10,10 @@ function createProxyAccessDialogStore (i18n, runtime) {
     const port = runtime.connect({ name: 'proxy-access-dialog' })
 
     const onMessage = (data) => {
-      if (!data || !data.origin || !data.permission) return
+      if (!data || !data.scope || !data.permission) return
       port.onMessage.removeListener(onMessage)
 
-      state.origin = data.origin
+      state.scope = data.scope
       state.permission = data.permission
       state.loading = false
 

--- a/add-on/src/pages/proxy-acl/page.js
+++ b/add-on/src/pages/proxy-acl/page.js
@@ -9,8 +9,8 @@ function createProxyAclPage (i18n) {
     const onToggleAllow = (e) => emit('toggleAllow', e)
 
     const { acl } = state
-    const origins = Array.from(state.acl.keys())
-    const hasGrants = origins.some((origin) => !!acl.get(origin).size)
+    const scopes = Array.from(state.acl.keys())
+    const hasGrants = scopes.some((scope) => !!acl.get(scope).size)
 
     return html`
       <div class="avenir pt5" style="background: linear-gradient(to top, #041727 0%,#043b55 100%); min-height:100%;">
@@ -32,16 +32,16 @@ function createProxyAclPage (i18n) {
           </header>
           ${hasGrants ? html`
             <table class="w-100 mb4" style="border-spacing: 0">
-              ${origins.reduce((rows, origin) => {
-                const permissions = acl.get(origin)
+              ${scopes.reduce((rows, scope) => {
+                const permissions = acl.get(scope)
 
                 if (!permissions.size) return rows
 
                 return rows.concat(
-                  originRow({ onRevoke, origin, i18n }),
+                  scopeRow({ onRevoke, scope, i18n }),
                   Array.from(permissions.keys())
                     .sort()
-                    .map((permission) => accessRow({ origin, permission, allow: permissions.get(permission), onRevoke, onToggleAllow, i18n }))
+                    .map((permission) => accessRow({ scope, permission, allow: permissions.get(permission), onRevoke, onToggleAllow, i18n }))
                 )
               }, [])}
             </table>
@@ -56,16 +56,16 @@ function createProxyAclPage (i18n) {
 
 module.exports = createProxyAclPage
 
-function originRow ({ origin, onRevoke, i18n }) {
+function scopeRow ({ scope, onRevoke, i18n }) {
   return html`
     <tr class="">
-      <th class="f3 normal tl light-gray pv3 ph2 bb b--white-40" colspan="2">${origin}</th>
-      <th class="tr pv3 ph0 bb b--white-40">${revokeButton({ onRevoke, origin, i18n })}</th>
+      <th class="f3 normal tl light-gray pv3 ph2 bb b--white-40" colspan="2">${scope}</th>
+      <th class="tr pv3 ph0 bb b--white-40">${revokeButton({ onRevoke, scope, i18n })}</th>
     </tr>
   `
 }
 
-function accessRow ({ origin, permission, allow, onRevoke, onToggleAllow, i18n }) {
+function accessRow ({ scope, permission, allow, onRevoke, onToggleAllow, i18n }) {
   const title = i18n.getMessage(
     allow
       ? 'page_proxyAcl_toggle_to_deny_button_title'
@@ -78,7 +78,7 @@ function accessRow ({ origin, permission, allow, onRevoke, onToggleAllow, i18n }
         class="f5 white ph3 pv2 ${allow ? 'bg-green' : 'bg-red'} tc bb b--white-10 pointer"
         style="width: 75px"
         onclick=${onToggleAllow}
-        data-origin="${origin}"
+        data-scope="${scope}"
         data-permission="${permission}"
         data-allow=${allow}
         title="${title}">
@@ -89,14 +89,14 @@ function accessRow ({ origin, permission, allow, onRevoke, onToggleAllow, i18n }
       <td class="f5 light-gray ph3 pv2 bb b--white-10">${permission}</td>
       <td class="tr bb b--white-10">
         <div class="child">
-          ${revokeButton({ onRevoke, origin, permission, i18n })}
+          ${revokeButton({ onRevoke, scope, permission, i18n })}
         </div>
       </td>
     </tr>
   `
 }
 
-function revokeButton ({ onRevoke, origin, permission = null, i18n }) {
+function revokeButton ({ onRevoke, scope, permission = null, i18n }) {
   const title = permission
     ? i18n.getMessage('page_proxyAcl_revoke_button_title', permission)
     : i18n.getMessage('page_proxyAcl_revoke_all_button_title')
@@ -105,7 +105,7 @@ function revokeButton ({ onRevoke, origin, permission = null, i18n }) {
     <button
       class="button-reset outline-0 bg-transparent bw0 pointer ph3 pv1 light-gray hover-red"
       onclick=${onRevoke}
-      data-origin="${origin}"
+      data-scope="${scope}"
       data-permission="${permission || ''}"
       title="${title}">
       ${closeIcon()}

--- a/add-on/src/pages/proxy-acl/store.js
+++ b/add-on/src/pages/proxy-acl/store.js
@@ -11,23 +11,23 @@ function createProxyAclStore (accessControl, i18n, confirm = window.confirm) {
     })
 
     emitter.on('revoke', (e) => {
-      const origin = e.currentTarget.getAttribute('data-origin')
+      const scope = e.currentTarget.getAttribute('data-scope')
       const permission = e.currentTarget.getAttribute('data-permission')
 
       const msg = permission
-        ? i18n.getMessage('page_proxyAcl_confirm_revoke', [permission, origin])
-        : i18n.getMessage('page_proxyAcl_confirm_revoke_all', origin)
+        ? i18n.getMessage('page_proxyAcl_confirm_revoke', [permission, scope])
+        : i18n.getMessage('page_proxyAcl_confirm_revoke_all', scope)
 
       if (!confirm(msg)) return
 
-      accessControl.revokeAccess(origin, permission)
+      accessControl.revokeAccess(scope, permission)
     })
 
     emitter.on('toggleAllow', (e) => {
-      const origin = e.currentTarget.getAttribute('data-origin')
+      const scope = e.currentTarget.getAttribute('data-scope')
       const permission = e.currentTarget.getAttribute('data-permission')
       const allow = e.currentTarget.getAttribute('data-allow') === 'true'
-      accessControl.setAccess(origin, permission, !allow)
+      accessControl.setAccess(scope, permission, !allow)
     })
 
     async function onAclChange (changes) {

--- a/test/functional/lib/ipfs-proxy/access-control.test.js
+++ b/test/functional/lib/ipfs-proxy/access-control.test.js
@@ -6,7 +6,7 @@ const AccessControl = require('../../../../add-on/src/lib/ipfs-proxy/access-cont
 const Storage = require('mem-storage-area/Storage')
 const { objToAcl } = require('../../../helpers/acl')
 
-describe('lib/ipfs-proxy/access-control', () => {
+describe.only('lib/ipfs-proxy/access-control', () => {
   before(() => {
     global.URL = URL
   })
@@ -19,23 +19,23 @@ describe('lib/ipfs-proxy/access-control', () => {
     expect(acl).to.deep.equal(new Map())
 
     const sets = [
-      ['http://ipfs.io', 'ipfs.files.add', true],
-      ['https://ipld.io', 'ipfs.object.new', false],
-      ['https://filecoin.io', 'ipfs.pubsub.subscribe', true],
-      ['https://filecoin.io', 'ipfs.pubsub.subscribe', false],
-      ['https://filecoin.io', 'ipfs.pubsub.publish', true]
+      ['http://ipfs.io/', 'ipfs.files.add', true],
+      ['https://ipld.io/', 'ipfs.object.new', false],
+      ['https://filecoin.io/', 'ipfs.pubsub.subscribe', true],
+      ['https://filecoin.io/', 'ipfs.pubsub.subscribe', false],
+      ['https://filecoin.io/', 'ipfs.pubsub.publish', true]
     ]
 
     await Promise.all(sets.map(s => accessControl.setAccess(...s)))
 
     const expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': true
       },
-      'https://ipld.io': {
+      'https://ipld.io/': {
         'ipfs.object.new': false
       },
-      'https://filecoin.io': {
+      'https://filecoin.io/': {
         'ipfs.pubsub.subscribe': false,
         'ipfs.pubsub.publish': true
       }
@@ -48,32 +48,32 @@ describe('lib/ipfs-proxy/access-control', () => {
 
   it('should allow access for wildcard allow', async () => {
     const accessControl = new AccessControl(new Storage())
-    let access = await accessControl.getAccess('https://ipfs.io', 'files.add')
+    let access = await accessControl.getAccess('https://ipfs.io/', 'files.add')
 
     expect(access).to.equal(null)
 
     // Add wildcard
-    await accessControl.setAccess('https://ipfs.io', '*', true)
+    await accessControl.setAccess('https://ipfs.io/', '*', true)
 
-    access = await accessControl.getAccess('https://ipfs.io', 'files.add')
+    access = await accessControl.getAccess('https://ipfs.io/', 'files.add')
 
-    const expectedAccess = { origin: 'https://ipfs.io', permission: 'files.add', allow: true }
+    const expectedAccess = { scope: 'https://ipfs.io/', permission: 'files.add', allow: true }
 
     expect(access).to.deep.equal(expectedAccess)
   })
 
   it('should deny access for wildcard deny', async () => {
     const accessControl = new AccessControl(new Storage())
-    let access = await accessControl.getAccess('https://ipfs.io', 'files.add')
+    let access = await accessControl.getAccess('https://ipfs.io/', 'files.add')
 
     expect(access).to.equal(null)
 
     // Add wildcard
-    await accessControl.setAccess('https://ipfs.io', '*', false)
+    await accessControl.setAccess('https://ipfs.io/', '*', false)
 
-    access = await accessControl.getAccess('https://ipfs.io', 'files.add')
+    access = await accessControl.getAccess('https://ipfs.io/', 'files.add')
 
-    const expectedAccess = { origin: 'https://ipfs.io', permission: 'files.add', allow: false }
+    const expectedAccess = { scope: 'https://ipfs.io/', permission: 'files.add', allow: false }
 
     expect(access).to.deep.equal(expectedAccess)
   })
@@ -81,14 +81,14 @@ describe('lib/ipfs-proxy/access-control', () => {
   it('should clear existing grants when setting wildcard access', async () => {
     const accessControl = new AccessControl(new Storage())
 
-    await accessControl.setAccess('https://ipfs.io', 'files.add', false)
-    await accessControl.setAccess('https://ipfs.io', 'object.new', true)
-    await accessControl.setAccess('https://ipfs.io', 'config.set', false)
+    await accessControl.setAccess('https://ipfs.io/', 'files.add', false)
+    await accessControl.setAccess('https://ipfs.io/', 'object.new', true)
+    await accessControl.setAccess('https://ipfs.io/', 'config.set', false)
 
     let acl = await accessControl.getAcl()
 
     let expectedAcl = objToAcl({
-      'https://ipfs.io': {
+      'https://ipfs.io/': {
         'files.add': false,
         'object.new': true,
         'config.set': false
@@ -98,12 +98,12 @@ describe('lib/ipfs-proxy/access-control', () => {
     expect(acl).to.deep.equal(expectedAcl)
 
     // Add wildcard
-    await accessControl.setAccess('https://ipfs.io', '*', false)
+    await accessControl.setAccess('https://ipfs.io/', '*', false)
 
     acl = await accessControl.getAcl()
 
     expectedAcl = objToAcl({
-      'https://ipfs.io': {
+      'https://ipfs.io/': {
         '*': false
       }
     })
@@ -115,12 +115,12 @@ describe('lib/ipfs-proxy/access-control', () => {
     const accessControl = new AccessControl(new Storage())
 
     // Add wildcard
-    await accessControl.setAccess('https://ipfs.io', '*', false)
+    await accessControl.setAccess('https://ipfs.io/', '*', false)
 
     let error
 
     try {
-      await accessControl.setAccess('https://ipfs.io', 'files.add', true)
+      await accessControl.setAccess('https://ipfs.io/', 'files.add', true)
     } catch (err) {
       error = err
     }
@@ -132,12 +132,12 @@ describe('lib/ipfs-proxy/access-control', () => {
     const accessControl = new AccessControl(new Storage())
 
     // Add wildcard
-    await accessControl.setAccess('https://ipfs.io', '*', false)
+    await accessControl.setAccess('https://ipfs.io/', '*', false)
 
     let error
 
     try {
-      await accessControl.setAccess('https://ipfs.io', 'files.add', false)
+      await accessControl.setAccess('https://ipfs.io/', 'files.add', false)
     } catch (err) {
       error = err
     }
@@ -145,20 +145,20 @@ describe('lib/ipfs-proxy/access-control', () => {
     expect(() => { if (error) throw error }).to.not.throw()
   })
 
-  it('should get granted access for origin and permission', async () => {
+  it('should get granted access for scope and permission', async () => {
     const accessControl = new AccessControl(new Storage())
 
-    let access = await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', true)
-    const expectedAccess = { origin: 'http://ipfs.io', permission: 'ipfs.files.add', allow: true }
+    let access = await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', true)
+    const expectedAccess = { scope: 'http://ipfs.io/', permission: 'ipfs.files.add', allow: true }
 
     expect(access).to.deep.equal(expectedAccess)
 
-    access = await accessControl.getAccess('http://ipfs.io', 'ipfs.files.add')
+    access = await accessControl.getAccess('http://ipfs.io/', 'ipfs.files.add')
 
     expect(access).to.deep.equal(expectedAccess)
   })
 
-  it('should not get access if origin is invalid', async () => {
+  it('should not get access if scope is invalid', async () => {
     const accessControl = new AccessControl(new Storage())
     let error
 
@@ -168,7 +168,7 @@ describe('lib/ipfs-proxy/access-control', () => {
       error = err
     }
 
-    expect(() => { if (error) throw error }).to.throw('Invalid origin')
+    expect(() => { if (error) throw error }).to.throw('Invalid scope')
   })
 
   it('should not get access if permission is invalid', async () => {
@@ -176,7 +176,7 @@ describe('lib/ipfs-proxy/access-control', () => {
     let error
 
     try {
-      await accessControl.getAccess('http://ipfs.io', 138)
+      await accessControl.getAccess('http://ipfs.io/', 138)
     } catch (err) {
       error = err
     }
@@ -186,12 +186,12 @@ describe('lib/ipfs-proxy/access-control', () => {
 
   it('should return null for missing grant', async () => {
     const accessControl = new AccessControl(new Storage())
-    const access = await accessControl.getAccess('http://ipfs.io', 'ipfs.files.add')
+    const access = await accessControl.getAccess('http://ipfs.io/', 'ipfs.files.add')
 
     expect(access).to.equal(null)
   })
 
-  it('should not set access if origin is invalid', async () => {
+  it('should not set access if scope is invalid', async () => {
     const accessControl = new AccessControl(new Storage())
     let error
 
@@ -201,7 +201,7 @@ describe('lib/ipfs-proxy/access-control', () => {
       error = err
     }
 
-    expect(() => { if (error) throw error }).to.throw('Invalid origin')
+    expect(() => { if (error) throw error }).to.throw('Invalid scope')
 
     try {
       await accessControl.setAccess(138, 'ipfs.files.add', true)
@@ -209,7 +209,7 @@ describe('lib/ipfs-proxy/access-control', () => {
       error = err
     }
 
-    expect(() => { if (error) throw error }).to.throw('Invalid origin')
+    expect(() => { if (error) throw error }).to.throw('Invalid scope')
   })
 
   it('should not set access if permission is invalid', async () => {
@@ -217,7 +217,7 @@ describe('lib/ipfs-proxy/access-control', () => {
     let error
 
     try {
-      await accessControl.setAccess('http://ipfs.io', 138, true)
+      await accessControl.setAccess('http://ipfs.io/', 138, true)
     } catch (err) {
       error = err
     }
@@ -230,7 +230,7 @@ describe('lib/ipfs-proxy/access-control', () => {
     let error
 
     try {
-      await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', 'true')
+      await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', 'true')
     } catch (err) {
       error = err
     }
@@ -244,14 +244,14 @@ describe('lib/ipfs-proxy/access-control', () => {
 
       accessControl.on('change', changes => {
         expect(changes).to.deep.equal(objToAcl({
-          'http://ipfs.io': {
+          'http://ipfs.io/': {
             'ipfs.files.add': false
           }
         }))
         resolve()
       })
 
-      accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', false)
+      accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', false)
     })
   })
 
@@ -271,14 +271,14 @@ describe('lib/ipfs-proxy/access-control', () => {
   it('should revoke granted access', async () => {
     const accessControl = new AccessControl(new Storage())
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', false)
-    let access = await accessControl.getAccess('http://ipfs.io', 'ipfs.files.add')
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', false)
+    let access = await accessControl.getAccess('http://ipfs.io/', 'ipfs.files.add')
 
-    expect(access).to.deep.equal({ origin: 'http://ipfs.io', permission: 'ipfs.files.add', allow: false })
+    expect(access).to.deep.equal({ scope: 'http://ipfs.io/', permission: 'ipfs.files.add', allow: false })
 
-    await accessControl.revokeAccess('http://ipfs.io', 'ipfs.files.add')
+    await accessControl.revokeAccess('http://ipfs.io/', 'ipfs.files.add')
 
-    access = await accessControl.getAccess('http://ipfs.io', 'ipfs.files.add')
+    access = await accessControl.getAccess('http://ipfs.io/', 'ipfs.files.add')
 
     expect(access).to.equal(null)
   })
@@ -286,26 +286,26 @@ describe('lib/ipfs-proxy/access-control', () => {
   it('should revoke all granted access if no permission specified', async () => {
     const accessControl = new AccessControl(new Storage())
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', false)
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.block.put', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.block.put', false)
 
     let acl = await accessControl.getAcl()
 
     expect(acl).to.deep.equal(objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': false,
         'ipfs.block.put': false
       }
     }))
 
-    await accessControl.revokeAccess('http://ipfs.io')
+    await accessControl.revokeAccess('http://ipfs.io/')
 
     acl = await accessControl.getAcl()
 
-    expect(acl).to.deep.equal(objToAcl({ 'http://ipfs.io': {} }))
+    expect(acl).to.deep.equal(objToAcl({ 'http://ipfs.io/': {} }))
   })
 
-  it('should not revoke access if origin is invalid', async () => {
+  it('should not revoke access if scope is invalid', async () => {
     const accessControl = new AccessControl(new Storage())
     let error
 
@@ -315,7 +315,7 @@ describe('lib/ipfs-proxy/access-control', () => {
       error = err
     }
 
-    expect(() => { if (error) throw error }).to.throw('Invalid origin')
+    expect(() => { if (error) throw error }).to.throw('Invalid scope')
   })
 
   it('should not revoke access if permission is invalid', async () => {
@@ -323,7 +323,7 @@ describe('lib/ipfs-proxy/access-control', () => {
     let error
 
     try {
-      await accessControl.revokeAccess('http://ipfs.io', 138)
+      await accessControl.revokeAccess('http://ipfs.io/', 138)
     } catch (err) {
       error = err
     }

--- a/test/functional/lib/ipfs-proxy/access-control.test.js
+++ b/test/functional/lib/ipfs-proxy/access-control.test.js
@@ -226,7 +226,7 @@ describe('lib/ipfs-proxy/access-control', () => {
     let error
 
     try {
-      await accessControl.setAccess('NOT A VALID ORIGIN', 'ipfs.files.add', true)
+      await accessControl.setAccess('NOT A VALID SCOPE', 'ipfs.files.add', true)
     } catch (err) {
       error = err
     }
@@ -340,7 +340,7 @@ describe('lib/ipfs-proxy/access-control', () => {
     let error
 
     try {
-      await accessControl.revokeAccess('NOT A VALID ORIGIN', 'ipfs.files.add')
+      await accessControl.revokeAccess('NOT A VALID SCOPE', 'ipfs.files.add')
     } catch (err) {
       error = err
     }

--- a/test/functional/lib/ipfs-proxy/pre-acl.test.js
+++ b/test/functional/lib/ipfs-proxy/pre-acl.test.js
@@ -16,10 +16,10 @@ describe('lib/ipfs-proxy/pre-acl', () => {
   it('should throw if access is disabled', async () => {
     const getState = () => ({ ipfsProxy: false })
     const accessControl = new AccessControl(new Storage())
-    const origin = 'https://ipfs.io'
+    const getScope = () => 'https://ipfs.io/'
     const permission = 'files.add'
 
-    const preAcl = createPreAcl(getState, accessControl, origin, permission)
+    const preAcl = createPreAcl(getState, accessControl, getScope, permission)
 
     let error
 
@@ -35,14 +35,14 @@ describe('lib/ipfs-proxy/pre-acl', () => {
   it('should allow access if permission is on whitelist', async () => {
     const getState = () => ({ ipfsProxy: true })
     const accessControl = new AccessControl(new Storage())
-    const origin = 'https://ipfs.io'
+    const getScope = () => 'https://ipfs.io/'
     const requestAccess = async () => { throw new Error('Requested access for whitelist permission') }
 
     let error
 
     try {
       await Promise.all(ACL_WHITELIST.map(permission => {
-        const preAcl = createPreAcl(getState, accessControl, origin, permission, requestAccess)
+        const preAcl = createPreAcl(getState, accessControl, getScope, permission, requestAccess)
         return preAcl()
       }))
     } catch (err) {
@@ -55,10 +55,10 @@ describe('lib/ipfs-proxy/pre-acl', () => {
   it('should request access if no grant exists', async () => {
     const getState = () => ({ ipfsProxy: true })
     const accessControl = new AccessControl(new Storage())
-    const origin = 'https://ipfs.io'
+    const getScope = () => 'https://ipfs.io/'
     const permission = 'files.add'
     const requestAccess = Sinon.spy(async () => ({ allow: true }))
-    const preAcl = createPreAcl(getState, accessControl, origin, permission, requestAccess)
+    const preAcl = createPreAcl(getState, accessControl, getScope, permission, requestAccess)
 
     await preAcl()
 
@@ -68,10 +68,10 @@ describe('lib/ipfs-proxy/pre-acl', () => {
   it('should deny access when user denies request', async () => {
     const getState = () => ({ ipfsProxy: true })
     const accessControl = new AccessControl(new Storage())
-    const origin = 'https://ipfs.io'
+    const getScope = () => 'https://ipfs.io/'
     const permission = 'files.add'
     const requestAccess = Sinon.spy(async () => ({ allow: false }))
-    const preAcl = createPreAcl(getState, accessControl, origin, permission, requestAccess)
+    const preAcl = createPreAcl(getState, accessControl, getScope, permission, requestAccess)
 
     let error
 
@@ -88,10 +88,10 @@ describe('lib/ipfs-proxy/pre-acl', () => {
   it('should not re-request if denied', async () => {
     const getState = () => ({ ipfsProxy: true })
     const accessControl = new AccessControl(new Storage())
-    const origin = 'https://ipfs.io'
+    const getScope = () => 'https://ipfs.io/'
     const permission = 'files.add'
     const requestAccess = Sinon.spy(async () => ({ allow: false }))
-    const preAcl = createPreAcl(getState, accessControl, origin, permission, requestAccess)
+    const preAcl = createPreAcl(getState, accessControl, getScope, permission, requestAccess)
 
     let error
 
@@ -120,10 +120,10 @@ describe('lib/ipfs-proxy/pre-acl', () => {
   it('should not re-request if allowed', async () => {
     const getState = () => ({ ipfsProxy: true })
     const accessControl = new AccessControl(new Storage())
-    const origin = 'https://ipfs.io'
+    const getScope = () => 'https://ipfs.io/'
     const permission = 'files.add'
     const requestAccess = Sinon.spy(async () => ({ allow: true }))
-    const preAcl = createPreAcl(getState, accessControl, origin, permission, requestAccess)
+    const preAcl = createPreAcl(getState, accessControl, getScope, permission, requestAccess)
 
     await preAcl()
     expect(requestAccess.callCount).to.equal(1)

--- a/test/functional/pages/proxy-access-dialog/page.test.js
+++ b/test/functional/pages/proxy-access-dialog/page.test.js
@@ -7,13 +7,13 @@ const createMockI18n = require('../../../helpers/mock-i18n')
 describe('pages/proxy-access-dialog/page', () => {
   it('should display title, wildcard checkbox and allow/deny buttons', async () => {
     const i18n = createMockI18n()
-    const state = { origin: 'http://ipfs.io', permission: 'files.add' }
+    const state = { scope: 'http://ipfs.io', permission: 'files.add' }
 
     let res
 
     expect(() => { res = createProxyAccessDialogPage(i18n)(state).toString() }).to.not.throw()
-    expect(res).to.have.string(`page_proxyAccessDialog_title[${state.origin},${state.permission}]`)
-    expect(res).to.have.string(`page_proxyAccessDialog_wildcardCheckbox_label[${state.origin}]`)
+    expect(res).to.have.string(`page_proxyAccessDialog_title[${state.scope},${state.permission}]`)
+    expect(res).to.have.string(`page_proxyAccessDialog_wildcardCheckbox_label[${state.scope}]`)
     expect(res).to.have.string(`page_proxyAccessDialog_denyButton_text`)
     expect(res).to.have.string(`page_proxyAccessDialog_allowButton_text`)
   })

--- a/test/functional/pages/proxy-acl/page.test.js
+++ b/test/functional/pages/proxy-acl/page.test.js
@@ -16,11 +16,11 @@ describe('pages/proxy-acl/page', () => {
     expect(res.toString()).to.have.string('page_proxyAcl_no_perms')
   })
 
-  it('should render with single origin ACL and single allowed permission', async () => {
+  it('should render with single scope ACL and single allowed permission', async () => {
     const i18n = createMockI18n()
     const state = {
       acl: objToAcl({
-        'https://ipfs.io': {
+        'https://ipfs.io/': {
           'ipfs.files.add': true
         }
       })
@@ -35,11 +35,11 @@ describe('pages/proxy-acl/page', () => {
     expect(res).to.have.string('ipfs.files.add')
   })
 
-  it('should render with single origin ACL and single denied permission', async () => {
+  it('should render with single scope ACL and single denied permission', async () => {
     const i18n = createMockI18n()
     const state = {
       acl: objToAcl({
-        'https://ipfs.io': {
+        'https://ipfs.io/': {
           'ipfs.files.add': false
         }
       })
@@ -54,11 +54,11 @@ describe('pages/proxy-acl/page', () => {
     expect(res).to.have.string('ipfs.files.add')
   })
 
-  it('should render with single origin ACL and multiple permissions', async () => {
+  it('should render with single scope ACL and multiple permissions', async () => {
     const i18n = createMockI18n()
     const state = {
       acl: objToAcl({
-        'https://ipfs.io': {
+        'https://ipfs.io/': {
           'ipfs.files.add': true,
           'ipfs.object.new': false
         }
@@ -76,15 +76,15 @@ describe('pages/proxy-acl/page', () => {
     expect(res).to.have.string('ipfs.object.new')
   })
 
-  it('should render with multiple origins and multiple permissions', async () => {
+  it('should render with multiple scopes and multiple permissions', async () => {
     const i18n = createMockI18n()
     const state = {
       acl: objToAcl({
-        'https://ipfs.io': {
+        'https://ipfs.io/': {
           'ipfs.files.add': false,
           'ipfs.object.new': true
         },
-        'https://ipld.io': {
+        'https://ipld.io/': {
           'ipfs.block.put': true
         }
       })
@@ -94,8 +94,8 @@ describe('pages/proxy-acl/page', () => {
 
     expect(() => { res = createProxyAclPage(i18n)(state).toString() }).to.not.throw()
 
-    expect(res).to.have.string('https://ipfs.io')
-    expect(res).to.have.string('https://ipld.io')
+    expect(res).to.have.string('https://ipfs.io/')
+    expect(res).to.have.string('https://ipld.io/')
     expect(res).to.have.string('page_proxyAcl_toggle_to_allow_button_title')
     expect(res).to.have.string('page_proxyAcl_toggle_to_deny_button_title')
     expect(res).to.have.string('ipfs.files.add')

--- a/test/functional/pages/proxy-acl/store.test.js
+++ b/test/functional/pages/proxy-acl/store.test.js
@@ -121,7 +121,7 @@ describe('pages/proxy-acl/store', () => {
       emitter.emit.callThrough()
 
       // Now revoke this grant
-      const e = createMockEvent({ 'data-origin': 'http://ipfs.io/', 'data-permission': 'ipfs.files.add' })
+      const e = createMockEvent({ 'data-scope': 'http://ipfs.io/', 'data-permission': 'ipfs.files.add' })
       emitter.emit('revoke', e)
     })
 
@@ -184,7 +184,7 @@ describe('pages/proxy-acl/store', () => {
       emitter.emit.callThrough()
 
       // Now revoke all grants
-      const e = createMockEvent({ 'data-origin': 'http://ipfs.io/' })
+      const e = createMockEvent({ 'data-scope': 'http://ipfs.io/' })
       emitter.emit('revoke', e)
     })
 
@@ -239,7 +239,7 @@ describe('pages/proxy-acl/store', () => {
     emitter.emit.callThrough()
 
     // Now attempt revoke all grants
-    const e = createMockEvent({ 'data-origin': 'http://ipfs.io/' })
+    const e = createMockEvent({ 'data-scope': 'http://ipfs.io/' })
     emitter.emit('revoke', e)
 
     acl = await accessControl.getAcl()
@@ -295,7 +295,7 @@ describe('pages/proxy-acl/store', () => {
       emitter.emit.callThrough()
 
       // Now toggle the access right
-      const e = createMockEvent({ 'data-origin': 'http://ipfs.io/', 'data-permission': 'ipfs.files.add', 'data-allow': 'false' })
+      const e = createMockEvent({ 'data-scope': 'http://ipfs.io/', 'data-permission': 'ipfs.files.add', 'data-allow': 'false' })
       emitter.emit('toggleAllow', e)
     })
 

--- a/test/functional/pages/proxy-acl/store.test.js
+++ b/test/functional/pages/proxy-acl/store.test.js
@@ -46,7 +46,7 @@ describe('pages/proxy-acl/store', () => {
     const emitter = new EventEmitter()
     const state = {}
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', true)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', true)
 
     store(state, emitter)
 
@@ -65,7 +65,7 @@ describe('pages/proxy-acl/store', () => {
     const acl = await accessControl.getAcl()
 
     const expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': true
       }
     })
@@ -82,8 +82,8 @@ describe('pages/proxy-acl/store', () => {
     const emitter = new EventEmitter()
     const state = {}
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', true)
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.object.new', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', true)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.object.new', false)
 
     store(state, emitter)
 
@@ -102,7 +102,7 @@ describe('pages/proxy-acl/store', () => {
     let acl = await accessControl.getAcl()
 
     let expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': true,
         'ipfs.object.new': false
       }
@@ -121,14 +121,14 @@ describe('pages/proxy-acl/store', () => {
       emitter.emit.callThrough()
 
       // Now revoke this grant
-      const e = createMockEvent({ 'data-origin': 'http://ipfs.io', 'data-permission': 'ipfs.files.add' })
+      const e = createMockEvent({ 'data-origin': 'http://ipfs.io/', 'data-permission': 'ipfs.files.add' })
       emitter.emit('revoke', e)
     })
 
     acl = await accessControl.getAcl()
 
     expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.object.new': false
       }
     })
@@ -145,8 +145,8 @@ describe('pages/proxy-acl/store', () => {
     const emitter = new EventEmitter()
     const state = {}
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', false)
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.object.new', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.object.new', false)
 
     store(state, emitter)
 
@@ -165,7 +165,7 @@ describe('pages/proxy-acl/store', () => {
     let acl = await accessControl.getAcl()
 
     let expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': false,
         'ipfs.object.new': false
       }
@@ -184,14 +184,14 @@ describe('pages/proxy-acl/store', () => {
       emitter.emit.callThrough()
 
       // Now revoke all grants
-      const e = createMockEvent({ 'data-origin': 'http://ipfs.io' })
+      const e = createMockEvent({ 'data-origin': 'http://ipfs.io/' })
       emitter.emit('revoke', e)
     })
 
     acl = await accessControl.getAcl()
 
     expectedAcl = objToAcl({
-      'http://ipfs.io': {}
+      'http://ipfs.io/': {}
     })
 
     expect(acl).to.deep.equal(expectedAcl)
@@ -206,8 +206,8 @@ describe('pages/proxy-acl/store', () => {
     const emitter = new EventEmitter()
     const state = {}
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', false)
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.object.new', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.object.new', false)
 
     store(state, emitter)
 
@@ -226,7 +226,7 @@ describe('pages/proxy-acl/store', () => {
     let acl = await accessControl.getAcl()
 
     const expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': false,
         'ipfs.object.new': false
       }
@@ -239,7 +239,7 @@ describe('pages/proxy-acl/store', () => {
     emitter.emit.callThrough()
 
     // Now attempt revoke all grants
-    const e = createMockEvent({ 'data-origin': 'http://ipfs.io' })
+    const e = createMockEvent({ 'data-origin': 'http://ipfs.io/' })
     emitter.emit('revoke', e)
 
     acl = await accessControl.getAcl()
@@ -256,8 +256,8 @@ describe('pages/proxy-acl/store', () => {
     const emitter = new EventEmitter()
     const state = {}
 
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.files.add', false)
-    await accessControl.setAccess('http://ipfs.io', 'ipfs.object.new', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.files.add', false)
+    await accessControl.setAccess('http://ipfs.io/', 'ipfs.object.new', false)
 
     store(state, emitter)
 
@@ -276,7 +276,7 @@ describe('pages/proxy-acl/store', () => {
     let acl = await accessControl.getAcl()
 
     let expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': false,
         'ipfs.object.new': false
       }
@@ -295,14 +295,14 @@ describe('pages/proxy-acl/store', () => {
       emitter.emit.callThrough()
 
       // Now toggle the access right
-      const e = createMockEvent({ 'data-origin': 'http://ipfs.io', 'data-permission': 'ipfs.files.add', 'data-allow': 'false' })
+      const e = createMockEvent({ 'data-origin': 'http://ipfs.io/', 'data-permission': 'ipfs.files.add', 'data-allow': 'false' })
       emitter.emit('toggleAllow', e)
     })
 
     acl = await accessControl.getAcl()
 
     expectedAcl = objToAcl({
-      'http://ipfs.io': {
+      'http://ipfs.io/': {
         'ipfs.files.add': true,
         'ipfs.object.new': false
       }


### PR DESCRIPTION
🎥 https://youtu.be/v6wuFRDKVBU

This PR introduces scope based permissions - following a similar implementation as service worker registration scopes.

This means that allowing access to:
https://ipfs.io/ipfs/QmQxeMcbqW9npq5h5kyE2iPECR9jxJF4j5x4bSRQ2phLY4/

will allow access to:
https://ipfs.io/ipfs/QmQxeMcbqW9npq5h5kyE2iPECR9jxJF4j5x4bSRQ2phLY4/path/to/something

...but not:
https://ipfs.io/ipfs/QmWfVY9y3xjsixTgbd9AorQxH7VtMpzfx2HaWtsoUYecaX

or other hashes.

resolves #375

---

### Scopes

Permissions are scoped to the **origin and path** (and sub-paths) of the file from which the permission was requested.

Scoped permissions in `window.ipfs` work similarly to how they work for [service worker registrations](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register#Examples) except that the user cannot control the scope, and it is set to the origin and path from which the permission was requested.

Scope based permissions allow applications running on an IPFS gateway to be granted different permissions. Consider the following two web sites running on the ipfs.io gateway:

* https://ipfs.io/ipfs/QmQxeMcbqW9npq5h5kyE2iPECR9jxJF4j5x4bSRQ2phLY4/
* https://ipfs.io/ipfs/QmTegrragyzfFq6DSuUaPYoKzm4eRBj2tgQaDHC72dLLaV/

With [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) these two applications would be granted the same permissions. With scoped permissions, these applications will be given a different set of permissions.

e.g.

* Allow `files.add` to `https://domain.com/`
    * ...will allow `files.add` to:
        * `https://domain.com/file`
        * `https://domain.com/file2.html`
        * `https://domain.com/sub/paths`
        * `https://domain.com/sub/paths/files`
        * etc.
* Allow `files.add` to `https://domain.com/feature`
    * ...will allow `files.add` to:
        * `https://domain.com/feature/file`
        * `https://domain.com/feature/file2.html`
        * `https://domain.com/feature/sub/paths`
        * `https://domain.com/feature/sub/paths/files`
        * `https://domain.com/featuresearch/sub/paths/files` (note substring)
        * `https://domain.com/features.html` (note substring)
        * etc.
    * ...will cause additional prompt for `files.add` to:
        * `https://domain.com/`
        * `https://domain.com/files`
        * etc.
