### PR TITLE
Temporarily disables access to MFS functions on window.ipfs

### DIFF
--- a/add-on/src/lib/ipfs-proxy/pre-acl.js
+++ b/add-on/src/lib/ipfs-proxy/pre-acl.js
@@ -2,6 +2,20 @@
 // All other IPFS functions require authorization.
 const ACL_WHITELIST = Object.freeze(require('./acl-whitelist.json'))
 
+// TEMPORARY blacklist of MFS functions that are automatically denied access
+// https://github.com/ipfs-shipyard/ipfs-companion/issues/330#issuecomment-367651787
+const MFS_BLACKLIST = Object.freeze([
+  'files.cp',
+  'files.mkdir',
+  'files.stat',
+  'files.rm',
+  'files.read',
+  'files.write',
+  'files.mv',
+  'files.flush',
+  'files.ls'
+])
+
 // Creates a "pre" function that is called prior to calling a real function
 // on the IPFS instance. It will throw if access is denied, and ask the user if
 // no access decision has been made yet.
@@ -9,6 +23,10 @@ function createPreAcl (getState, accessControl, getScope, permission, requestAcc
   return async (...args) => {
     // Check if all access to the IPFS node is disabled
     if (!getState().ipfsProxy) throw new Error('User disabled access to IPFS')
+
+    if (MFS_BLACKLIST.includes(permission)) {
+      throw new Error('MFS functions are temporarily disabled')
+    }
 
     // No need to verify access if permission is on the whitelist
     if (ACL_WHITELIST.includes(permission)) return args


### PR DESCRIPTION
Simply disable access to them for now until we can scope the paths they operate on. Discussion here: https://github.com/ipfs-shipyard/ipfs-companion/issues/330#issuecomment-367651787

Using [this list](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#mutable-file-system) for the list of functions that we should blacklist.