### PR TITLE
Versioned Dev Builds for CI ✅

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -3,29 +3,29 @@ node(label: 'linux') {
         cleanWs()
         checkout scm
         sh 'printenv'
-        sh 'git show-ref --head HEAD | head -c 7 > HEAD'
-        sh 'cat HEAD'
+        sh 'git show-ref --head HEAD | head -c 7 > git-HEAD'
+        sh 'cat git-HEAD'
     }
     stage('ci:install') {
-        sh 'docker build -t ipfs-companion:$(cat HEAD) .'
+        sh 'docker build -t ipfs-companion:$(cat git-HEAD) .'
     }
     catchError {
         stage('ci:test') {
-            sh 'docker run -i --rm -e JUNIT_REPORT_PATH=test/report.xml -v $(pwd)/test:/usr/src/app/test:rw ipfs-companion:$(cat HEAD) npm run ci:test'
+            sh 'docker run -i --rm -e JUNIT_REPORT_PATH=test/report.xml -v $(pwd)/test:/usr/src/app/test:rw ipfs-companion:$(cat git-HEAD) npm run ci:test'
         }
     }
     junit allowEmptyResults: true, testResults: 'test/report.xml'
     catchError {
         stage('ci:build') {
             sh 'mkdir -p $(pwd)/build'
-            sh 'docker run -i --rm -v $(pwd)/build:/usr/src/app/build:rw -v $(pwd)/add-on:/usr/src/app/add-on:rw  ipfs-companion:$(cat HEAD) npm run ci:build'
+            sh 'docker run -i --rm -v $(pwd)/build:/usr/src/app/build:rw -v $(pwd)/add-on:/usr/src/app/add-on:rw  ipfs-companion:$(cat git-HEAD) npm run ci:build'
             archiveArtifacts artifacts: 'build/*.zip', fingerprint: true
         }
         stage('lint:web-ext') {
-            sh 'docker run -i --rm -v $(pwd)/add-on:/usr/src/app/add-on:ro ipfs-companion:$(cat HEAD) npm run lint:web-ext'
+            sh 'docker run -i --rm -v $(pwd)/add-on:/usr/src/app/add-on:ro ipfs-companion:$(cat git-HEAD) npm run lint:web-ext'
         }
     }
-    sh 'docker rmi -f ipfs-companion:$(cat HEAD)'
+    sh 'docker rmi -f ipfs-companion:$(cat git-HEAD)'
     sh 'ls -lh .'
     sh 'ls -Rlh add-on'
     sh 'ls -Rlh build'

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -3,27 +3,29 @@ node(label: 'linux') {
         cleanWs()
         checkout scm
         sh 'printenv'
+        sh 'git show-ref --head HEAD | head -c 7 > HEAD'
+        sh 'cat HEAD'
     }
     stage('ci:install') {
-        sh 'docker build -t ipfs-companion:${JOB_BASE_NAME}-${BUILD_NUMBER} .'
+        sh 'docker build -t ipfs-companion:$(cat HEAD) .'
     }
     catchError {
         stage('ci:test') {
-            sh 'docker run -i --rm -e JUNIT_REPORT_PATH=test/report.xml -v $(pwd)/test:/usr/src/app/test:rw ipfs-companion:${JOB_BASE_NAME}-${BUILD_NUMBER} npm run ci:test'
+            sh 'docker run -i --rm -e JUNIT_REPORT_PATH=test/report.xml -v $(pwd)/test:/usr/src/app/test:rw ipfs-companion:$(cat HEAD) npm run ci:test'
         }
     }
     junit allowEmptyResults: true, testResults: 'test/report.xml'
     catchError {
         stage('ci:build') {
             sh 'mkdir -p $(pwd)/build'
-            sh 'docker run -i --rm -v $(pwd)/build:/usr/src/app/build:rw -v $(pwd)/add-on:/usr/src/app/add-on:rw  ipfs-companion:${JOB_BASE_NAME}-${BUILD_NUMBER} npm run ci:build'
+            sh 'docker run -i --rm -v $(pwd)/build:/usr/src/app/build:rw -v $(pwd)/add-on:/usr/src/app/add-on:rw  ipfs-companion:$(cat HEAD) npm run ci:build'
             archiveArtifacts artifacts: 'build/*.zip', fingerprint: true
         }
         stage('lint:web-ext') {
-            sh 'docker run -i --rm -v $(pwd)/add-on:/usr/src/app/add-on:ro ipfs-companion:${JOB_BASE_NAME}-${BUILD_NUMBER} npm run lint:web-ext'
+            sh 'docker run -i --rm -v $(pwd)/add-on:/usr/src/app/add-on:ro ipfs-companion:$(cat HEAD) npm run lint:web-ext'
         }
     }
-    sh 'docker rmi -f ipfs-companion:${JOB_BASE_NAME}-${BUILD_NUMBER}'
+    sh 'docker rmi -f ipfs-companion:$(cat HEAD)'
     sh 'ls -lh .'
     sh 'ls -Rlh add-on'
     sh 'ls -Rlh build'

--- a/ci/update-manifest.sh
+++ b/ci/update-manifest.sh
@@ -3,21 +3,22 @@
 # to explicitly state that produced artifact is a dev build.
 set -e
 
-# Name includes git revision to make QA and bug reporting easier for users :-)
-REVISION=$(git show-ref --head HEAD | head -c 7)
-
-# Browsers do not accept non-numeric values in version string
-# so we calculate some sub-versions based on number of commits in master and  current branch
-COMMITS_IN_MASTER=$(git rev-list --count master)
-NEW_COMMITS_IN_CURRENT_BRANCH=$(git rev-list --count HEAD ^master)
-
 # make it immutable
 git checkout add-on/manifest.json
 
-# update name
+## NAME
+# Name includes git revision to make QA and bug reporting easier for users :-)
+REVISION=$(git show-ref --head HEAD | head -c 7)
 sed -i 's,__MSG_manifest_extensionName__,IPFS Companion (Dev Build @ '"$REVISION"'),' add-on/manifest.json
 grep $REVISION add-on/manifest.json
 
-# update version
-sed -i "s|\"version\".*:.*\"\(.*\)\"|\"version\": \"\1.${COMMITS_IN_MASTER}.${NEW_COMMITS_IN_CURRENT_BRANCH}\"|" add-on/manifest.json
+## VERSION
+# Browsers do not accept non-numeric values in version string
+# so we calculate some sub-versions based on number of commits in master and  current branch
+COMMITS_IN_MASTER=$(git rev-list --count refs/remotes/origin/master)
+NEW_COMMITS_IN_CURRENT_BRANCH=$(git rev-list --count HEAD ^refs/remotes/origin/master)
+# mozilla/addons-linter: Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3.4"
+BUILD_VERSION=$(($COMMITS_IN_MASTER*10+$NEW_COMMITS_IN_CURRENT_BRANCH))
+sed -i "s|\"version\".*:.*\"\(.*\)\"|\"version\": \"\1.${BUILD_VERSION}\"|" add-on/manifest.json
 grep \"version\" add-on/manifest.json
+

--- a/ci/update-manifest.sh
+++ b/ci/update-manifest.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script is used by CI setup to update add-on name in manifest
+# to explicitly state that produced artifact is a dev build.
+set -e
+
+# Name includes git revision to make QA and bug reporting easier for users :-)
+REVISION=$(git show-ref --head HEAD | head -c 7)
+
+# Browsers do not accept non-numeric values in version string
+# so we calculate some sub-versions based on number of commits in master and  current branch
+COMMITS_IN_MASTER=$(git rev-list --count master)
+NEW_COMMITS_IN_CURRENT_BRANCH=$(git rev-list --count HEAD ^master)
+
+# make it immutable
+git checkout add-on/manifest.json
+
+# update name
+sed -i 's,__MSG_manifest_extensionName__,IPFS Companion (Dev Build @ '"$REVISION"'),' add-on/manifest.json
+grep $REVISION add-on/manifest.json
+
+# update version
+sed -i "s|\"version\".*:.*\"\(.*\)\"|\"version\": \"\1.${COMMITS_IN_MASTER}.${NEW_COMMITS_IN_CURRENT_BRANCH}\"|" add-on/manifest.json
+grep \"version\" add-on/manifest.json

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ci": "run-s ci:*",
     "ci:install": "npx yarn@1.3.2 install --frozen-lockfile || npx yarn@1.3.2 install --frozen-lockfile",
     "ci:test": "npx yarn@1.3.2 test",
-    "ci:build": "npx yarn@1.3.2 build ; chmod -R ugo+rwX build/ add-on/",
+    "ci:build": "./ci/update-manifest.sh ; npx yarn@1.3.2 build ; chmod -R ugo+rwX build/ add-on/",
     "yarn-build": "npx yarn@1.3.2 && npx yarn@1.3.2 build"
   },
   "private": true,


### PR DESCRIPTION
This PR is a prerequisite for https://github.com/ipfs-shipyard/ipfs-companion/issues/385 and ensures we have good times during QA/testing.

It adds a script that modifies manifest during the build, so that produced artifact is clearly marked as Dev Build and includes git revision it was built from:

```
build
└── ipfs_companion_dev_build_bd3da68_-2.2.0.7523.zip
```

Change is also present in Browser UI (addon listing):

> ![2018-02-22-225506_1647x1421_scrot](https://user-images.githubusercontent.com/157609/36566406-b3938838-1823-11e8-8453-489d0d6b83d2.png)


>  ![2018-02-22-225515_1647x1421_scrot](https://user-images.githubusercontent.com/157609/36566394-ab61a35c-1823-11e8-9e1e-1d36d59f3e37.png)

And at Jenkins:

>  ![screen shot 2018-02-22 at 23 00 08](https://user-images.githubusercontent.com/157609/36566572-2f7895f6-1824-11e8-9f4b-41b6a323ac85.png)

