### PR TITLE
Set Up Self-hosted Beta Channel for Firefox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+vendor
+build
+coverage/
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 vendor
 node_modules
 package-lock.json
-firefox
+./firefox/
 cache
 build
 npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:9.5.0
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 ENV PATH="/usr/src/app/node_modules/.bin:${PATH}"
+RUN curl -s https://ipfs.io/ipfs/QmbukYcmtyU6ZEKt6fepnvrTNa9F6VqsUPMUgNxQjEmphH > /usr/local/bin/jq && chmod +x /usr/local/bin/jq
 COPY package.json /usr/src/app/package.json
 COPY yarn.lock /usr/src/app/yarn.lock
 RUN npm run ci:install

--- a/README.md
+++ b/README.md
@@ -62,33 +62,32 @@ _(some are disabled by default, use Preferences screen to enable)_
 - Detect domains with [dnslink](https://github.com/jbenet/go-dnslink) in DNS TXT record and load them from IPFS
 - Make plaintext IPFS links clickable
 - Mirror to IPFS by right click on any image or video
+- Embedded node can be used for uploads even when external API is down
 - [`window.ipfs`](docs/window.ipfs.md) - web pages can access your IPFS node
 
 ## Install
 
-We recommend installing the add-on via your browser's add-on store.
+### Release Channel
+
+We recommend installing the stable release via your browser's add-on store.
 
 | Firefox | Chrome / Chromium |
 |---------|-------------------|
 | [![Get the add-on](https://blog.mozilla.org/addons/files/2015/11/AMO-button_1.png)](https://addons.mozilla.org/en-US/firefox/addon/ipfs-companion/) | [![](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch) |
 
-`ipfs-companion` is designed to retrieve content from a locally running IPFS daemon. so make sure [IPFS is installed](https://ipfs.io/docs/getting-started/) on your computer.
+**Note:** `ipfs-companion` is designed to retrieve content from a locally running IPFS daemon.  
+Make sure [IPFS is installed](https://ipfs.io/docs/getting-started/) on your computer.
 
-### Modern Firefox (> 53)
+### Beta Channel
 
-Install the latest signed release from [AMO](https://addons.mozilla.org/en-US/firefox/addon/ipfs-companion/).
+Developers and enthusiasts can opt-in for Beta-quality channel with hand-picked Dev Builds:
 
-It will guarantee automatic updates to the latest version reviewed by Mozilla community.
+- Beta for Firefox: [Self-hosted Signed Dev Build](https://ipfs-shipyard.github.io/ipfs-companion/ci/firefox/)
+- Beta for Chrome: [Dev Build at Chrome Web Store](https://chrome.google.com/webstore/detail/ipfs-companion-dev-build/hjoieblefckbooibpepigmacodalfndh)
 
-#### Legacy Firefox (< 53) and XUL-Compatible Browsers
-
-Legacy  versions `1.x.x` were based on currently deprecated Add-On SDK (Firefox-only).   
-While it is not maintained anymore, one can inspect, build and install it using codebase from [legacy-sdk](https://github.com/ipfs/ipfs-companion/tree/legacy-sdk) branch.    
-For historical background on the rewrite see [Issue #20: Move to WebExtensions](https://github.com/ipfs/ipfs-companion/issues/20).
-
-### Chrome / Chromium
-
-Install the latest signed release from [Chrome Web Store](https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch).
+It is also possible to [grab the last successful build from `master`](https://ci.ipfs.team/job/IPFS%20Shipyard/job/ipfs-companion/job/master/lastSuccessfulBuild/),
+but these builds are not signed nor will automatically update:
+`.zip` bundles are meant only to be manually loaded via `chrome://extensions` (Chrome) or `about:debugging` (Firefox) for the purpose of quick smoke-testing.
 
 
 ## Development or other Browsers Supporting WebExtensions API
@@ -124,6 +123,13 @@ docker run -it -v $(pwd)/build:/usr/src/app/build ipfs-companion yarn build
 ```
 
 Now you can install the extension directly from `build/`
+
+### Legacy Firefox (< 53) and XUL-Compatible Browsers
+
+Legacy  versions `1.x.x` were based on currently deprecated Add-On SDK (Firefox-only).   
+While it is not maintained anymore, one can inspect, build and install it using codebase from [legacy-sdk](https://github.com/ipfs/ipfs-companion/tree/legacy-sdk) branch.    
+For historical background on the rewrite see [Issue #20: Move to WebExtensions](https://github.com/ipfs/ipfs-companion/issues/20).
+
 
 ### Brave
 

--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -1,96 +1,86 @@
 {
-    "manifest_version": 2,
-    "name": "__MSG_manifest_extensionName__",
-    "short_name": "__MSG_manifest_shortExtensionName__",
-    "version" : "2.2.0",
-
-    "description": "__MSG_manifest_extensionDescription__",
-    "homepage_url": "https://github.com/ipfs/ipfs-companion",
-    "author": "Marcin Rataj",
-    "icons": {
-        "19": "icons/png/ipfs-logo-on_19.png",
-        "38": "icons/png/ipfs-logo-on_38.png",
-        "128": "icons/png/ipfs-logo-on_128.png"
+  "manifest_version": 2,
+  "name": "__MSG_manifest_extensionName__",
+  "short_name": "__MSG_manifest_shortExtensionName__",
+  "version": "2.2.0",
+  "description": "__MSG_manifest_extensionDescription__",
+  "homepage_url": "https://github.com/ipfs/ipfs-companion",
+  "author": "Marcin Rataj",
+  "icons": {
+    "19": "icons/png/ipfs-logo-on_19.png",
+    "38": "icons/png/ipfs-logo-on_38.png",
+    "128": "icons/png/ipfs-logo-on_128.png"
+  },
+  "applications": {
+    "gecko": {
+      "id": "ipfs-firefox-addon@lidel.org",
+      "strict_min_version": "58.0"
+    }
+  },
+  "permissions": [
+    "<all_urls>",
+    "idle",
+    "activeTab",
+    "tabs",
+    "notifications",
+    "alarms",
+    "storage",
+    "contextMenus",
+    "clipboardWrite",
+    "webNavigation",
+    "webRequest",
+    "webRequestBlocking"
+  ],
+  "background": {
+    "page": "dist/background/background.html"
+  },
+  "browser_action": {
+    "browser_style": false,
+    "default_icon": {
+      "19": "icons/png/ipfs-logo-off_19.png",
+      "38": "icons/png/ipfs-logo-off_38.png",
+      "128": "icons/png/ipfs-logo-off_128.png"
     },
-    "applications": {
-        "gecko": {
-            "id": "ipfs-firefox-addon@lidel.org",
-            "strict_min_version": "58.0"
-        }
+    "default_title": "__MSG_browserAction_title__",
+    "default_popup": "dist/popup/browser-action/index.html"
+  },
+  "options_ui": {
+    "browser_style": false,
+    "page": "dist/options/options.html"
+  },
+  "web_accessible_resources": [
+    "icons/ipfs-logo-on.svg",
+    "icons/ipfs-logo-off.svg"
+  ],
+  "content_scripts": [
+    {
+      "all_frames": true,
+      "js": [
+        "dist/contentScripts/ipfs-proxy/content.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "run_at": "document_start"
+    }
+  ],
+  "protocol_handlers": [
+    {
+      "protocol": "web+dweb",
+      "name": "IPFS Add-On: DWEB protocol handler",
+      "uriTemplate": "https://ipfs.io/%s"
     },
-
-    "permissions": [
-        "<all_urls>",
-        "idle",
-        "activeTab",
-        "tabs",
-        "notifications",
-        "alarms",
-        "storage",
-        "contextMenus",
-        "clipboardWrite",
-        "webNavigation",
-        "webRequest",
-        "webRequestBlocking"
-    ],
-
-    "background": {
-        "page": "dist/background/background.html"
+    {
+      "protocol": "web+ipns",
+      "name": "IPFS Add-On: IPNS protocol handler",
+      "uriTemplate": "https://ipfs.io/%s"
     },
-
-    "browser_action": {
-        "browser_style": false,
-        "default_icon": {
-            "19": "icons/png/ipfs-logo-off_19.png",
-            "38": "icons/png/ipfs-logo-off_38.png",
-            "128": "icons/png/ipfs-logo-off_128.png"
-        },
-        "default_title": "__MSG_browserAction_title__",
-        "default_popup": "dist/popup/browser-action/index.html"
-    },
-
-    "options_ui": {
-        "browser_style": false,
-        "page": "dist/options/options.html"
-    },
-
-    "web_accessible_resources": [
-        "icons/ipfs-logo-on.svg",
-        "icons/ipfs-logo-off.svg"
-    ],
-
-    "content_scripts": [
-        {
-            "all_frames": true,
-            "js": [
-                "dist/contentScripts/ipfs-proxy/content.js"
-            ],
-            "matches": [
-                "<all_urls>"
-            ],
-            "run_at": "document_start"
-        }
-    ],
-
-	"protocol_handlers": [
-		{
-			"protocol": "web+dweb",
-			"name": "IPFS Add-On: DWEB protocol handler",
-			"uriTemplate": "https://ipfs.io/%s"
-		},
-		{
-			"protocol": "web+ipns",
-			"name": "IPFS Add-On: IPNS protocol handler",
-			"uriTemplate": "https://ipfs.io/%s"
-		},
-		{
-			"protocol": "web+ipfs",
-			"name": "IPFS Add-On: IPFS protocol handler",
-			"uriTemplate": "https://ipfs.io/%s"
-		}
-	],
-
-    "content_security_policy": "script-src 'self'; object-src 'self'; frame-src 'self';",
-
-    "default_locale": "en"
+    {
+      "protocol": "web+ipfs",
+      "name": "IPFS Add-On: IPFS protocol handler",
+      "uriTemplate": "https://ipfs.io/%s"
+    }
+  ],
+  "content_security_policy": "script-src 'self'; object-src 'self'; frame-src 'self';",
+  "default_locale": "en"
 }

--- a/ci/firefox/index.html
+++ b/ci/firefox/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width" />
+    <title>IPFS Companion: Signed Dev Build for Firefox</title>
+    <link href="https://ipfs-shipyard.github.io/ipfs-companion/assets/css/style.css" rel="stylesheet">
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      <h1>IPFS Companion: Signed Dev Build for Firefox</h1>
+      <p id="content">Please wait, fetching dev build info.. :-)</p>
+      <p>(<a href="https://support.mozilla.org/en-US/kb/unable-install-add-ons-extensions-or-themes#w_you-are-asked-to-download-the-add-on-rather-than-installing-it">Read this if you are asked to download the add-on, rather than installing it</a>)
+    </div>
+    <script>
+      const updateManifestUrl = 'https://ipfs-shipyard.github.io/ipfs-companion/ci/firefox/update.json'
+      const fallbackInstallUrl = 'https://ipfs.io/ipfs/QmXQLH4ib98NLgfhveitd1uK1rGuaKiimKVmrjdg6G7Lp6/ipfs_companion_dev_build_ea5c2af-2.2.0.7583-an+fx.xpi'
+
+      function parseVersionString (str) {
+        if (typeof(str) != 'string') { return false }
+        let x = str.split('.')
+        let maj = parseInt(x[0]) || 0
+        let min = parseInt(x[1]) || 0
+        let pat = parseInt(x[2]) || 0
+        let bui = parseInt(x[3]) || 0
+        return { major: maj, minor: min, patch: pat, build: bui }
+      }
+
+      async function init(url)  {
+        let content = document.getElementById('content')
+        try {
+          let manifest = await (await fetch(url)).json()
+          console.log('fetched data', manifest)
+
+          // find latest build
+          let updates = manifest.addons['ipfs-companion-dev-build@ci.ipfs.team'].updates
+          let latest = updates.reduce((acc, val) => {
+            let a = acc ? parseVersionString(acc.version) : null
+            let b = parseVersionString(val.version)
+            if (a && a.major > b.major && a.minor > b.minor &&  a.patch > b.patch && a.build && b.build) {
+              return acc
+            }
+            return val
+          }, null)
+          console.log('latest build', latest.version)
+
+          // Add Install Button
+          let a = document.createElement('a')
+          a.href = latest.update_link
+          a.innerText = latest.version
+          content.innerText = 'Click to install the latest Dev Build: '
+          content.appendChild(a)
+
+        } catch(error) {
+          console.error('error while fetching ' + updateManifestUrl, error)
+          content.innerHTML = `Failed to fetch update.json :-( Try <a href="${fallbackInstallUrl}">this version</a> and then manually force-update via Extensions screen`
+        }
+      }
+
+      init(updateManifestUrl)
+
+    </script>
+  </body>
+</html>

--- a/ci/firefox/update.json
+++ b/ci/firefox/update.json
@@ -1,0 +1,13 @@
+{
+    "addons": {
+        "ipfs-companion-dev-build@ci.ipfs.team": {
+            "updates": [
+                {
+                    "version": "2.2.0.7583",
+                    "update_hash": "sha256:607a9400dfe198198fd29de2ca4fcee8d195f6835d049e8caf457d6078fcb472",
+                    "update_link": "https://ipfs.io/ipfs/QmXQLH4ib98NLgfhveitd1uK1rGuaKiimKVmrjdg6G7Lp6/ipfs_companion_dev_build_ea5c2af-2.2.0.7583-an+fx.xpi"
+                }
+            ]
+        }
+    }
+}

--- a/ci/update-manifest.sh
+++ b/ci/update-manifest.sh
@@ -3,14 +3,22 @@
 # to explicitly state that produced artifact is a dev build.
 set -e
 
+MANIFEST=add-on/manifest.json
+DEV_BUILD_ADDON_ID="ipfs-companion-dev-build@ci.ipfs.team"
+UPDATE_URL="https://ipfs-shipyard.github.io/ipfs-companion/update.json"
+
 # make it immutable
-git checkout add-on/manifest.json
+git checkout $MANIFEST
+
+function set-manifest {
+  jq -M --indent 2 "$1" < $MANIFEST > tmp.json && mv tmp.json $MANIFEST
+}
 
 ## NAME
 # Name includes git revision to make QA and bug reporting easier for users :-)
 REVISION=$(git show-ref --head HEAD | head -c 7)
-sed -i 's,__MSG_manifest_extensionName__,IPFS Companion (Dev Build @ '"$REVISION"'),' add-on/manifest.json
-grep $REVISION add-on/manifest.json
+set-manifest ".name = \"IPFS Companion (Dev Build @ $REVISION)\""
+grep $REVISION $MANIFEST
 
 ## VERSION
 # Browsers do not accept non-numeric values in version string
@@ -19,6 +27,15 @@ COMMITS_IN_MASTER=$(git rev-list --count refs/remotes/origin/master)
 NEW_COMMITS_IN_CURRENT_BRANCH=$(git rev-list --count HEAD ^refs/remotes/origin/master)
 # mozilla/addons-linter: Version string must be a string comprising one to four dot-separated integers (0-65535). E.g: 1.2.3.4"
 BUILD_VERSION=$(($COMMITS_IN_MASTER*10+$NEW_COMMITS_IN_CURRENT_BRANCH))
-sed -i "s|\"version\".*:.*\"\(.*\)\"|\"version\": \"\1.${BUILD_VERSION}\"|" add-on/manifest.json
-grep \"version\" add-on/manifest.json
+set-manifest ".version = (.version + \".${BUILD_VERSION}\")"
+grep \"version\" $MANIFEST
+
+
+## ADD-ON ID
+set-manifest ".applications.gecko[\"id\"] = \"$DEV_BUILD_ADDON_ID\""
+grep ipfs-companion-dev-build $MANIFEST
+
+## ADD DEV BUILD UPDATE_URL
+set-manifest ".applications.gecko[\"update_url\"] = \"$UPDATE_URL\""
+grep update_url $MANIFEST
 

--- a/ci/update-manifest.sh
+++ b/ci/update-manifest.sh
@@ -4,23 +4,27 @@
 set -e
 
 MANIFEST=add-on/manifest.json
-DEV_BUILD_ADDON_ID="ipfs-companion-dev-build@ci.ipfs.team"
-UPDATE_URL="https://ipfs-shipyard.github.io/ipfs-companion/update.json"
 
-# make it immutable
+# restore original (make this script immutable)
 git checkout $MANIFEST
 
+# Switch to self-hosted dev-build for Firefox (https://github.com/ipfs-shipyard/ipfs-companion/issues/385)
+DEV_BUILD_ADDON_ID="ipfs-companion-dev-build@ci.ipfs.team"
+UPDATE_URL="https://ipfs-shipyard.github.io/ipfs-companion/ci/firefox/update.json"
+
+
+# Use jq for JSON operations
 function set-manifest {
   jq -M --indent 2 "$1" < $MANIFEST > tmp.json && mv tmp.json $MANIFEST
 }
 
-## NAME
+## Set NAME
 # Name includes git revision to make QA and bug reporting easier for users :-)
 REVISION=$(git show-ref --head HEAD | head -c 7)
 set-manifest ".name = \"IPFS Companion (Dev Build @ $REVISION)\""
 grep $REVISION $MANIFEST
 
-## VERSION
+## Set VERSION
 # Browsers do not accept non-numeric values in version string
 # so we calculate some sub-versions based on number of commits in master and  current branch
 COMMITS_IN_MASTER=$(git rev-list --count refs/remotes/origin/master)
@@ -31,11 +35,11 @@ set-manifest ".version = (.version + \".${BUILD_VERSION}\")"
 grep \"version\" $MANIFEST
 
 
-## ADD-ON ID
+## Set ADD-ON ID
 set-manifest ".applications.gecko[\"id\"] = \"$DEV_BUILD_ADDON_ID\""
 grep ipfs-companion-dev-build $MANIFEST
 
-## ADD DEV BUILD UPDATE_URL
+## Add UPDATE_URL
 set-manifest ".applications.gecko[\"update_url\"] = \"$UPDATE_URL\""
 grep update_url $MANIFEST
 


### PR DESCRIPTION
This PR closes #385, be sure to read that issue first as the Firefox context is bit complex:

![](https://upload.wikimedia.org/wikipedia/commons/a/a9/Rube_Goldberg%27s_%22Self-Operating_Napkin%22_%28cropped%29.gif)

Changes introduced in this PR:

- Normalize indentation of `manifest.json` (makes future diffing easier)
- Publish initial version of `update.json` (the manifest for self-hosted Beta Channel for Firefox) 
  -  I enabled Github Pages for `master` branch which gave us a stable permalink: 
     `https://ipfs-shipyard.github.io/ipfs-companion/ci/firefox/update.json`
  - Created simple landing page that reads the manifest and displays a link to the latest Beta. 
- Advertising Beta channels in `README`:
  - Beta for Firefox: Self-hosted Signed Dev Build (link will work after PR is merged)
  - Beta for Chrome: [Dev Build at Chrome Web Store](https://chrome.google.com/webstore/detail/ipfs-companion-dev-build/hjoieblefckbooibpepigmacodalfndh)