### PR TITLE
Fixes ipfs.swarm.peers call when using js-ipfs-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ipfs": "0.27.7",
     "ipfs-api": "18.1.1",
     "ipfs-css": "0.2.0",
-    "ipfs-postmsg-proxy": "2.8.3",
+    "ipfs-postmsg-proxy": "2.8.4",
     "is-ipfs": "0.3.2",
     "is-svg": "3.0.0",
     "lru_map": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4064,9 +4064,9 @@ ipfs-multipart@~0.1.0:
     content "^3.0.0"
     dicer "^0.2.5"
 
-ipfs-postmsg-proxy@2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.8.3.tgz#a8ebb6b7ae0ae76d388d6a3422cdb4b469cc45a2"
+ipfs-postmsg-proxy@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.8.4.tgz#eb1d1f0e78e0ee63664081abbb7dc2b126034fc0"
   dependencies:
     big.js "^5.0.3"
     callbackify "^1.1.0"


### PR DESCRIPTION
Currently the return type for `ipfs.swarm.peers` is different depending on whether we're talking directly to a js-ipfs or js-ipfs-api ([issue opened here](https://github.com/ipfs/js-ipfs/issues/1248)).

This PR updates the proxy to take this into account so that it doesn't error when passed a `PeerId` where it is expecting a `PeerInfo` (https://github.com/tableflip/ipfs-postmsg-proxy/commit/eb0aa43416ad79c4a84b0aaa48a035f54d4d6dae).