### PR TITLE
Use constant publicGatewayUrl to avoid string repetitions and to facilitate updates

### DIFF
--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -75,7 +75,7 @@ function redirectToGateway (requestUrl, state) {
 // PROTOCOL HANDLERS: web+ in Firefox (protocol_handlers from manifest.json)
 // ===================================================================
 
-const webPlusProtocolHandler = 'https://ipfs.io/web%2B'
+const webPlusProtocolHandler = optionDefaults.publicGatewayUrl + '/web%2B'
 
 function webPlusProtocolRequest (request) {
   return request.url.startsWith(webPlusProtocolHandler)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -3,6 +3,7 @@
 
 const IsIpfs = require('is-ipfs')
 const { urlAtPublicGw } = require('./ipfs-path')
+const { optionDefaults } = require('./options')
 
 function createRequestModifier (getState, dnsLink, ipfsPathValidator) {
   return function modifyRequest (request) {


### PR DESCRIPTION
Even the default option is already defined, better to use it :)