### PR TITLE
Fix up page-action layout

### DIFF
--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -21,7 +21,7 @@ module.exports = function contextActions ({
   const isPinningSupported = (ipfsNodeType !== 'embedded')
 
   return html`
-    <div class="bb b--black-20 mt1 pb2">
+    <div class='pv1'>
       ${navItem({
         text: browser.i18n.getMessage('panelCopy_currentIpfsAddress'),
         onClick: onCopyIpfsAddr

--- a/add-on/src/popup/browser-action/operations.js
+++ b/add-on/src/popup/browser-action/operations.js
@@ -15,7 +15,7 @@ module.exports = function operations ({
   onToggleRedirect
 }) {
   return html`
-    <div class="bb b--black-20 mv2 pb2">
+    <div class="pv1">
       ${isIpfsOnline ? (
         navItem({
           text: browser.i18n.getMessage('panel_quickUpload'),

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -30,8 +30,12 @@ module.exports = function browserActionPage (state, emit) {
   return html`
     <div class="helvetica">
       ${header(headerProps)}
-      ${contextActions(contextActionsProps)}
-      ${operations(opsProps)}
+      <div class="bb b--black-20">
+        ${contextActions(contextActionsProps)}
+      </div>
+      <div class="bb b--black-20">
+        ${operations(opsProps)}
+      </div>
       ${gatewayStatus(gwStatusProps)}
     </div>
   `

--- a/add-on/src/popup/page-action/header.js
+++ b/add-on/src/popup/page-action/header.js
@@ -7,15 +7,15 @@ const logo = require('../logo')
 module.exports = function header ({ isIpfsContext, pageActionTitle }) {
   if (!isIpfsContext) return null
   return html`
-    <div class="ph2 pv1 br2 br--top bg-light-gray">
-      <h2 class="f6 mv2 tl fw1">
+    <div class="ph2 br2 br--top bg-light-gray bb b--black-20">
+      <h2 class="ma0 pt1 pb2 pl2 tl">
         ${logo({
-          size: 19,
+          size: 20,
           path: '../../../icons',
           ipfsNodeType: 'external',
           isIpfsOnline: true,
           heartbeat: false
-        })} <span class="pl1">${pageActionTitle || browser.i18n.getMessage('pageAction_statusPlaceholder')}</span>
+        })} <span class="pl1 f6 fw4 v-mid">${pageActionTitle || browser.i18n.getMessage('pageAction_statusPlaceholder')}</span>
       </h2>
     </div>
   `

--- a/add-on/src/popup/page-action/index.html
+++ b/add-on/src/popup/page-action/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../browser-action/browser-action.css">
     <script src="../../ipfs-companion-common.js"></script>
   </head>
-  <body style="width: 320px; overflow: hidden; background: white;">
+  <body style="width: 330px; overflow: hidden; background: white;">
     <div id="root"></div>
     <script src="page-action.js"></script>
   </body>


### PR DESCRIPTION
Fixes the minor style snags raised by @alanshaw in irc

<img width=359 src="https://usercontent.irccloud-cdn.com/file/StPZHv7O/Screen%20Shot%202018-03-15%20at%2013.21.52.png" />

> font is super light for me & seems to be a double border at the bottom?

---

With this changeset the page action menu now looks like this:

<img width="1100" alt="screenshot 2018-03-16 17 20 16" src="https://user-images.githubusercontent.com/58871/37535405-8b2f84f0-293f-11e8-8cf4-545bcb2a7465.png">

Pulls the border styling out from the menu option sections to the page layout level, to make the components easier to reuse / assume less about context.