### PR TITLE
fix: proxy access dialog display issue on Firefox

### DIFF
--- a/add-on/src/lib/ipfs-proxy/request-access.js
+++ b/add-on/src/lib/ipfs-proxy/request-access.js
@@ -12,7 +12,8 @@ function createRequestAccess (browser, screen) {
     const url = browser.extension.getURL(opts.dialogPath || DIALOG_PATH)
 
     let dialogTabId
-    if (browser && browser.windows && browser.windows.create) {
+
+    if (browser.windows && browser.windows.create) {
       // display modal dialog in a centered popup window
       const currentWin = await browser.windows.getCurrent()
       const width = opts.dialogWidth || DIALOG_WIDTH
@@ -22,10 +23,6 @@ function createRequestAccess (browser, screen) {
 
       const dialogWindow = await browser.windows.create({ url, width, height, top, left, type: 'popup' })
       dialogTabId = dialogWindow.tabs[0].id
-      // Fix for Fx57 bug where bundled page loaded using
-      // browser.windows.create won't show contents unless resized.
-      // See https://bugzilla.mozilla.org/show_bug.cgi?id=1402110
-      await browser.windows.update(dialogWindow.id, {width: dialogWindow.width + 1})
     } else {
       // fallback: opening dialog as a new active tab
       // (runtimes without browser.windows.create, eg. Andorid)

--- a/add-on/src/pages/proxy-access-dialog/index.js
+++ b/add-on/src/pages/proxy-access-dialog/index.js
@@ -10,3 +10,9 @@ const app = choo()
 app.use(createProxyAccessDialogStore(browser.i18n, browser.runtime))
 app.route('*', createProxyAccessDialogPage(browser.i18n))
 app.mount('#root')
+
+// Fix for Fx57 bug where bundled page loaded using
+// browser.windows.create won't show contents unless resized.
+// See https://bugzilla.mozilla.org/show_bug.cgi?id=1402110
+browser.windows.getCurrent()
+  .then(win => browser.windows.update(win.id, { width: win.width + 1 }))


### PR DESCRIPTION
I noticed this was still happening despite the previous "fix". I move the code for the fix into the page JS and it worked.