### PR TITLE
Decouple Page Action Updates

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -87,10 +87,6 @@
     "message": "Non-IPFS resource",
     "description": "Default label for icon hidden in Page Action menu (pageAction_titleNonIpfs)"
   },
-  "pageAction_statusPlaceholder": {
-    "message": "(checking status...)",
-    "description": "Placeholder label for status header in Page Action menu (pageAction_statusPlaceholder)"
-  },
   "contextMenu_uploadToIpfs": {
     "message": "Upload to IPFS",
     "description": "An item in right-click context menu (contextMenu_uploadToIpfs)"

--- a/add-on/src/popup/browser-action/browser-action.css
+++ b/add-on/src/popup/browser-action/browser-action.css
@@ -9,3 +9,11 @@
 .outline-0--focus:focus {
   outline: 0;
 }
+
+.fade-in {
+  animation: fade-in 800ms;
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}

--- a/add-on/src/popup/browser-action/browser-action.css
+++ b/add-on/src/popup/browser-action/browser-action.css
@@ -11,7 +11,7 @@
 }
 
 .fade-in {
-  animation: fade-in 800ms;
+  animation: fade-in 600ms;
 }
 @keyframes fade-in {
   from { opacity: 0; }

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -21,7 +21,7 @@ module.exports = function contextActions ({
   const isPinningSupported = (ipfsNodeType !== 'embedded')
 
   return html`
-    <div class='pv1'>
+    <div class='fade-in pv1'>
       ${navItem({
         text: browser.i18n.getMessage('panelCopy_currentIpfsAddress'),
         onClick: onCopyIpfsAddr

--- a/add-on/src/popup/browser-action/gateway-status.js
+++ b/add-on/src/popup/browser-action/gateway-status.js
@@ -16,7 +16,7 @@ module.exports = function gatewayStatus ({
 }) {
   const api = ipfsNodeType === 'embedded' ? 'js-ipfs' : ipfsApiUrl
   return html`
-    <ul class="list mv3 ph3 bg-white black">
+    <ul class="fade-in list mv3 ph3 bg-white black">
       <li class="flex mb2">
         <span class="w-40 f7 ttu">${browser.i18n.getMessage('panel_statusGatewayAddress')}</span>
         <code class="w-60 f7 tr">${gatewayAddress == null ? 'unknown' : gatewayAddress}</code>

--- a/add-on/src/popup/browser-action/header.js
+++ b/add-on/src/popup/browser-action/header.js
@@ -9,7 +9,7 @@ const isJsIpfsEnabled = require('../../lib/is-js-ipfs-enabled')()
 module.exports = function header ({ ipfsNodeType, onToggleNodeType, isIpfsOnline }) {
   return html`
     <div class="pv3 br2 br--top ba bw1 b--white" style="background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%,#043b55 100%); background-size: auto 100%">
-      <div class="tc mb2" title="${isIpfsOnline ? '' : 'offline'}">
+      <div class="fade-in tc mb2" title="${isIpfsOnline ? '' : 'offline'}">
         ${logo({
           size: 52,
           path: '../../../icons',

--- a/add-on/src/popup/browser-action/operations.js
+++ b/add-on/src/popup/browser-action/operations.js
@@ -15,7 +15,7 @@ module.exports = function operations ({
   onToggleRedirect
 }) {
   return html`
-    <div class="pv1">
+    <div class="fade-in pv1">
       ${isIpfsOnline ? (
         navItem({
           text: browser.i18n.getMessage('panel_quickUpload'),

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -33,10 +33,16 @@ module.exports = (state, emitter) => {
     port = browser.runtime.connect({name: 'browser-action-port'})
     port.onMessage.addListener(async (message) => {
       if (message.statusUpdate) {
+        let status = message.statusUpdate
         console.log('In browser action, received message from background:', message)
-        await updateBrowserActionState(message.statusUpdate)
-        // another redraw after laggy state update finished
+        await updateBrowserActionState(status)
         emitter.emit('render')
+        if (status.ipfsPageActionsContext) {
+          // calculating pageActions states is expensive (especially pin-related checks)
+          // we update them in separate step to keep UI snappy
+          await updatePageActionsState(status)
+          emitter.emit('render')
+        }
       }
     })
   })
@@ -56,9 +62,9 @@ module.exports = (state, emitter) => {
     emitter.emit('render')
 
     try {
-      const { ipfsCompanion } = await getBackgroundPage()
-      const currentPath = await resolveToIPFS(new URL(state.currentTab.url).pathname)
-      const pinResult = await ipfsCompanion.ipfs.pin.add(currentPath, { recursive: true })
+      const ipfs = await getIpfsApi()
+      const currentPath = await resolveToIPFS(ipfs, new URL(state.currentTab.url).pathname)
+      const pinResult = await ipfs.pin.add(currentPath, { recursive: true })
       console.log('ipfs.pin.add result', pinResult)
       state.isPinned = true
       notify('notify_pinnedIpfsResourceTitle', currentPath)
@@ -75,9 +81,9 @@ module.exports = (state, emitter) => {
     emitter.emit('render')
 
     try {
-      const { ipfsCompanion } = await getBackgroundPage()
-      const currentPath = await resolveToIPFS(new URL(state.currentTab.url).pathname)
-      const result = await ipfsCompanion.ipfs.pin.rm(currentPath, {recursive: true})
+      const ipfs = await getIpfsApi()
+      const currentPath = await resolveToIPFS(ipfs, new URL(state.currentTab.url).pathname)
+      const result = await ipfs.pin.rm(currentPath, {recursive: true})
       state.isPinned = false
       console.log('ipfs.pin.rm result', result)
       notify('notify_unpinnedIpfsResourceTitle', currentPath)
@@ -154,23 +160,21 @@ module.exports = (state, emitter) => {
   })
 
   async function updatePageActionsState (status) {
-    // IPFS contexts require access to background page
-    // which is denied in Private Browsing mode
-    const bg = await getBackgroundPage()
+    // IPFS contexts require access to ipfs API object from background page
+    // Note: access to background page is denied in Private Browsing mode
+    const ipfs = await getIpfsApi()
 
     // Check if current page is an IPFS one
-    const ipfsContext = bg && status && status.ipfsPageActionsContext
-
-    state.isIpfsContext = !!ipfsContext
+    state.isIpfsContext = !!(ipfs && status && status.ipfsPageActionsContext)
     state.currentTab = status.currentTab || null
 
     if (state.isIpfsContext) {
       // There is no point in displaying actions that require API interaction if API is down
       const apiIsUp = status && status.peerCount >= 0
-      if (apiIsUp) await updatePinnedState(status)
-      if (state.currentTab && browser.pageAction) {
+      if (apiIsUp) await updatePinnedState(ipfs, status)
+      if (browser.pageAction && state.currentTab) {
         // Get title stored on page load so that valid transport is displayed
-        // even if user toggles between public/custom gateway
+        // even if user toggles between public/custom gateway after the load
         state.pageActionTitle = await browser.pageAction.getTitle({tabId: state.currentTab.id})
       }
     }
@@ -190,7 +194,6 @@ module.exports = (state, emitter) => {
       state.swarmPeers = status.peerCount === -1 ? 0 : status.peerCount
       state.isIpfsOnline = status.peerCount > -1
       state.gatewayVersion = status.gatewayVersion ? status.gatewayVersion : null
-      await updatePageActionsState(status) // state.isIpfsContext
     } else {
       state.ipfsNodeType = 'external'
       state.swarmPeers = null
@@ -200,11 +203,10 @@ module.exports = (state, emitter) => {
     }
   }
 
-  async function updatePinnedState (status) {
+  async function updatePinnedState (ipfs, status) {
     try {
-      const { ipfsCompanion } = await getBackgroundPage()
-      const currentPath = await resolveToIPFS(new URL(status.currentTab.url).pathname)
-      const response = await ipfsCompanion.ipfs.pin.ls(currentPath, {quiet: true})
+      const currentPath = await resolveToIPFS(ipfs, new URL(status.currentTab.url).pathname)
+      const response = await ipfs.pin.ls(currentPath, {quiet: true})
       console.log(`positive ipfs.pin.ls for ${currentPath}: ${JSON.stringify(response)}`)
       state.isPinned = true
     } catch (error) {
@@ -227,11 +229,15 @@ function getBackgroundPage () {
   return browser.runtime.getBackgroundPage()
 }
 
-async function resolveToIPFS (path) {
+async function getIpfsApi () {
+  const bg = await getBackgroundPage()
+  return (bg && bg.ipfsCompanion) ? bg.ipfsCompanion.ipfs : null
+}
+
+async function resolveToIPFS (ipfs, path) {
   path = safeIpfsPath(path) // https://github.com/ipfs/ipfs-companion/issues/303
   if (/^\/ipns/.test(path)) {
-    const { ipfsCompanion } = await getBackgroundPage()
-    const response = await ipfsCompanion.ipfs.name.resolve(path, {recursive: true, nocache: false})
+    const response = await ipfs.name.resolve(path, {recursive: true, nocache: false})
     return response.Path
   }
   return path

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -204,6 +204,8 @@ module.exports = (state, emitter) => {
   }
 
   async function updatePinnedState (ipfs, status) {
+    // skip update if there is an ongoing pin or unpin
+    if (state.isPinning || state.isUnPinning) return
     try {
       const currentPath = await resolveToIPFS(ipfs, new URL(status.currentTab.url).pathname)
       const response = await ipfs.pin.ls(currentPath, {quiet: true})

--- a/add-on/src/popup/page-action/header.js
+++ b/add-on/src/popup/page-action/header.js
@@ -7,15 +7,15 @@ const logo = require('../logo')
 module.exports = function header ({ isIpfsContext, pageActionTitle }) {
   if (!isIpfsContext) return null
   return html`
-    <div class="ph2 br2 br--top bg-light-gray bb b--black-20">
-      <h2 class="fade-in ma0 pt1 pb2 pl2 tl">
+    <div class="fade-in ph2 br2 br--top bg-light-gray bb b--black-20">
+      <h2 class="ma0 pt1 pb2 pl2 tl">
         ${logo({
           size: 20,
           path: '../../../icons',
           ipfsNodeType: 'external',
           isIpfsOnline: true,
           heartbeat: false
-        })} <span class="pl1 f6 fw4 v-mid">${pageActionTitle || browser.i18n.getMessage('pageAction_statusPlaceholder')}</span>
+        })} <span class="pl1 f6 fw4 v-mid">${pageActionTitle || '…'}</span>
       </h2>
     </div>
   `

--- a/add-on/src/popup/page-action/header.js
+++ b/add-on/src/popup/page-action/header.js
@@ -8,7 +8,7 @@ module.exports = function header ({ isIpfsContext, pageActionTitle }) {
   if (!isIpfsContext) return null
   return html`
     <div class="ph2 br2 br--top bg-light-gray bb b--black-20">
-      <h2 class="ma0 pt1 pb2 pl2 tl">
+      <h2 class="fade-in ma0 pt1 pb2 pl2 tl">
         ${logo({
           size: 20,
           path: '../../../icons',


### PR DESCRIPTION
This PR aim to address the fact calculating pageActions for IPFS Paths is expensive (especially pin-related checks when pin is in progress).

- fixes and closes  #426 
  - calculating pageActions states is expensive (especially pin-related checks when pin is in progress)
    - pageActions are updated in a separate step to keep UI snappy
- experiment: add 800ms fade-in for dynamically added UI elements
  - it may be subjective, but it eased the feel of 'erratic updates' a bit
    - people do not focus on updates happening during fade-in 
  - we can revert this change later, or replace basic fade-in with better animation
  - demo (gif may render slower than realtime, but gives a good idea what is happening): 
    > ![peek 2018-03-21 13-52](https://user-images.githubusercontent.com/157609/37710819-1d8e108c-2d0f-11e8-9f83-341c1f2d3934.gif)

