### PR TITLE
Fix options_ui in OSX Chrome

### DIFF
--- a/add-on/src/options/options.css
+++ b/add-on/src/options/options.css
@@ -1,3 +1,9 @@
+html {
+  /* allocate proper width in Chrome */
+  min-width: 650px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
 form * {
   font: caption;
   font-size: 1em;
@@ -45,10 +51,10 @@ label > dl > dd {
   margin-left: 0;
   margin-right: .2em;
 }
-div:hover {
+fieldset > div:hover {
   background-color: rgba(62, 148, 152, 0.05);
 }
-div:hover > label > dl > dd {
+fieldset > div:hover > label > dl > dd {
   color: #333;
 }
 input, select {

--- a/add-on/src/options/options.css
+++ b/add-on/src/options/options.css
@@ -1,8 +1,14 @@
-html {
-  /* allocate proper width in Chrome */
+html.is-chrome {
+  overflow: hidden;
+}
+.is-chrome body {
   min-width: 650px;
-  overflow-x: hidden;
+  height: 450px;
+  padding: 15px;
   overflow-y: auto;
+}
+body {
+  margin: 0;
 }
 form * {
   font: caption;

--- a/add-on/src/options/options.css
+++ b/add-on/src/options/options.css
@@ -2,13 +2,11 @@ html.is-chrome {
   overflow: hidden;
 }
 .is-chrome body {
+  margin: 0;
   min-width: 650px;
   height: 450px;
   padding: 15px;
   overflow-y: auto;
-}
-body {
-  margin: 0;
 }
 form * {
   font: caption;

--- a/add-on/src/options/options.js
+++ b/add-on/src/options/options.js
@@ -16,6 +16,7 @@ app.route('*', optionsPage)
 // Start the application and render it to the given querySelector
 app.mount('#root')
 
+// Fix for Chrome in OSX https://github.com/ipfs-shipyard/ipfs-companion/pull/429
 if (window.navigator.vendor === 'Google Inc.') {
   document.querySelector('html').className = 'is-chrome'
 }

--- a/add-on/src/options/options.js
+++ b/add-on/src/options/options.js
@@ -15,3 +15,7 @@ app.route('*', optionsPage)
 
 // Start the application and render it to the given querySelector
 app.mount('#root')
+
+if (window.navigator.vendor === 'Google Inc.') {
+  document.querySelector('html').className = 'is-chrome'
+}


### PR DESCRIPTION
This PR aims to fix UI bug reported by @alanshaw:

<img width="1286" alt="screen shot 2018-03-21 at 11 33 10" src="https://user-images.githubusercontent.com/157609/37717971-f453990e-2d21-11e8-8eb0-9dc70bbdc25f.png">

## Notes on `options_ui` in Chrome
- fix is to either specify `min-width` and `overflow` controls, or explicitly open `options_ui` page in a new tab
  - `open_in_tab` is [being deprecated](https://developer.chrome.com/extensions/optionsV2#step-1), so we would have to do it manually
    > ![screenshot-2018-3-21 options - google chrome](https://user-images.githubusercontent.com/157609/37718168-63be4e38-2d22-11e8-82bb-be836cf23cf0.png)
