### PR TITLE
fix: object count

### DIFF
--- a/add-on/_locales/de_DE/messages.json
+++ b/add-on/_locales/de_DE/messages.json
@@ -309,18 +309,6 @@
     "message": "Browser-Erweiterung, die den Zugriff auf IPFS-Ressourcen vereinfacht",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Verbunden mit $PEERCOUNT$ Peers und $FILESCOUNT$ Dateien freigegeben",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Verbunden mit $PEERCOUNT$ Peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -341,18 +341,6 @@
     "message": "Browser extension that simplifies access to IPFS resources",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connected to $PEERCOUNT$ peers and sharing $FILESCOUNT$ files",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connected to $PEERCOUNT$ peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/es_ES/messages.json
+++ b/add-on/_locales/es_ES/messages.json
@@ -309,18 +309,6 @@
     "message": "Extensión del navegador que simplifica el acceso a los recursos de IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Conectado a los puertos $PEERCOUNT$ y compartiendo archivos $FILESCOUNT$",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Conectado $PEERCOUNT$ a los puertos",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/fr_FR/messages.json
+++ b/add-on/_locales/fr_FR/messages.json
@@ -309,18 +309,6 @@
     "message": "Extension de navigateur qui simplifie l’accès aux ressources de IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connecté à $PEERCOUNT$ paires et partages $FILESCOUNT$ fichiers",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connecté à $PEERCOUNT$ paires",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/id_AC/messages.json
+++ b/add-on/_locales/id_AC/messages.json
@@ -309,18 +309,6 @@
     "message": "Ekstensi peramban nyang meunyederhanakan akses u sumber daya IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Meuhubong u rekan-rekan $PEERCOUNT$ dan berbagi file $FILESCOUNT$",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Meuhubong u rekan-rekan $PEERCOUNT$",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/id_ID/messages.json
+++ b/add-on/_locales/id_ID/messages.json
@@ -309,18 +309,6 @@
     "message": "Ekstensi peramban yang menyederhanakan akses ke sumber daya IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Terhubung ke rekan-rekan $PEERCOUNT$ dan berbagi file $FILESCOUNT$",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Terhubung ke rekan-rekan $PEERCOUNT$",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/it_IT/messages.json
+++ b/add-on/_locales/it_IT/messages.json
@@ -309,18 +309,6 @@
     "message": "Estensione per il browser che semplifica l'accesso alle risorse IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connected to $PEERCOUNT$ peers and sharing $FILESCOUNT$ files",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connected to $PEERCOUNT$ peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/pl_PL/messages.json
+++ b/add-on/_locales/pl_PL/messages.json
@@ -309,18 +309,6 @@
     "message": "Rozszerzenie przeglądarki ułatwiające dostęp do zasobów IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Połączono z $PEERCOUNT$ węzłami, udostępniając $FILESCOUNT$ plików",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Połączono z $PEERCOUNT$ węzłami",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/ro_RO/messages.json
+++ b/add-on/_locales/ro_RO/messages.json
@@ -309,18 +309,6 @@
     "message": "Extensie a browserului care simplifică accesul la resursele IPFS",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connected to $PEERCOUNT$ peers and sharing $FILESCOUNT$ files",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connected to $PEERCOUNT$ peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/ru_RU/messages.json
+++ b/add-on/_locales/ru_RU/messages.json
@@ -309,18 +309,6 @@
     "message": "Browser extension that simplifies access to IPFS resources",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connected to $PEERCOUNT$ peers and sharing $FILESCOUNT$ files",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connected to $PEERCOUNT$ peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/sv_SE/messages.json
+++ b/add-on/_locales/sv_SE/messages.json
@@ -309,18 +309,6 @@
     "message": "Browser extension that simplifies access to IPFS resources",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connected to $PEERCOUNT$ peers and sharing $FILESCOUNT$ files",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connected to $PEERCOUNT$ peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/_locales/zh_CN/messages.json
+++ b/add-on/_locales/zh_CN/messages.json
@@ -309,18 +309,6 @@
     "message": "简化IPFS资源访问的浏览器扩展",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
-  "quickUpload_subhead_peers_and_files": {
-    "message": "Connected to $PEERCOUNT$ peers and sharing $FILESCOUNT$ files",
-    "description": "Info stats beneath the header on the share files page (quickUpload_subhead_peers_and_files)",
-    "placeholders": {
-      "peerCount": {
-        "content": "$1"
-      },
-      "filesCount": {
-        "content": "$2"
-      }
-    }
-  },
   "quickUpload_subhead_peers": {
     "message": "Connected to $PEERCOUNT$ peers",
     "description": "Partial info stats beneath the header on the share files page (quickUpload_subhead_peers)",

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -169,11 +169,6 @@ module.exports = async function init () {
     const info = {
       ipfsNodeType: state.ipfsNodeType,
       peerCount: state.peerCount,
-      // Convert big.js numbers into strings before sending.
-      // Chrome uses JSON.stringify to send objects over port.postMessage whereas
-      // Firefox uses structured clone. It means that on the other side FF gets
-      // a weird object (not a big.js number object) unless we stringify first.
-      repoStats: JSON.parse(JSON.stringify(state.repoStats)),
       gwURLString: state.gwURLString,
       pubGwURLString: state.pubGwURLString,
       currentTab: await browser.tabs.query({active: true, currentWindow: true}).then(tabs => tabs[0])
@@ -383,8 +378,6 @@ module.exports = async function init () {
     let oldPeerCount = state.peerCount
     state.peerCount = await getSwarmPeerCount()
     updatePeerCountDependentStates(oldPeerCount, state.peerCount)
-    // update repo stats
-    state.repoStats = await getRepoStats()
     // trigger pending updates
     await sendStatusUpdateToBrowserAction()
   }
@@ -403,17 +396,6 @@ module.exports = async function init () {
     } catch (error) {
       console.error(`Error while ipfs.swarm.peers: ${error}`)
       return offlinePeerCount
-    }
-  }
-
-  async function getRepoStats () {
-    if (!ipfs || !ipfs.stats || !ipfs.stats.repo) return {}
-    try {
-      const repoStats = await ipfs.stats.repo()
-      return repoStats
-    } catch (error) {
-      console.error(`Error while ipfs.stats.repo: ${error}`)
-      return {}
     }
   }
 

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -15,13 +15,11 @@ app.mount('#root')
 function quickUploadStore (state, emitter) {
   state.message = ''
   state.peerCount = ''
-  state.filesCount = ''
   state.ipfsNodeType = 'external'
 
-  function updateState ({ipfsNodeType, peerCount, repoStats = {}}) {
+  function updateState ({ipfsNodeType, peerCount}) {
     state.ipfsNodeType = ipfsNodeType
     state.peerCount = peerCount
-    state.filesCount = repoStats.numObjects || ''
   }
 
   let port
@@ -66,14 +64,8 @@ function quickUploadStore (state, emitter) {
 
 function quickUploadPage (state, emit) {
   const onFileInputChange = (e) => emit('fileInputChange', e)
-  const {filesCount, peerCount} = state
-  let subhead = ''
-  if (filesCount && peerCount) {
-    subhead = browser.i18n.getMessage('quickUpload_subhead_peers_and_files', [peerCount, filesCount])
-  }
-  if (!filesCount && peerCount) {
-    subhead = browser.i18n.getMessage('quickUpload_subhead_peers', [peerCount])
-  }
+  const {peerCount} = state
+
   return html`
     <div class="avenir pt5" style="background: linear-gradient(to top, #041727 0%,#043b55 100%); height:100%;">
       <div class="mw8 center pa3 white">
@@ -88,7 +80,7 @@ function quickUploadPage (state, emit) {
               ${browser.i18n.getMessage('panel_quickUpload')}
             </h1>
             <p class="f3 fw2 lh-copy ma0 light-gray">
-              ${subhead}
+              ${browser.i18n.getMessage('quickUpload_subhead_peers', [peerCount])}
             </p>
           </div>
         </header>

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -16,15 +16,12 @@ function quickUploadStore (state, emitter) {
   state.message = ''
   state.peerCount = ''
   state.filesCount = ''
-  state.repoSize = ''
   state.ipfsNodeType = 'external'
 
   function updateState ({ipfsNodeType, peerCount, repoStats = {}}) {
     state.ipfsNodeType = ipfsNodeType
     state.peerCount = peerCount
-    state.filesCount = repoStats.NumObjects || ''
-    const repoSizeInMB = ((repoStats.RepoSize || 0) / 1000000)
-    state.repoSize = `${repoSizeInMB}MB`
+    state.filesCount = repoStats.numObjects || ''
   }
 
   let port


### PR DESCRIPTION
* Is now camel case: `NumObjects` -> `numObjects`
* Means that quick upload page now shows "and sharing 9497 files" again
* Removes `state.repoSize` as it's unused