### PR TITLE
fix: response for multiple acl dialogs get mixed up

### DIFF
--- a/add-on/src/lib/ipfs-proxy/request-access.js
+++ b/add-on/src/lib/ipfs-proxy/request-access.js
@@ -58,6 +58,7 @@ function createRequestAccess (browser, screen) {
     const userResponse = new Promise((resolve, reject) => {
       onPortConnect = port => {
         if (port.name !== dialogPortName) return
+        if (!port.sender || !port.sender.tab || port.sender.tab.id !== tabId) return
 
         browser.runtime.onConnect.removeListener(onPortConnect)
 
@@ -88,7 +89,10 @@ function createRequestAccess (browser, screen) {
     let onTabRemoved
 
     const userTabRemoved = new Promise((resolve, reject) => {
-      onTabRemoved = () => reject(new Error(`Failed to obtain access response for ${permission} at ${scope}`))
+      onTabRemoved = (id) => {
+        if (id !== tabId) return
+        reject(new Error(`Failed to obtain access response for ${permission} at ${scope}`))
+      }
       browser.tabs.onRemoved.addListener(onTabRemoved)
     })
 


### PR DESCRIPTION
This is a fix for the issue reported here: https://github.com/ipfs-shipyard/ipfs-companion/pull/442#pullrequestreview-110017486

This PR adds checks to the port connect and tab removed listeners to ensure that the tab that is connecting or being closed is the tab that they are in charge of!

To test:

```js
Promise.all([ipfs.id(), ipfs.files.ls(), ipfs.id(), ipfs.files.ls(), ipfs.files.ls()]).then(console.log).catch(console.log)
```

Expect 5 dialogs to open*, you should be able to respond to each one individually.

\* fix for multiple dialogs for the same permission is coming soon in #442