### PR TITLE
Post release chores

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ _(some are disabled by default, use Preferences screen to enable)_
 
 We recommend installing the stable release via your browser's add-on store.
 
-| Firefox | Chrome / Chromium |
-|---------|-------------------|
-| [![Get the add-on](https://blog.mozilla.org/addons/files/2015/11/AMO-button_1.png)](https://addons.mozilla.org/en-US/firefox/addon/ipfs-companion/) | [![](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch) |
+| Firefox                                                                                                                                                    | Chrome / Chromium                                                                                                                                                                              |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [![Install From AMO](https://ipfs.io/ipfs/QmSX44XockQifmxE8Wdevkaa6vaqTXtGdH9t9aHWXZkuJq)](https://addons.mozilla.org/en-US/firefox/addon/ipfs-companion/) | [![Install from Chrome Store](https://ipfs.io/ipfs/QmPinSJKFYCMuTDh484dLk5Av4HpZRzBRR1KPv7TM7CBVF)](https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch) |
 
 **Note:** `ipfs-companion` is designed to retrieve content from a locally running IPFS daemon.  
 Make sure [IPFS is installed](https://ipfs.io/docs/getting-started/) on your computer.

--- a/add-on/manifest.common.json
+++ b/add-on/manifest.common.json
@@ -2,10 +2,10 @@
   "manifest_version": 2,
   "name": "__MSG_manifest_extensionName__",
   "short_name": "__MSG_manifest_shortExtensionName__",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "__MSG_manifest_extensionDescription__",
-  "homepage_url": "https://github.com/ipfs/ipfs-companion",
-  "author": "Marcin Rataj",
+  "homepage_url": "https://github.com/ipfs-shipyard/ipfs-companion",
+  "author": "IPFS Community",
   "icons": {
     "19": "icons/png/ipfs-logo-on_19.png",
     "38": "icons/png/ipfs-logo-on_38.png",


### PR DESCRIPTION
- move badge hosting to IPFS
- version bump to v2.2.1 (so that dev builds are in front of stable channel)
- updated author in manifest.  `about:addons` now looks like this:
   >  ![screenshot_16](https://user-images.githubusercontent.com/157609/38563126-6bf123a4-3cdc-11e8-94bd-b521a04c1c4c.png)

