### PR TITLE
fix: updates ipfs-postmsg-proxy to version 2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ipfs": "0.28.2",
     "ipfs-api": "18.2.0",
     "ipfs-css": "0.2.0",
-    "ipfs-postmsg-proxy": "2.13.1",
+    "ipfs-postmsg-proxy": "2.14.0",
     "is-ipfs": "0.3.2",
     "is-svg": "3.0.0",
     "lru_map": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,7 +1179,7 @@ buffer-indexof@~0.0.0:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-0.0.2.tgz#ed0f36b7ae166a66a7cd174c0467ae8dedf008f5"
 
-buffer-loader@0.0.1:
+buffer-loader@0.0.1, buffer-loader@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-loader/-/buffer-loader-0.0.1.tgz#4d677ca92dd889310878b02a2fbcfab712024cf2"
 
@@ -4133,7 +4133,14 @@ ipfs-block-service@~0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/ipfs-block-service/-/ipfs-block-service-0.13.0.tgz#4d827863c59f34f9e44deb92dea9a5b1a9fcb093"
 
-ipfs-block@^0.6.1, ipfs-block@~0.6.1:
+ipfs-block@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ipfs-block/-/ipfs-block-0.7.1.tgz#f506d6159219e19690d3ab863c039cba293d1e40"
+  dependencies:
+    cids "^0.5.3"
+    class-is "^1.1.0"
+
+ipfs-block@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/ipfs-block/-/ipfs-block-0.6.1.tgz#b93053e9ea95f75ed2907817ffbf55d992a06ad1"
   dependencies:
@@ -4150,15 +4157,15 @@ ipfs-multipart@~0.1.0:
     content "^3.0.0"
     dicer "^0.2.5"
 
-ipfs-postmsg-proxy@2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.13.1.tgz#9fe5d3c6fea0148323a5c0b3aaf5874e02ddf406"
+ipfs-postmsg-proxy@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.14.0.tgz#38526e9808cb5c30f22e02a64e96682d9851fa35"
   dependencies:
     big.js "^5.0.3"
     callbackify "^1.1.0"
     cids "^0.5.3"
-    ipfs-block "^0.6.1"
-    ipld-dag-pb "^0.13.1"
+    ipfs-block "^0.7.1"
+    ipld-dag-pb "^0.14.1"
     is-pull-stream "0.0.0"
     is-stream "^1.1.0"
     multiaddr "^4.0.0"
@@ -4342,9 +4349,26 @@ ipld-dag-cbor@~0.12.0:
     multihashing-async "~0.4.7"
     traverse "^0.6.6"
 
-ipld-dag-pb@^0.13.1, ipld-dag-pb@~0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz#4c879ae11ef602db857d71e954fda18fd3d6ae2a"
+ipld-dag-pb@^0.14.1:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.14.2.tgz#a2bd007a7420836d3a431a2a4af0e6688b583de8"
+  dependencies:
+    async "^2.6.0"
+    bs58 "^4.0.1"
+    buffer-loader "~0.0.1"
+    cids "~0.5.3"
+    class-is "^1.1.0"
+    is-ipfs "~0.3.2"
+    multihashes "~0.4.13"
+    multihashing-async "~0.4.8"
+    protons "^1.0.1"
+    pull-stream "^3.6.7"
+    pull-traverse "^1.0.3"
+    stable "~0.1.6"
+
+ipld-dag-pb@~0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.13.0.tgz#62092b9cb0a3970b8d8466ca1f3d3a3f5fb64622"
   dependencies:
     async "^2.6.0"
     bs58 "^4.0.1"
@@ -4359,9 +4383,9 @@ ipld-dag-pb@^0.13.1, ipld-dag-pb@~0.13.1:
     pull-traverse "^1.0.3"
     stable "^0.1.6"
 
-ipld-dag-pb@~0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.13.0.tgz#62092b9cb0a3970b8d8466ca1f3d3a3f5fb64622"
+ipld-dag-pb@~0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz#4c879ae11ef602db857d71e954fda18fd3d6ae2a"
   dependencies:
     async "^2.6.0"
     bs58 "^4.0.1"
@@ -8681,7 +8705,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-stable@^0.1.6:
+stable@^0.1.6, stable@~0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
 


### PR DESCRIPTION
This fixes a problem with the DAG node/link and Block dependencies not yet having a `isDAGNode` etc. function.