### PR TITLE
fix: window.ipfs streaming

### DIFF
--- a/add-on/src/contentScripts/ipfs-proxy/content.js
+++ b/add-on/src/contentScripts/ipfs-proxy/content.js
@@ -8,10 +8,14 @@ function init () {
   const port = browser.runtime.connect({ name: 'ipfs-proxy' })
 
   // Forward on messages from background to the page and vice versa
-  port.onMessage.addListener((data) => window.postMessage(data, '*'))
+  port.onMessage.addListener((data) => {
+    if (data && data.sender && data.sender.startsWith('postmsg-rpc/')) {
+      window.postMessage(data, '*')
+    }
+  })
 
   window.addEventListener('message', (msg) => {
-    if (msg.data && msg.data.sender === 'postmsg-rpc/client') {
+    if (msg.data && msg.data.sender && msg.data.sender.startsWith('postmsg-rpc/')) {
       port.postMessage(msg.data)
     }
   })

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ipfs": "0.28.2",
     "ipfs-api": "18.2.0",
     "ipfs-css": "0.3.0",
-    "ipfs-postmsg-proxy": "2.15.0",
+    "ipfs-postmsg-proxy": "2.16.0",
     "is-ipfs": "0.3.2",
     "is-svg": "3.0.0",
     "lru_map": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4259,9 +4259,9 @@ ipfs-multipart@~0.1.0:
     content "^3.0.0"
     dicer "^0.2.5"
 
-ipfs-postmsg-proxy@2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.15.0.tgz#689d0bcd90e88d792bac50dfc4f8df85b6ba5f26"
+ipfs-postmsg-proxy@2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/ipfs-postmsg-proxy/-/ipfs-postmsg-proxy-2.16.0.tgz#ce5506bcb5876f383f746dfd3165eba5b598f23c"
   dependencies:
     big.js "^5.0.3"
     callbackify "^1.1.0"
@@ -4277,7 +4277,7 @@ ipfs-postmsg-proxy@2.15.0:
     prepost "^1.1.0"
     pull-abortable "^4.1.1"
     pull-defer "^0.2.2"
-    pull-postmsg-stream "^1.1.3"
+    pull-postmsg-stream "^1.2.0"
     pull-stream "^3.6.7"
     pull-stream-to-stream "^1.3.4"
     shortid "^2.2.8"
@@ -7429,12 +7429,6 @@ postcss@6.0.19:
     source-map "^0.6.1"
     supports-color "^5.2.0"
 
-postmsg-rpc@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/postmsg-rpc/-/postmsg-rpc-2.3.0.tgz#b355afabff1371457af831fe439dd84804229392"
-  dependencies:
-    shortid "^2.2.8"
-
 postmsg-rpc@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/postmsg-rpc/-/postmsg-rpc-2.4.0.tgz#4e2daf6851852364696debd5d6bf6936d1424cdf"
@@ -7468,10 +7462,6 @@ prelude-ls@~1.1.2:
 prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
-
-prepost@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/prepost/-/prepost-1.0.1.tgz#62c55d1ced516127e40ce2e3d8fc1a390cd86c7b"
 
 prepost@^1.1.0:
   version "1.1.0"
@@ -7683,12 +7673,12 @@ pull-pause@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/pull-pause/-/pull-pause-0.0.2.tgz#19d45be8faa615fa556f14a96fd733462c37fba3"
 
-pull-postmsg-stream@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/pull-postmsg-stream/-/pull-postmsg-stream-1.1.3.tgz#1318f4a7a64d7378e5c44db0627f19d29b9f41f1"
+pull-postmsg-stream@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pull-postmsg-stream/-/pull-postmsg-stream-1.2.0.tgz#3898c05abc7c68d972bbd91a69dd30649c33fb00"
   dependencies:
-    postmsg-rpc "^2.1.1"
-    prepost "^1.0.1"
+    postmsg-rpc "^2.4.0"
+    prepost "^1.1.0"
 
 pull-pushable@^2.0.0, pull-pushable@^2.0.1, pull-pushable@^2.1.2, pull-pushable@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
There were two issues at play here:

1. `pull-postmsg-stream` was using an old version of `postmsg-rpc` so wasn't getting the data from a message correctly and caused it to error when pulling over web extension port messaging
2. Companion was actively disallowing bi-directional messages. For pull streams to work, messages need to flow in both directions