### PR TITLE
Remove API client constructor from window.Ipfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "node"
+    - "lts/*"
 sudo: false
 env:
     global:

--- a/add-on/src/contentScripts/ipfs-proxy/page.js
+++ b/add-on/src/contentScripts/ipfs-proxy/page.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const Ipfs = require('ipfs')
 const { createProxyClient } = require('ipfs-postmsg-proxy')
 const _Buffer = Buffer
 
 window.Buffer = window.Buffer || _Buffer
-window.Ipfs = window.Ipfs || Ipfs
 window.ipfs = window.ipfs || createProxyClient()


### PR DESCRIPTION
This PR decreases size of `add-on/dist/contentScripts/ipfs-proxy/` by 1.7MB  (60%)

Context:
https://github.com/ipfs-shipyard/ipfs-companion/issues/460#issuecomment-384225346

