### PR TITLE
Skip HTTP GET of websocket handshake

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -99,6 +99,10 @@ module.exports = async function init () {
   // ===================================================================
 
   function onBeforeSendHeaders (request) {
+    // skip websocket handshake (not supported by HTTP2IPFS gateways)
+    if (request.type === 'websocket') {
+      return
+    }
     if (request.url.startsWith(state.apiURLString)) {
       // For some reason js-ipfs-api sent requests with "Origin: null" under Chrome
       // which produced '403 - Forbidden' error.

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -13,6 +13,11 @@ function createRequestModifier (getState, dnsLink, ipfsPathValidator) {
       return
     }
 
+    // skip websocket handshake (not supported by HTTP2IPFS gateways)
+    if (request.type === 'websocket') {
+      return
+    }
+
     // skip all local requests
     if (request.url.startsWith('http://127.0.0.1:') || request.url.startsWith('http://localhost:') || request.url.startsWith('http://[::1]:')) {
       return


### PR DESCRIPTION
This PR forces blocking `webRequest` hooks to explicitly skip initial HTTP requests related to websocket [protocol upgrade](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism)  (HTTP2IPFS gateways do not support WSS anyway). That way we will be immune to ephemeral bugs such as one mentioned in #469 and won't break hybrid websites. 

Both Chrome and Firefox (nightly and stable) include it in mentioned scope and pass it to both hooks: 

> | Firefox | Chrome |
> | --- | --- |
> | ![screenshot_1](https://user-images.githubusercontent.com/157609/39519547-776be994-4e07-11e8-8103-54c865caced2.png)  |  ![screenshot_6](https://user-images.githubusercontent.com/157609/39519490-3b92660a-4e07-11e8-8997-e478f141f5df.png) |

Closes #469