### PR TITLE
Add release scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,14 @@ Don't want to install JS dependencies such as NodeJS and yarn?
 
 Do an isolated build inside of Docker!
 
-Run the following commands for ending up
-with a built extension inside the `build/` directory.
+Run the following command for ending up
+with a built extension inside the `build/` directory:
 
 ```sh
-docker build -t ipfs-companion .
-docker run -it -v $(pwd)/build:/usr/src/app/build ipfs-companion yarn ci:build
+npm run release-build
 ```
 
-Now you can install the extension directly from `build/`
+It is an alias for running `ci:build` script inside of immutable Docker image, which guarantees the same output on all platforms.
 
 ### Legacy Firefox (< 53) and XUL-Compatible Browsers
 

--- a/ci/update-manifest.sh
+++ b/ci/update-manifest.sh
@@ -5,8 +5,14 @@ set -e
 
 MANIFEST=add-on/manifest.common.json
 
-# restore original (make this script immutable)
+# restore original in case it was modified manually
 git checkout $MANIFEST
+
+# skip all manifest mutations when building for stable channel
+if [ "$RELEASE_CHANNEL" = "stable" ]; then
+    echo "Skipping manifest modification (RELEASE_CHANNEL=${RELEASE_CHANNEL})"
+    exit 0
+fi
 
 # Use jq for JSON operations
 function set-manifest {
@@ -16,7 +22,11 @@ function set-manifest {
 ## Set NAME
 # Name includes git revision to make QA and bug reporting easier for users :-)
 REVISION=$(git show-ref --head HEAD | head -c 7)
-set-manifest ".name = \"IPFS Companion (Dev Build @ $REVISION)\""
+if [ "$RELEASE_CHANNEL" = "beta" ]; then
+    set-manifest ".name = \"IPFS Companion (Beta @ $REVISION)\""
+else
+    set-manifest ".name = \"IPFS Companion (Dev Build @ $REVISION)\""
+fi
 grep $REVISION $MANIFEST
 
 ## Set VERSION

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -64,20 +64,24 @@ See [`docs/firefox-for-android.md`](firefox-for-android.md)
 
 ## Useful Tasks
 
-Each `npm` task can be run separately. The most useful ones are:
+Each `npm` task can be run separately, but for most of time `dev-build`, `test` and `fix:lint` are all you need.
 
 - `npm install` -- install all NPM dependencies
 - `npm run build` -- build the add-on (copy external libraries, create `.zip` bundles for Chrome and Firefox)
 - `npm run bundle:generic` -- overwrites manifest and packages a Brave/Chrome-compatible version
 - `npm run bundle:firefox` -- overwrites manifest and packages a Firefox-compatible version
-- `npm run yarn-build` -- fast dependency install + build with yarn (installs and updates yarn.lock if needed)
-- `npm run ci` -- reproducible test and build (with frozen yarn.lock)
+- `npm run ci` -- runs tests and build (with frozen yarn.lock)
 - `npm test` -- run entire test suite
 - `npm run lint` -- read-only check for potential syntax problems (run all linters)
 - `npm run fix:lint` -- try to fix simple syntax problems (run `standard` with `--fix` etc)
 - `npm run lint:standard` -- run [standard](http://standardjs.com) linter ([IPFS JavaScript projects default to standard code style](https://github.com/ipfs/community/blob/master/js-code-guidelines.md#linting--code-style))
 - `npm run lint:web-ext` -- run [addons-linter](https://github.com/mozilla/addons-linter) shipped with `web-ext` tool
 - `npm run firefox` -- run as temporary add-on in Firefox
+
+Release build shortcuts:
+- `npm run dev-build` -- all-in-one: fast dependency install, build with yarn (updates yarn.lock if needed)
+- `npm run beta-build` -- reproducible beta build in docker with frozen yarn.lock
+- `npm run release-build` -- reproducible release build in docker with frozen yarn.lock
 
 ## Tips
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:content-scripts:ipfs-proxy:content": "browserify -p prundupify -g uglifyify -t brfs -t [ browserify-package-json --global ] -s IpfsProxyContent add-on/src/contentScripts/ipfs-proxy/content.js -o add-on/dist/contentScripts/ipfs-proxy/content.js",
     "build:content-scripts:ipfs-proxy:cleanup": "shx rm add-on/dist/contentScripts/ipfs-proxy/page.js",
     "build:minimize-dist": "shx rm -rf add-on/dist/lib",
-    "build:bundle-all": "run-s bundle:generic bundle:firefox",
+    "build:bundle-all": "run-s bundle:generic && test \"$RELEASE_CHANNEL\" = \"beta\" && run-s bundle:firefox:beta || run-s bundle:firefox",
     "bundle": "run-s bundle:*",
     "bundle:generic": "shx cp add-on/manifest.common.json add-on/manifest.json && web-ext build -a build/generic",
     "bundle:firefox": "shx cat add-on/manifest.common.json add-on/manifest.firefox.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/",
@@ -57,8 +57,10 @@
     "ci:install": "npx yarn@1.6.0 install --frozen-lockfile || npx yarn@1.6.0 install --frozen-lockfile",
     "ci:test": "npx yarn@1.6.0 test",
     "ci:build": "./ci/update-manifest.sh ; npx yarn@1.6.0 build ; chmod -R ugo+rwX build/ add-on/",
-    "beta-build": "run-s ci:build bundle:firefox:beta",
-    "yarn-build": "npx yarn@1.6.0 && npx yarn@1.6.0 build"
+    "beta-build": "docker build -t ipfs-companion . && docker run -it -e RELEASE_CHANNEL=beta -v $(pwd)/build:/usr/src/app/build ipfs-companion yarn ci:build",
+    "release-build": "docker build -t ipfs-companion . && docker run -it -e RELEASE_CHANNEL=stable -v $(pwd)/build:/usr/src/app/build ipfs-companion yarn ci:build",
+    "dev-build": "npx yarn@1.6.0 && npx yarn@1.6.0 build",
+    "yarn-build": "run-s dev-build"
   },
   "private": true,
   "preferGlobal": false,


### PR DESCRIPTION
This PR automates tasks for building firefox and chrome bundles for 'stable' and 'beta'
channels by adding high-level all-in-one targets:

- `npm run dev-build` -- all-in-one for local development: fast dependency install and build with yarn (**update** yarn.lock if needed)
- `npm run beta-build` -- reproducible beta build in docker with **frozen** yarn.lock
- `npm run release-build` -- reproducible release build in docker with **frozen** yarn.lock

Scripts take care of updating `add-on/manifest.json` and provide docker orchestration necessary for achieving reproducible build (#306) across platforms. 