### PR TITLE
fix: correct manifest for firefox beta bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:content-scripts:ipfs-proxy:content": "browserify -p prundupify -g uglifyify -t brfs -t [ browserify-package-json --global ] -s IpfsProxyContent add-on/src/contentScripts/ipfs-proxy/content.js -o add-on/dist/contentScripts/ipfs-proxy/content.js",
     "build:content-scripts:ipfs-proxy:cleanup": "shx rm add-on/dist/contentScripts/ipfs-proxy/page.js",
     "build:minimize-dist": "shx rm -rf add-on/dist/lib",
-    "build:bundle-all": "run-s bundle:generic && shx test \"$RELEASE_CHANNEL\" = \"beta\" && run-s bundle:firefox:beta || run-s bundle:firefox",
+    "build:bundle-all": "RELEASE_CHANNEL=${RELEASE_CHANNEL:=dev} run-s bundle:generic && cross-env-shell test \"$RELEASE_CHANNEL\" = \"beta\" && run-s bundle:firefox:beta || run-s bundle:firefox",
     "bundle": "run-s bundle:*",
     "bundle:generic": "shx cp add-on/manifest.common.json add-on/manifest.json && web-ext build -a build/generic",
     "bundle:firefox": "shx cat add-on/manifest.common.json add-on/manifest.firefox.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/",


### PR DESCRIPTION
`shx` did not work correctly and we did not get proper bundle for Firefox.
This PR fixes it. Also, submitting as a PR to see if it does not break Windows build.
