### PR TITLE
fix: disable sharing action when upload is not possible

### DIFF
--- a/add-on/src/popup/browser-action/operations.js
+++ b/add-on/src/popup/browser-action/operations.js
@@ -9,6 +9,7 @@ module.exports = function operations ({
   ipfsNodeType,
   isIpfsOnline,
   redirectEnabled,
+  uploadEnabled,
   onQuickUpload,
   onOpenWebUi,
   onOpenPrefs,
@@ -16,7 +17,7 @@ module.exports = function operations ({
 }) {
   return html`
     <div class="fade-in pv1">
-      ${isIpfsOnline ? (
+      ${isIpfsOnline && uploadEnabled ? (
         navItem({
           text: browser.i18n.getMessage('panel_quickUpload'),
           bold: true,

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -21,7 +21,8 @@ module.exports = (state, emitter) => {
     gatewayAddress: null,
     swarmPeers: null,
     gatewayVersion: null,
-    redirectEnabled: false
+    redirectEnabled: false,
+    uploadEnabled: false
   })
 
   let port
@@ -201,6 +202,8 @@ module.exports = (state, emitter) => {
       state.ipfsNodeType = status.ipfsNodeType
       state.ipfsApiUrl = options.ipfsApiUrl
       state.redirectEnabled = options.useCustomGateway
+      // Upload requires access to the background page (https://github.com/ipfs-shipyard/ipfs-companion/issues/477)
+      state.uploadEnabled = !!(await browser.runtime.getBackgroundPage())
       state.swarmPeers = status.peerCount === -1 ? 0 : status.peerCount
       state.isIpfsOnline = status.peerCount > -1
       state.gatewayVersion = status.gatewayVersion ? status.gatewayVersion : null

--- a/yarn.lock
+++ b/yarn.lock
@@ -5554,7 +5554,7 @@ level-js@^2.2.4:
     typedarray-to-buffer "~1.0.0"
     xtend "~2.1.2"
 
-"level-js@github:timkuijsten/level.js#idbunwrapper":
+level-js@timkuijsten/level.js#idbunwrapper:
   version "2.2.3"
   resolved "https://codeload.github.com/timkuijsten/level.js/tar.gz/18e03adab34c49523be7d3d58fafb0c632f61303"
   dependencies:


### PR DESCRIPTION
Closes #477 by disabling Upload action when access to required backend is not possible  (eg. in Private Mode in Firefox).