### PR TITLE
Do not redirect XHR that would fail due to CORS bug in Firefox

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -58,7 +58,7 @@ module.exports = async function init () {
       onCopyCanonicalAddress: () => copier.copyCanonicalAddress(),
       onCopyAddressAtPublicGw: () => copier.copyAddressAtPublicGw()
     })
-    modifyRequest = createRequestModifier(getState, dnsLink, ipfsPathValidator)
+    modifyRequest = createRequestModifier(getState, dnsLink, ipfsPathValidator, runtime)
     ipfsProxy = createIpfsProxy(() => ipfs, getState)
     registerListeners()
     await setApiStatusUpdateInterval(options.ipfsApiPollMs)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -49,7 +49,7 @@ function createRequestModifier (getState, dnsLink, ipfsPathValidator) {
     // handle redirects to custom gateway
     if (state.redirect) {
       // Ignore preload requests
-      if (request.method === 'HEAD' && state.preloadAtPublicGateway && request.url.startsWith(state.pubGwURLString)) {
+      if (request.method === 'HEAD') {
         return
       }
       // Ignore XHR requests for which redirect would fail due to CORS bug in Firefox

--- a/test/functional/lib/ipfs-request.test.js
+++ b/test/functional/lib/ipfs-request.test.js
@@ -77,6 +77,53 @@ describe('modifyRequest', function () {
     })
   })
 
+  describe('XHR request for a path matching /ipfs/{CIDv0}', function () {
+    describe('with external node', function () {
+      beforeEach(function () {
+        state.ipfsNodeType = 'external'
+      })
+      it('should be served from custom gateway if fetched from the same origin and redirect is enabled in Firefox', function () {
+        const xhrRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', originUrl: 'https://google.com/'}
+        expect(modifyRequest(xhrRequest).redirectUrl).to.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+      it('should be served from custom gateway if fetched from the same origin and redirect is enabled in Chrome', function () {
+        const xhrRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', initiator: 'https://google.com/'}
+        expect(modifyRequest(xhrRequest).redirectUrl).to.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+    })
+    describe('with embedded node', function () {
+      beforeEach(function () {
+        state.ipfsNodeType = 'embedded'
+      })
+      it('should be served from public gateway if fetched from the same origin and redirect is enabled in Firefox', function () {
+        const xhrRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', originUrl: 'https://google.com/'}
+        expect(modifyRequest(xhrRequest).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+      it('should be served from public gateway if fetched from the same origin and redirect is enabled in Chrome', function () {
+        const xhrRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', initiator: 'https://google.com/'}
+        expect(modifyRequest(xhrRequest).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+    })
+    describe('with every node type', function () {
+      // tests in which results should be the same for all node types
+      nodeTypes.forEach(function (nodeType) {
+        beforeEach(function () {
+          state.ipfsNodeType = nodeType
+        })
+        it(`should be left untouched if request is a cross-origin XHR (Firefox, ${nodeType} node)`, function () {
+          // Context: https://github.com/ipfs-shipyard/ipfs-companion/issues/436
+          const xhrRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', originUrl: 'https://www.nasa.gov/foo.html'}
+          expect(modifyRequest(xhrRequest)).to.equal(undefined)
+        })
+        it(`should be left untouched if request is a cross-origin XHR (Chrome, ${nodeType} node)`, function () {
+          // Context: https://github.com/ipfs-shipyard/ipfs-companion/issues/436
+          const xhrRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', initiator: 'https://www.nasa.gov/foo.html'}
+          expect(modifyRequest(xhrRequest)).to.equal(undefined)
+        })
+      })
+    })
+  })
+
   describe('request for a path matching /ipns/{path}', function () {
     describe('with external node', function () {
       beforeEach(function () {
@@ -317,8 +364,8 @@ describe('modifyRequest', function () {
           expect(modifyRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if request.type != main_frame', function () {
-          const xhrRequest = {url: 'https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar', type: 'xmlhttprequest'}
-          expect(modifyRequest(xhrRequest)).to.equal(undefined)
+          const mediaRequest = {url: 'https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar', type: 'media'}
+          expect(modifyRequest(mediaRequest)).to.equal(undefined)
         })
       })
 

--- a/test/functional/lib/ipfs-request.test.js
+++ b/test/functional/lib/ipfs-request.test.js
@@ -73,6 +73,11 @@ describe('modifyRequest', function () {
           const request = url2request('https://google.com/ipfs/notacid?argTest#hashTest')
           expect(modifyRequest(request)).to.equal(undefined)
         })
+        it(`should be left untouched if its is a preload request (${nodeType} node)`, function () {
+          // HTTP HEAD is often used for preloading data at arbitrary gateways - it should arrive at original destination
+          const headRequest = {url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', method: 'HEAD'}
+          expect(modifyRequest(headRequest)).to.equal(undefined)
+        })
       })
     })
   })


### PR DESCRIPTION
This PR disables gateway redirect for cross-origin XHRs.

- It fixes all the websites broken by [CORS false-positive bug in Firefox](https://github.com/ipfs-shipyard/ipfs-companion/issues/436#issuecomment-378254294) (samples below).
  -  It is a "lesser evil". There will be no gateway redirect for such requests, but at least "IPFS-enabled" websites that do cross-origin requests to different gateways will work.
- I believe we want the same behavior on all browsers, so initial version of this PR conforms to the Firefox limitation in Chrome as well.
  - For: Different handling on different browsers would be a nightmare for a developer, who assumes it "works the same everywhere". 
  - Against: We introduce artificial limitation for browsers other than Firefox.
- The full context is in https://github.com/ipfs-shipyard/ipfs-companion/issues/436#issuecomment-378254294 including a link to the upstream bug.

### Samples

Examples of sites broken in [v2.3.0](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.3.0) by the bug:
- https://ipfs.github.io/public-gateway-checker/
- http://node2.e-mesh.net/hls/stream.html?gw=https://hardbin.com/ipfs (reported by @darkdrgn2k)
(open Console to see CORS error)

### Open Questions

I'd appreciate some quick feedback, before this gets merged and released: 
1. Is it OK to artificially limit Chrome just for sake of uniformity? 
2. Should we log a warning to the console on every skipped XHR, or is it too much?