### PR TITLE
feat: disable creation of window.ipfs attribute

### DIFF
--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -18,7 +18,7 @@
     "default_title": "__MSG_pageAction_titleNonIpfs__",
     "default_popup": "dist/popup/page-action/index.html"
   },
-  "content_scripts": null,
+  "content_scripts": [ ],
   "protocol_handlers": [
     {
       "protocol": "web+dweb",

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -18,6 +18,7 @@
     "default_title": "__MSG_pageAction_titleNonIpfs__",
     "default_popup": "dist/popup/page-action/index.html"
   },
+  "content_scripts": null,
   "protocol_handlers": [
     {
       "protocol": "web+dweb",

--- a/add-on/src/contentScripts/ipfs-proxy/content.js
+++ b/add-on/src/contentScripts/ipfs-proxy/content.js
@@ -7,14 +7,12 @@ const injectScript = require('./inject-script')
 
 function init () {
   const port = browser.runtime.connect({ name: 'ipfs-proxy' })
-
   // Forward on messages from background to the page and vice versa
   port.onMessage.addListener((data) => {
     if (data && data.sender && data.sender.startsWith('postmsg-rpc/')) {
       window.postMessage(data, '*')
     }
   })
-
   window.addEventListener('message', (msg) => {
     if (msg.data && msg.data.sender && msg.data.sender.startsWith('postmsg-rpc/')) {
       port.postMessage(msg.data)
@@ -24,8 +22,30 @@ function init () {
   injectScript(rawCode)
 }
 
-// Restricting window.ipfs to Secure Context
-// See: https://github.com/ipfs-shipyard/ipfs-companion/issues/476
-if (window.isSecureContext) {
+function injectIpfsProxy () {
+  // Skip if proxy is already present
+  if (window.ipfs) {
+    return false
+  }
+  // Restricting window.ipfs to Secure Context
+  // See: https://github.com/ipfs-shipyard/ipfs-companion/issues/476
+  if (!window.isSecureContext) {
+    return false
+  }
+  // Skip if not in HTML context
+  // Check 1/2
+  const doctype = window.document.doctype
+  if (doctype && doctype.name !== 'html') {
+    return false
+  }
+  // Check 2/2
+  if (document.documentElement.nodeName !== 'HTML') {
+    return false
+  }
+  // Should be ok by now
+  return true
+}
+
+if (injectIpfsProxy()) {
   init()
 }

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -116,7 +116,7 @@ module.exports = async function init () {
     const newHandle = await browser.contentScripts.register({
       matches: ['<all_urls>'],
       js: [
-        {file: '/dist/contentScripts/ipfs-proxy/content.js'}
+        {file: '/dist/bundles/ipfsProxyContentScript.bundle.js'}
       ],
       allFrames: true,
       runAt: 'document_start'


### PR DESCRIPTION
This PR enables Firefox users to disable creation of `window.ipfs` attribute via _Preferences_ screen, solving fingerprinting issue raised in #451.

It requires webpack, so should be merged after #498 

### Background

Existing `tabs.executeScript` API with `runAt: 'document_start'` flag was executing too late and page scripts were  unable to detect `window.ipfs` correctly.  More info on the underlying issue: #368 https://github.com/ipfs-shipyard/ipfs-companion/issues/362#issuecomment-362231167

As a workaround that worked in both Chrome and Firefox, we were forced to always load content script via manifest definition. This meant no control over when it is loaded and no easy off switch. If `window.ipfs` was disabled via _Preferences_, it was throwing an Error on access, but remained in the scope.

Mozilla added [`contentScripts`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contentScripts/register) API in Firefox 59. The key difference between `tabs.executeScript` and `contentScripts` API is that the latter provides guarantee to execute before anything else on the page, passing [our synchronous smoke test](https://ipfs-shipyard.github.io/ipfs-companion/docs/examples/window.ipfs-fallback.html). 

### Known Issues

Chrome does not provide `contentScripts` API so it will continue to statically load `content_script` via  manifest.  Hopefully with time, other browser vendors will adopt the new API.

