### PR TITLE
fix: rate-limiting the Linkify experiment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const SimpleProgressWebpackPlugin = require('simple-progress-webpack-plugin')
 // common configuration shared by all targets
 const commonConfig = {
   target: 'web',
+  bail: true,
   output: {
     path: path.resolve(__dirname, 'add-on/dist/bundles'),
     publicPath: '/dist/bundles/',


### PR DESCRIPTION
This PR updates very old content script responsible for making plain text IPFS paths clickable.

- Support dynamic JS apps by rate-limiting operations via global job queue
  - Run only one DOM-mutating task at the time
  - Ignore DOM nodes under a parent with  `contentEditable` property equal true
    - This fixes heavily customized input fields on Slack and Twitter and closes #503