### PR TITLE
fix: icons hover

### DIFF
--- a/add-on/src/popup/browser-action/icon.js
+++ b/add-on/src/popup/browser-action/icon.js
@@ -6,7 +6,7 @@ const browser = require('webextension-polyfill')
 
 function icon ({ svg, title, active, action }) {
   return html`
-    <button class="pa0 ma0 dib bn bg-transparent pointer grow transition-all ${active ? 'fill-aqua hover-fill-snow' : 'fill-gray hover-fill-snow-muted'}"
+    <button class="pa0 ma0 dib bn bg-transparent pointer transition-all ${active ? 'fill-aqua hover-fill-snow' : 'fill-gray hover-fill-snow-muted'}"
       style="outline:none;"
       title="${browser.i18n.getMessage(title)}"
       onclick=${action}>


### PR DESCRIPTION
This PR fixes a problem that happened in Chrome (Mac). 

As we hovered the icons they scaled a bit so it had a weird behaviour:
![before](https://user-images.githubusercontent.com/33324750/42035793-adde7dce-7adb-11e8-9de0-3297f0b7dadd.gif)

I've removed the scale effect, as it was minor and the changing background color is more than sufficient from an UX point of view:
![after](https://user-images.githubusercontent.com/33324750/42035797-b02e0e00-7adb-11e8-9368-6bc43f93133f.gif)

