### PR TITLE
Add support for uploading files linked to on a page, using the context menu

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -83,9 +83,13 @@
     "message": "Non-IPFS resource",
     "description": "Default label for icon hidden in Page Action menu (pageAction_titleNonIpfs)"
   },
-  "contextMenu_uploadToIpfs": {
-    "message": "Upload to IPFS",
-    "description": "An item in right-click context menu (contextMenu_uploadToIpfs)"
+  "contextMenu_AddToIpfsRawCid": {
+    "message": "Add to IPFS",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsRawCid)"
+  },
+  "contextMenu_AddToIpfsKeepFilename": {
+    "message": "Add to IPFS (Keep Filename)",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
   },
   "notify_addonIssueTitle": {
     "message": "IPFS Add-on Issue",

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -24,11 +24,12 @@ async function findUrlForContext (context) {
 
 module.exports.findUrlForContext = findUrlForContext
 
-const contextMenuUploadToIpfs = 'contextMenu_UploadToIpfs'
+const contextMenuAddToIpfsRawCid = 'contextMenu_AddToIpfsRawCid'
+const contextMenuAddToIpfsKeepFilename = 'contextMenu_AddToIpfsKeepFilename'
 const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpfsAddress'
 const contextMenuCopyAddressAtPublicGw = 'panel_copyCurrentPublicGwUrl'
 
-function createContextMenus (getState, runtime, ipfsPathValidator, { onUploadToIpfs, onCopyCanonicalAddress, onCopyAddressAtPublicGw }) {
+function createContextMenus (getState, runtime, ipfsPathValidator, { onAddToIpfsRawCid, onAddToIpfsKeepFilename, onCopyCanonicalAddress, onCopyAddressAtPublicGw }) {
   let copyAddressContexts = ['page', 'image', 'video', 'audio', 'link']
   if (runtime.isFirefox) {
     // https://github.com/ipfs-shipyard/ipfs-companion/issues/398
@@ -36,12 +37,21 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onUploadToI
   }
   try {
     browser.contextMenus.create({
-      id: contextMenuUploadToIpfs,
-      title: browser.i18n.getMessage(contextMenuUploadToIpfs),
+      id: contextMenuAddToIpfsRawCid,
+      title: browser.i18n.getMessage(contextMenuAddToIpfsRawCid),
       contexts: ['image', 'video', 'audio', 'link'],
       documentUrlPatterns: ['<all_urls>'],
       enabled: false,
-      onclick: onUploadToIpfs
+      onclick: onAddToIpfsRawCid
+    })
+
+    browser.contextMenus.create({
+      id: contextMenuAddToIpfsKeepFilename,
+      title: browser.i18n.getMessage(contextMenuAddToIpfsKeepFilename),
+      contexts: ['image', 'video', 'audio', 'link'],
+      documentUrlPatterns: ['<all_urls>'],
+      enabled: false,
+      onclick: onAddToIpfsKeepFilename
     })
 
     browser.contextMenus.create({
@@ -76,7 +86,9 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onUploadToI
   return {
     async update (changedTabId) {
       try {
-        await browser.contextMenus.update(contextMenuUploadToIpfs, {enabled: getState().peerCount > 0})
+        const canUpload = getState().peerCount > 0
+        await browser.contextMenus.update(contextMenuAddToIpfsRawCid, {enabled: canUpload})
+        await browser.contextMenus.update(contextMenuAddToIpfsKeepFilename, {enabled: canUpload})
         if (changedTabId) {
           // recalculate tab-dependant menu items
           const currentTab = await browser.tabs.query({active: true, currentWindow: true}).then(tabs => tabs[0])

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -38,7 +38,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onUploadToI
     browser.contextMenus.create({
       id: contextMenuUploadToIpfs,
       title: browser.i18n.getMessage(contextMenuUploadToIpfs),
-      contexts: ['image', 'video', 'audio'],
+      contexts: ['image', 'video', 'audio', 'link'],
       documentUrlPatterns: ['<all_urls>'],
       enabled: false,
       onclick: onUploadToIpfs

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -57,7 +57,8 @@ module.exports = async function init () {
     dnsLink = createDnsLink(getState)
     ipfsPathValidator = createIpfsPathValidator(getState, dnsLink)
     contextMenus = createContextMenus(getState, runtime, ipfsPathValidator, {
-      onUploadToIpfs: addFromURL,
+      onAddToIpfsRawCid: addFromURL,
+      onAddToIpfsKeepFilename: (info) => addFromURL(info, {wrapWithDirectory: true}),
       onCopyCanonicalAddress: () => copier.copyCanonicalAddress(),
       onCopyAddressAtPublicGw: () => copier.copyAddressAtPublicGw()
     })


### PR DESCRIPTION
#513 

Very simple addition so you can upload files that are linked to on a page. For example pdf files so you do not have to download them and manually upload them. 

A current problem I noticed is that when trying to upload links directly from google search results it opens a print dialog. This seems be fixed when using an extension that removes google redirect links. https://addons.mozilla.org/en-US/firefox/addon/google-no-tracking-url/?src=search