### PR TITLE
chore: update README to reflect v2.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IPFS Companion
 
-![demo of v2.2.0](https://user-images.githubusercontent.com/157609/38491868-6c9dbaa0-3bed-11e8-975a-52bea908f1cb.gif)
+![demo of v2.4.2](https://user-images.githubusercontent.com/157609/42695172-d35ede9c-86b4-11e8-9165-0471a60fd60d.gif)
 
 [![](https://img.shields.io/github/release/ipfs/ipfs-companion.svg)](https://github.com/ipfs/ipfs-companion/releases/latest)
 [![](https://img.shields.io/badge/mozilla-reviewed-blue.svg)](https://addons.mozilla.org/en-US/firefox/addon/ipfs-companion/)
@@ -54,18 +54,16 @@ Websites can detect if `window.ipfs` exists and opt-in to use it instead of crea
 It saves system resources and battery (on mobile), avoids the overhead of peer discovery/connection, enables shared repository access and more!
 Make sure to read our [notes on `window.ipfs`](https://github.com/ipfs-shipyard/ipfs-companion/blob/master/docs/window.ipfs.md), where we explain it in-depth and provide examples on how to use it your own dapp.
 
-#### Toggle Between Embedded and External Node
+#### Toggle IPFS Integrations
 
-> ![screenshot of node type toggle](https://user-images.githubusercontent.com/157609/39421672-59010924-4c6a-11e8-9e64-6b5d5f5f2768.png)
+> ![screenshot of suspend toggle](https://user-images.githubusercontent.com/157609/42685002-18c7cee4-8692-11e8-9171-970866d91ae0.gif)
 
-The Browser Action menu provides a toggle for switching  between embedded,
-in-memory `js-ipfs` and external IPFS node accessed over HTTP API.
-Read about differences at [docs/node-types](docs/node-types.md).
+The Browser Action pop-up provides a toggle for suspending all active IPFS integrations with a single click.
 
 #### IPFS Status and Context Actions
 
 - IPFS API and Gateway status
-- Quick Upload of local files
+- Add local (quick upload) or remote files (context menu) to IPFS with option to preserve filename
 - Easy access to [WebUI](https://github.com/ipfs/webui/) and add-on Preferences
 - Toggle redirection to local gateway (automatic by default, manual mode can be enabled in Preferences)
 - Additional actions for pages loaded from IPFS
@@ -83,9 +81,10 @@ _(some are disabled by default, use Preferences screen to enable)_
     - `dweb:/ipfs/$cid`
     - `dweb:/ipns/$cid_or_fqdn`
 - Detect domains with [dnslink](https://github.com/jbenet/go-dnslink) in DNS TXT record and load them from IPFS
-- Make plaintext IPFS links clickable
+- Make plaintext IPFS links clickable ([demo](https://ipfs.io/ipfs/bafybeidvtwx54qr44kidymvhfzefzxhgkieigwth6oswk75zhlzjdmunoy/linkify-demo.html))
 - Mirror to IPFS by right click on any image or video
-- Embedded node can be used for uploads even when external API is down
+- Switch between _External_ HTTP API and _Embedded_ js-ipfs node. Read about differences at [docs/node-types](docs/node-types.md).
+  > [![screenshot of node type switch](https://user-images.githubusercontent.com/157609/42382479-b4d98768-8134-11e8-979c-69b758846bf0.png)](https://github.com/ipfs-shipyard/ipfs-companion/blob/master/docs/node-types.md)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 The best place to ask your questions about IPFS in general, how it works and what you can do with it is at [discuss.ipfs.io](https://discuss.ipfs.io/).  
 We are also available at the [#ipfs](https://webchat.freenode.net/?channels=ipfs) channel, where most of IPFS community hangs out.
 
+Questions specific to this browser companion can be asked directly at [`#ipfs-in-web-browsers`](https://webchat.freenode.net/?channels=ipfs-in-web-browsers)
+
+#### Cross-Origin XHR are executed "twice" in Firefox
+
+Due to CORS bug XHRs in Firefox are handled via late redirects in `onHeadersReceived`.
+Original request is cancelled after response headers are received, so there is no overhead of reading response payload twice.
+
+For more details on this see [PR #511](https://github.com/ipfs-shipyard/ipfs-companion/pull/511).
+
 #### Upload via Right-Click Does Not Work in Firefox
 
 See [this workaround](https://github.com/ipfs/ipfs-companion/issues/227).

--- a/test/data/linkify-demo.html
+++ b/test/data/linkify-demo.html
@@ -4,10 +4,16 @@
     <meta charset="utf-8" />
 
 <body>
+    <p>
+    Make sure the <em>Linkify</em> experiment is enabled in <a href="https://github.com/ipfs-shipyard/ipfs-companion">IPFS Companion</a> before you load this page:<br>
+    <img src="https://ipfs.io/ipfs/QmY1D42peN9oPCoEeFezKR2jWKReDnJek52zcj7pcXXaaH" alt="Linkify enabled on Preferences screen" />
+    </p>
     <p id='plain-links'>
     <h1> Should be linkified</h1>
         /ipfs/QmTAsnXoWmLZQEpvyZscrReFzqxP3pvULfGVgpJuayrp1w
-        <br>ipfs://QmTAsnXoWmLZQEpvyZscrReFzqxP3pvULfGVgpJuayrp1w
+        <br>/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy
+        <br>ipfs://QmTAsnXoWmLZQEpvyZscrReFzqxP3pvULfGVgpJuayrp1w (cidv0b58)
+        <br>ipfs://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy (cidv1b32)
         <br>ipns://ipfs.git.sexy
         <br>dweb:/ipfs/QmTAsnXoWmLZQEpvyZscrReFzqxP3pvULfGVgpJuayrp1w
     <h1> Should NOT be linkified</h1>


### PR DESCRIPTION
- swapped GIF to reflect UI changes in  v2.4.x
- node type moved to experiments
- added linkify demo page

→ [README PREVIEW](https://github.com/ipfs-shipyard/ipfs-companion/blob/23585ebfc3f1d8fc2764123ae8bf2bb9f19acf51/README.md#ipfs-companion)