### PR TITLE
Change webpack minimizer flags to follow Aegir

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "web-ext": "2.7.0",
     "webpack": "4.14.0",
     "webpack-bundle-analyzer": "2.13.1",
-    "webpack-cli": "3.0.8"
+    "webpack-cli": "3.0.8",
+    "webpack-merge": "4.1.3"
   },
   "dependencies": {
     "choo": "6.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10726,6 +10726,12 @@ webpack-cli@3.0.8:
     v8-compile-cache "^2.0.0"
     yargs "^11.1.0"
 
+webpack-merge@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.3.tgz#8aaff2108a19c29849bc9ad2a7fd7fce68e87c4a"
+  dependencies:
+    lodash "^4.17.5"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"


### PR DESCRIPTION
### Problem fixed by this PR

Default minimizer flags break pubsub with embedded node  by removing 'unused' code of pubsub experiment. Details in #521.

### In This PR

-  Backport of https://github.com/ipfs/aegir/pull/214: it restores pubsub functionality and applies the fix for  entire build pipeline to avoid similar issues in future.
- The way configuration blocks are merged is improved by use of [webpack-merge](https://www.npmjs.com/package/webpack-merge)
- Bundles are bit smaller due to moving LICENSE comments to separate file (`extractComments: true`)
- Closes #521 