### PR TITLE
window.ipfs.files.cp|mv fixes

### DIFF
--- a/add-on/src/lib/ipfs-proxy/pre-mfs-scope.js
+++ b/add-on/src/lib/ipfs-proxy/pre-mfs-scope.js
@@ -45,12 +45,28 @@ function createSrcDestPre (getScope, getIpfs, rootPath) {
   return async (...args) => {
     // console.log('createSrcDestPre.args.before: ' + JSON.stringify(args))
     const appPath = await getAppPath(getScope, getIpfs, rootPath)
-    // console.log('createSrcDestPre.args.appPath', appPath)
-    args[0][0] = safeSourcePathPrefix(appPath, args[0][0])
-    args[0][1] = Path.join(appPath, safePath(args[0][1]))
-    // console.log('createSrcDestPre.args.after: ' + JSON.stringify(args))
+    // console.log('createSrcDestPre.appPath:     ', appPath)
+    args = prefixSrcDestArgs(appPath, args)
+    // console.log('createSrcDestPre.args.after:  ' + JSON.stringify(args))
     return args
   }
+}
+
+// Prefix src and dest args where applicable
+function prefixSrcDestArgs (prefix, args) {
+  return args.map((item) => {
+    if (typeof item === 'string') {
+      return safeSourcePathPrefix(prefix, item)
+    } else if (Array.isArray(item)) {
+      // The syntax recently changed to remove passing an array,
+      // but we allow for both versions until js-ipfs-api is updated to remove
+      // support for it
+      console.warn('[ipfs-companion] use of array in ipfs.files.cp|mv is deprecated, see https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#filescp')
+      return prefixSrcDestArgs(prefix, item)
+    }
+    // at this point its probably {options} or callback
+    return item
+  })
 }
 
 // Add a prefix to a src path in a safe way

--- a/test/functional/lib/ipfs-proxy/pre-mfs-scope.test.js
+++ b/test/functional/lib/ipfs-proxy/pre-mfs-scope.test.js
@@ -22,6 +22,17 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     expect(args[0][1]).to.equal('/test-dapps/https/ipfs.io/destination.txt')
   })
 
+  it('should not scope src path if it is valid /ipfs/ path for files.cp', async () => {
+    // Bug B from https://github.com/ipfs-shipyard/ipfs-companion/issues/530#issue-341352979
+    const fnName = 'files.cp'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre(['/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', '/destination.jpg'])
+    expect(args[0][0]).to.equal('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+    expect(args[0][1]).to.equal('/test-dapps/https/ipfs.io/destination.jpg')
+  })
+
   it('should scope src path for files.mkdir', async () => {
     const fnName = 'files.mkdir'
     const getScope = () => 'https://ipfs.io/'

--- a/test/functional/lib/ipfs-proxy/pre-mfs-scope.test.js
+++ b/test/functional/lib/ipfs-proxy/pre-mfs-scope.test.js
@@ -12,7 +12,40 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     expect(pre).to.equal(null)
   })
 
-  it('should scope src/dest paths for files.cp', async () => {
+  it('should scope (src, dest) paths for files.cp', async () => {
+    const fnName = 'files.cp'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre('/source.txt', '/destination.txt')
+    expect(args[0]).to.equal('/test-dapps/https/ipfs.io/source.txt')
+    expect(args[1]).to.equal('/test-dapps/https/ipfs.io/destination.txt')
+  })
+
+  it('should scope (src1, src2, destDir) paths for files.cp', async () => {
+    const fnName = 'files.cp'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre('/source1.txt', '/source2.txt', '/destinationDir/')
+    expect(args[0]).to.equal('/test-dapps/https/ipfs.io/source1.txt')
+    expect(args[1]).to.equal('/test-dapps/https/ipfs.io/source2.txt')
+    expect(args[2]).to.equal('/test-dapps/https/ipfs.io/destinationDir')
+  })
+
+  it('should not scope src path if it is valid /ipfs/ path for files.cp', async () => {
+    // Bug B from https://github.com/ipfs-shipyard/ipfs-companion/issues/530#issue-341352979
+    const fnName = 'files.cp'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', '/destination.jpg')
+    expect(args[0]).to.equal('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+    expect(args[1]).to.equal('/test-dapps/https/ipfs.io/destination.jpg')
+  })
+
+  // array-wrapping is deprecated, but we support it until removed from js-ipfs-api
+  it('should scope ([src, dest]) paths for files.cp', async () => {
     const fnName = 'files.cp'
     const getScope = () => 'https://ipfs.io/'
     const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
@@ -22,7 +55,8 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     expect(args[0][1]).to.equal('/test-dapps/https/ipfs.io/destination.txt')
   })
 
-  it('should not scope src path if it is valid /ipfs/ path for files.cp', async () => {
+  // array-wrapping is deprecated, but we support it until removed from js-ipfs-api
+  it('should not scope array-wrapped src path if it is valid /ipfs/ path for files.cp', async () => {
     // Bug B from https://github.com/ipfs-shipyard/ipfs-companion/issues/530#issue-341352979
     const fnName = 'files.cp'
     const getScope = () => 'https://ipfs.io/'
@@ -78,7 +112,18 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     expect(args[0]).to.equal('/test-dapps/https/ipfs.io/path/to/file.md')
   })
 
-  it('should scope src/dest paths for files.mv', async () => {
+  // array-wrapping is deprecated, but we support it until removed from js-ipfs-api
+  it('should scope (src, dest) paths for files.mv', async () => {
+    const fnName = 'files.mv'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre('/source.txt', '/destination.txt')
+    expect(args[0]).to.equal('/test-dapps/https/ipfs.io/source.txt')
+    expect(args[1]).to.equal('/test-dapps/https/ipfs.io/destination.txt')
+  })
+
+  it('should scope ([src, dest]) paths for files.mv', async () => {
     const fnName = 'files.mv'
     const getScope = () => 'https://ipfs.io/'
     const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })

--- a/test/functional/lib/ipfs-proxy/pre-mfs-scope.test.js
+++ b/test/functional/lib/ipfs-proxy/pre-mfs-scope.test.js
@@ -33,7 +33,7 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     expect(args[2]).to.equal('/test-dapps/https/ipfs.io/destinationDir')
   })
 
-  it('should not scope src path if it is valid /ipfs/ path for files.cp', async () => {
+  it('should not scope src path if it is a valid /ipfs/ path for files.cp', async () => {
     // Bug B from https://github.com/ipfs-shipyard/ipfs-companion/issues/530#issue-341352979
     const fnName = 'files.cp'
     const getScope = () => 'https://ipfs.io/'
@@ -42,6 +42,17 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     const args = await pre('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', '/destination.jpg')
     expect(args[0]).to.equal('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
     expect(args[1]).to.equal('/test-dapps/https/ipfs.io/destination.jpg')
+  })
+
+  it('should scope dest path even if it is a valid /ipfs/ path for files.cp', async () => {
+    // https://github.com/ipfs-shipyard/ipfs-companion/pull/531#pullrequestreview-139053285
+    const fnName = 'files.cp'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', '/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+    expect(args[0]).to.equal('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+    expect(args[1]).to.equal('/test-dapps/https/ipfs.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
   })
 
   // array-wrapping is deprecated, but we support it until removed from js-ipfs-api
@@ -65,6 +76,18 @@ describe('lib/ipfs-proxy/pre-mfs-scope', () => {
     const args = await pre(['/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', '/destination.jpg'])
     expect(args[0][0]).to.equal('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
     expect(args[0][1]).to.equal('/test-dapps/https/ipfs.io/destination.jpg')
+  })
+
+  // array-wrapping is deprecated, but we support it until removed from js-ipfs-api
+  it('should scope array-wrapped dest path even if it is a valid /ipfs/ path for files.cp', async () => {
+    // https://github.com/ipfs-shipyard/ipfs-companion/pull/531#pullrequestreview-139053285
+    const fnName = 'files.cp'
+    const getScope = () => 'https://ipfs.io/'
+    const getIpfs = () => ({ files: { mkdir: () => Promise.resolve() } })
+    const pre = createPreMfsScope(fnName, getScope, getIpfs, '/test-dapps')
+    const args = await pre(['/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', '/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy'])
+    expect(args[0][0]).to.equal('/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
+    expect(args[0][1]).to.equal('/test-dapps/https/ipfs.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
   })
 
   it('should scope src path for files.mkdir', async () => {


### PR DESCRIPTION
See #530 for full background.

- [x] https://github.com/ipfs-shipyard/ipfs-companion/commit/e16709c6b38ab7c2d93acff6159877a8c3f7d509 fixes bug B from  https://github.com/ipfs-shipyard/ipfs-companion/issues/530
- [x] https://github.com/ipfs-shipyard/ipfs-companion/pull/531/commits/109565fe0c187b72de45c4039e8d4c44367f04ad fixes  bug A and adds deprecation warning for array-wrapped src,dest arguments