### PR TITLE
feat: copy current IPFS path for IPNS address

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -71,6 +71,10 @@
     "message": "Copy Public Gateway URL",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPublicGwUrl)"
   },
+  "panel_copyResolveIpns": {
+    "message": "Copy IPNS Resolved to IPFS",
+    "description": "A menu item in Browser Action pop-up (panel_copyResolveIpns)"
+  },
   "pageAction_titleIpfsAtPublicGateway": {
     "message": "IPFS resource loaded via Public Gateway",
     "description": "A tooltip displayed over Page Action in location bar (pageAction_titleIpfsAtPublicGateway)"
@@ -106,6 +110,10 @@
   "notify_copiedCanonicalAddressTitle": {
     "message": "Copied Canonical Address",
     "description": "A title of system notification (notify_copiedCanonicalAddressTitle)"
+  },
+  "notify_copiedResolvedIpns": {
+    "message": "Copied Resolved IPFS Address",
+    "description": "A title of system notification (notify_copiedResolvedIpns)"
   },
   "notify_pinnedIpfsResourceTitle": {
     "message": "IPFS Resource is now pinned",

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -35,21 +35,30 @@ async function copyTextToClipboard (copyText) {
 }
 
 function createCopier (getState, notify) {
+  const copy = (text, notificationTitle) => {
+    copyTextToClipboard(text)
+    if (notify && notificationTitle) {
+      notify(notificationTitle, text)
+    }
+  }
   return {
     async copyCanonicalAddress (context) {
       const url = await findUrlForContext(context)
       const rawIpfsAddress = safeIpfsPath(url)
-      copyTextToClipboard(rawIpfsAddress)
-      notify('notify_copiedCanonicalAddressTitle', rawIpfsAddress)
+      copy(rawIpfsAddress, 'notify_copiedCanonicalAddressTitle')
     },
 
     async copyAddressAtPublicGw (context) {
       const url = await findUrlForContext(context)
       const state = getState()
       const urlAtPubGw = url.replace(state.gwURLString, state.pubGwURLString)
-      copyTextToClipboard(urlAtPubGw)
-      notify('notify_copiedPublicURLTitle', urlAtPubGw)
+      copy(urlAtPubGw, 'notify_copiedPublicURLTitle')
+    },
+
+    async copy (text, notificationTitle) {
+      copy(text, notificationTitle)
     }
+
   }
 }
 

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -189,7 +189,8 @@ module.exports = async function init () {
   const BrowserActionMessageHandlers = {
     notification: (message) => notify(message.title, message.message),
     copyCanonicalAddress: () => copier.copyCanonicalAddress(),
-    copyAddressAtPublicGw: () => copier.copyAddressAtPublicGw()
+    copyAddressAtPublicGw: () => copier.copyAddressAtPublicGw(),
+    copyResolvedIpnsAddress: (message) => copier.copy(message.text, 'notify_copiedResolvedIpns')
   }
 
   function handleMessageFromBrowserAction (message) {

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -10,6 +10,18 @@ function safeIpfsPath (urlOrPath) {
 
 exports.safeIpfsPath = safeIpfsPath
 
+async function resolveIpfsPath (ipfs, urlOrPath) {
+  const path = safeIpfsPath(urlOrPath) // https://github.com/ipfs/ipfs-companion/issues/303
+  if (/^\/ipns/.test(path)) {
+    const response = await ipfs.name.resolve(path, {recursive: true, nocache: false})
+    // old versions of API used object with Path field
+    return response.Path ? response.Path : response
+  }
+  return path
+}
+
+exports.resolveIpfsPath = resolveIpfsPath
+
 function urlAtPublicGw (path, pubGwUrl) {
   return new URL(`${pubGwUrl}${path}`).toString().replace(/([^:]\/)\/+/g, '$1')
 }

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -9,6 +9,7 @@ module.exports = function contextActions ({
   active,
   ipfsNodeType,
   isIpfsContext,
+  isIpnsContext,
   isPinning,
   isUnPinning,
   isPinned,
@@ -17,10 +18,12 @@ module.exports = function contextActions ({
   onCopyIpfsAddr,
   onCopyPublicGwAddr,
   onPin,
-  onUnPin
+  onUnPin,
+  onCopyResolvedIpnsAddr
 }) {
   if (!isIpfsContext) return null
   const activePinControls = active && isIpfsOnline && isApiAvailable && !(isPinning || isUnPinning)
+  const activeIpnsResolver = active && isIpfsOnline && isApiAvailable
   return html`
     <div class='fade-in pv1'>
       ${navItem({
@@ -31,6 +34,13 @@ module.exports = function contextActions ({
         text: browser.i18n.getMessage('panel_copyCurrentPublicGwUrl'),
         onClick: onCopyPublicGwAddr
       })}
+      ${isIpnsContext ? (
+        navItem({
+          text: browser.i18n.getMessage('panel_copyResolveIpns'),
+          disabled: !activeIpnsResolver,
+          onClick: onCopyResolvedIpnsAddr
+        })
+      ) : null}
       ${!isPinned ? (
         navItem({
           text: browser.i18n.getMessage('panel_pinCurrentIpfsAddress'),

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -14,6 +14,7 @@ module.exports = function browserActionPage (state, emit) {
   const onCopyPublicGwAddr = () => emit('copyPublicGwAddr')
   const onPin = () => emit('pin')
   const onUnPin = () => emit('unPin')
+  const onCopyResolvedIpnsAddr = () => emit('copyResolvedIpnsAddr')
 
   const onQuickUpload = () => emit('quickUpload')
   const onOpenWebUi = () => emit('openWebUi')
@@ -23,7 +24,7 @@ module.exports = function browserActionPage (state, emit) {
   const onToggleActive = () => emit('toggleActive')
 
   const headerProps = Object.assign({ onToggleNodeType, onToggleActive, onOpenPrefs }, state)
-  const contextActionsProps = Object.assign({ onCopyIpfsAddr, onCopyPublicGwAddr, onPin, onUnPin }, state)
+  const contextActionsProps = Object.assign({ onCopyIpfsAddr, onCopyPublicGwAddr, onPin, onUnPin, onCopyResolvedIpnsAddr }, state)
   const opsProps = Object.assign({ onQuickUpload, onOpenWebUi, onToggleRedirect }, state)
 
   return html`

--- a/add-on/src/popup/page-action/page.js
+++ b/add-on/src/popup/page-action/page.js
@@ -11,9 +11,10 @@ const contextActions = require('../browser-action/context-actions')
 module.exports = function pageActionPage (state, emit) {
   const onCopyIpfsAddr = () => emit('copyIpfsAddr')
   const onCopyPublicGwAddr = () => emit('copyPublicGwAddr')
+  const onCopyResolvedIpnsAddr = () => emit('copyResolvedIpnsAddr')
   const onPin = () => emit('pin')
   const onUnPin = () => emit('unPin')
-  const contextActionsProps = Object.assign({ onCopyIpfsAddr, onCopyPublicGwAddr, onPin, onUnPin }, state)
+  const contextActionsProps = Object.assign({ onCopyIpfsAddr, onCopyPublicGwAddr, onCopyResolvedIpnsAddr, onPin, onUnPin }, state)
 
   // Instant init: page-action is shown only in ipfsContext
   contextActionsProps.isIpfsContext = true


### PR DESCRIPTION
This PR implements context menu item to get  current CID for an IPNS address: 

![screenshot_6](https://user-images.githubusercontent.com/157609/42765974-88384f54-8919-11e8-8417-283d8a9ae8b2.png)

Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/508

I am quite sure this needs to be reworded before merging. 

@olizilla  Any ideas how to label this feature? 