### PR TITLE
fix(linkify): do not wrap / ignore false-positives

### DIFF
--- a/add-on/src/contentScripts/linkifyDOM.js
+++ b/add-on/src/contentScripts/linkifyDOM.js
@@ -170,13 +170,13 @@ const PQueue = require('p-queue')
 
     while ((match = urlRE.exec(txt))) {
       link = await textToIpfsResource(match)
-      const textChunk = document.createTextNode(match[0])
-      if (span == null) {
-        // Create a span to hold the new text with links in it.
-        span = document.createElement('span')
-        span.className = 'linkifiedIpfsAddress'
-      }
       if (link) {
+        const textChunk = document.createTextNode(match[0])
+        if (span == null) {
+          // Create a span to hold the new text with links in it.
+          span = document.createElement('span')
+          span.className = 'linkifiedIpfsAddress'
+        }
         // put in text up to the link
         span.appendChild(document.createTextNode(txt.substring(point, match.index)))
         // create a link and put it in the span
@@ -185,13 +185,10 @@ const PQueue = require('p-queue')
         a.setAttribute('href', link)
         a.appendChild(textChunk)
         span.appendChild(a)
-      } else {
-        // wrap text in span to exclude it from future processing
-        span.appendChild(textChunk)
+        // track insertion point
+        const replaceLength = match[0].length
+        point = match.index + replaceLength
       }
-      // track insertion point
-      const replaceLength = match[0].length
-      point = match.index + replaceLength
     }
     if (span && node.parentNode) {
       try {


### PR DESCRIPTION
For historical reasons Linkify was wrapping false-positives (things that look like /ipfs/ paths  but have invalid CID) in `<span class..>` to ignore them in future. 
This behavior breaks some snippets, as noted in #539.
Good news is that since that was created, we've added IPFS validation lookup cache and `<span>` is no longer necessary.  

Note to self: in the long run we'll need e2e integration tests that run content script against sample page in a real browser.

Closes #539  (including https://github.com/ipfs-shipyard/ipfs-companion/issues/539#issuecomment-407938115)
