### PR TITLE
fix: pinning of IPNS paths

### DIFF
--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -277,7 +277,8 @@ async function resolveToIPFS (ipfs, urlOrPath) {
   let path = safeIpfsPath(urlOrPath) // https://github.com/ipfs/ipfs-companion/issues/303
   if (/^\/ipns/.test(path)) {
     const response = await ipfs.name.resolve(path, {recursive: true, nocache: false})
-    return response.Path
+    // old API returned object, latest one returns string ¯\_(ツ)_/¯
+    return response.Path ? response.Path : response
   }
   return path
 }


### PR DESCRIPTION
In past `ipfs.name.resolve` returned object with `Path` field, right now it returns a path as a string.

Closes #542 
