### PR TITLE
fix: drag & drop uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "dependencies": {
     "choo": "6.13.0",
     "doc-sniff": "1.0.1",
+    "drag-and-drop-files": "0.0.1",
     "file-type": "8.1.0",
     "filereader-pull-stream": "1.0.0",
     "filesize": "3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,6 +2778,10 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+drag-and-drop-files@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/drag-and-drop-files/-/drag-and-drop-files-0.0.1.tgz#adcb1dd0e9d01d510da8131909e47c43e05c3c02"
+
 drbg.js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"


### PR DESCRIPTION
This PR restores drag&drop support and closes #549.
(Looks like it got removed during one of refactorings)

- directory upload is not possible at this time, we detect it and display error message instead
- empty file without extension looks the same as empty directory, so the error accounts for that possibility
- account for edge cases where the source of dragged object is not valid, which results in drag&drop event with empty file list

# Demo

![drag-and-drop-demo](https://user-images.githubusercontent.com/157609/43724124-88ec5cc0-9999-11e8-9f1d-a083d4486966.gif)

# Interop tests

- [ ] @olizilla  – would appreciate drag&drop smoke-test under Mac
- [x] @hacdias   – would appreciate drag&drop smoke-test under Windows 