### PR TITLE
Improved logger

### DIFF
--- a/add-on/src/lib/ipfs-client/embedded.js
+++ b/add-on/src/lib/ipfs-client/embedded.js
@@ -2,11 +2,12 @@
 
 const Ipfs = require('ipfs')
 const { optionDefaults } = require('../options')
+const log = require('../log')('api:embedded')
 
 let node = null
 
 exports.init = function init (opts) {
-  console.log('[ipfs-companion] Embedded ipfs init')
+  log('IPFS init using embedded js-ipfs')
 
   node = new Ipfs(
     JSON.parse(opts.ipfsNodeConfig || optionDefaults.ipfsNodeConfig)
@@ -24,7 +25,7 @@ exports.init = function init (opts) {
 }
 
 exports.destroy = async function () {
-  console.log('[ipfs-companion] Embedded ipfs destroy')
+  log('js-ipfs node destroy')
   if (!node) return
 
   await node.stop()

--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -2,9 +2,10 @@
 /* eslint-env browser */
 
 const IpfsApi = require('ipfs-api')
+const log = require('../log')('api:external')
 
 exports.init = async function (opts) {
-  console.log('[ipfs-companion] External ipfs init', opts.apiURLString)
+  log('IPFS init using API at %s', opts.apiURLString)
 
   const url = opts.apiURL
   const api = IpfsApi({host: url.hostname, port: url.port, procotol: url.protocol})
@@ -12,7 +13,7 @@ exports.init = async function (opts) {
 }
 
 exports.destroy = async function () {
-  console.log('[ipfs-companion] External ipfs destroy')
+  log('IPFS API client destroy')
 }
 
 // TODO: Upgrade to a caching proxy for ipfs-api

--- a/add-on/src/lib/log.js
+++ b/add-on/src/lib/log.js
@@ -1,0 +1,14 @@
+const root = 'ipfs-companion'
+
+const debug = require('debug')
+
+module.exports = (loggerName) => {
+  const log = debug(`${root}:${loggerName}`)
+  log.debug = debug(`${log.namespace}:debug`)
+  log.error = debug(`${log.namespace}:error`)
+
+  log.color = '#0b3a53'
+  log.debug.color = '#7f8491'
+  log.error.color = '#ea5037'
+  return log
+}

--- a/add-on/src/lib/please-wait.js
+++ b/add-on/src/lib/please-wait.js
@@ -1,0 +1,10 @@
+const messages = [
+  'Adding Randomly Mispeled Words Into Text',
+  'Creating Randomly Generated Feature',
+  'Doing Something You Don\'t Wanna Know About',
+  'Doing The Impossible',
+  'Don\'t Panic',
+  'Generating Plans for Faster-Than-Light Travel',
+  'Does Anyone Actually Read This?'
+]
+exports.pleaseWait = () => messages[Math.floor(Math.random() * messages.length)]

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "choo": "6.13.0",
+    "debug": "https://github.com/visionmedia/debug/tarball/207a6a2d53507ec9dd57c94c46cc7d3dd272306d/debug.tar.gz",
     "doc-sniff": "1.0.1",
     "drag-and-drop-files": "0.0.1",
     "file-type": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2654,11 +2654,11 @@ debug@2, debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, de
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@^3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@^3.1.0, "debug@https://github.com/visionmedia/debug/tarball/207a6a2d53507ec9dd57c94c46cc7d3dd272306d/debug.tar.gz", debug@~3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  resolved "https://github.com/visionmedia/debug/tarball/207a6a2d53507ec9dd57c94c46cc7d3dd272306d/debug.tar.gz#1f55c7ea8093a60532f82b9caf51b819447f556f"
   dependencies:
-    ms "2.0.0"
+    ms "^2.1.1"
 
 decamelize-keys@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This PR tries to address the problem of noisy console logs in tests  and a chore of adding debug ones during development.

- switched from `console.log` to [debug](https://www.npmjs.com/package/debug) 
- light convention of default, debug and error loggers 
- hardcoded different color for each logger type
- ability to customize debug level of other ipfs packages using `debug` library via `localStorage.debug`
  - can be changed [here](https://github.com/ipfs-shipyard/ipfs-companion/compare/improved-logger?expand=1#diff-170909c5725b3676d266c4f14d69aba5R19) but  we could expose this on the _Preferences_ screen (either as input or checkbox to enable debug logger) to help users and developers in troubleshooting

### Known Issues / Open Questions

- [ ] `debug`  v3.1.0 does not work correctly in webextension context.
It was fixed in https://github.com/visionmedia/debug/pull/476 but not released yet, so this PR uses specific git revision instead of npm release.

This is just an initial stab to see how it could work. 

cc @alanshaw, @olizilla   Do we have already established logging conventions in other JS projects that should be applied here? Personal opinions are also useful  :)