### PR TITLE
Workaround for 'invalid Read on closed Body' in files.add (webext in Chrome)

### DIFF
--- a/test/functional/lib/ipfs-request-workarounds.test.js
+++ b/test/functional/lib/ipfs-request-workarounds.test.js
@@ -1,0 +1,64 @@
+'use strict'
+const { describe, it, before, beforeEach, after } = require('mocha')
+const { expect } = require('chai')
+const { URL } = require('url')
+const browser = require('sinon-chrome')
+const { initState } = require('../../../add-on/src/lib/state')
+const createRuntimeChecks = require('../../../add-on/src/lib/runtime-checks')
+const { createRequestModifier } = require('../../../add-on/src/lib/ipfs-request')
+const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
+const { createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
+const { optionDefaults } = require('../../../add-on/src/lib/options')
+
+// const nodeTypes = ['external', 'embedded']
+
+describe('modifyRequest processing', function () {
+  let state, dnslinkResolver, ipfsPathValidator, modifyRequest, runtime
+
+  before(function () {
+    global.URL = URL
+    global.browser = browser
+  })
+
+  beforeEach(async function () {
+    state = initState(optionDefaults)
+    const getState = () => state
+    dnslinkResolver = createDnslinkResolver(getState)
+    runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
+    ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
+    modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
+  })
+
+  describe('a request to <apiURL>/api/v0/add with stream-channels=true', function () {
+    const expectHeader = { name: 'Expect', value: '100-continue' }
+    it('should apply the "Expect: 100-continue" fix for https://github.com/ipfs/go-ipfs/issues/5168 ', function () {
+      const request = {
+        method: 'POST',
+        requestHeaders: [
+          { name: 'Content-Type', value: 'multipart/form-data; boundary=--------------------------015695779813832455524979' }
+        ],
+        type: 'xmlhttprequest',
+        url: `${state.apiURLString}api/v0/add?progress=true&wrapWithDirectory=true&pin=true&wrap-with-directory=true&stream-channels=true`
+      }
+      expect(modifyRequest.onBeforeSendHeaders(request).requestHeaders).to.deep.include(expectHeader)
+    })
+  })
+
+  describe('a request to <apiURL>/api/v0/ with Origin=null', function () {
+    it('should remove Origin header ', function () {
+      const bogusOriginHeader = { name: 'Origin', value: 'null' }
+      const request = {
+        requestHeaders: [ bogusOriginHeader ],
+        type: 'xmlhttprequest',
+        url: `${state.apiURLString}api/v0/id`
+      }
+      expect(modifyRequest.onBeforeSendHeaders(request).requestHeaders).to.not.include(bogusOriginHeader)
+    })
+  })
+
+  after(function () {
+    delete global.URL
+    delete global.browser
+    browser.flush()
+  })
+})


### PR DESCRIPTION
> Chrome does allow setting `Expect` via [`onBeforeSendHeaders`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders) WebExtension API

This means we now have a workaround for https://github.com/ipfs-shipyard/ipfs-companion/issues/480 that works in both Firefox and Chromium.

Details: https://github.com/ipfs-shipyard/ipfs-companion/issues/480#issuecomment-417657758 & https://github.com/ipfs/go-ipfs/issues/5168#issuecomment-417112652

Closes #480 