### PR TITLE
fix: support gateway at localhost:80

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 const { optionDefaults, storeMissingOptions, migrateOptions } = require('./options')
 const { initState, offlinePeerCount } = require('./state')
-const { createIpfsPathValidator, urlAtPublicGw } = require('./ipfs-path')
+const { createIpfsPathValidator, pathAtHttpGateway } = require('./ipfs-path')
 const createDnslinkResolver = require('./dnslink')
 const { createRequestModifier, redirectOptOutHint } = require('./ipfs-request')
 const { initIpfsClient, destroyIpfsClient } = require('./ipfs-client')
@@ -165,7 +165,7 @@ module.exports = async function init () {
     // console.log((sender.tab ? 'Message from a content script:' + sender.tab.url : 'Message from the extension'), request)
     if (request.pubGwUrlForIpfsOrIpnsPath) {
       const path = request.pubGwUrlForIpfsOrIpnsPath
-      const result = ipfsPathValidator.validIpfsOrIpnsPath(path) ? urlAtPublicGw(path, state.pubGwURLString) : null
+      const result = ipfsPathValidator.validIpfsOrIpnsPath(path) ? pathAtHttpGateway(path, state.pubGwURLString) : null
       return Promise.resolve({ pubGwUrlForIpfsOrIpnsPath: result })
     }
   }
@@ -237,7 +237,7 @@ module.exports = async function init () {
     return new Promise((resolve, reject) => {
       const http = new XMLHttpRequest()
       // Make sure preload request is excluded from global redirect
-      const preloadUrl = urlAtPublicGw(`${path}#${redirectOptOutHint}`, state.pubGwURLString)
+      const preloadUrl = pathAtHttpGateway(`${path}#${redirectOptOutHint}`, state.pubGwURLString)
       http.open('HEAD', preloadUrl)
       http.onreadystatechange = function () {
         if (this.readyState === this.DONE) {
@@ -638,6 +638,10 @@ module.exports = async function init () {
   const api = {
     get ipfs () {
       return ipfs
+    },
+
+    get state () {
+      return state
     },
 
     get dnslinkResolver () {

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -11,8 +11,10 @@ function safeIpfsPath (urlOrPath) {
   return decodeURIComponent(urlOrPath.replace(/^.*(\/ip(f|n)s\/.+)$/, '$1'))
 }
 
-function subdomainToIpfsPath (urlString) {
-  const url = new URL(urlString)
+function subdomainToIpfsPath (url) {
+  if (typeof url === 'string') {
+    url = new URL(url)
+  }
   const fqdn = url.hostname.split('.')
   const cid = fqdn[0]
   const protocol = fqdn[1]
@@ -21,11 +23,12 @@ function subdomainToIpfsPath (urlString) {
 
 exports.safeIpfsPath = safeIpfsPath
 
-function urlAtPublicGw (path, pubGwUrl) {
-  return new URL(`${pubGwUrl}${path}`).toString().replace(/([^:]\/)\/+/g, '$1')
+function pathAtHttpGateway (path, gatewayUrl) {
+  // return URL without duplicated slashes
+  return new URL(`${gatewayUrl}${path}`).toString().replace(/([^:]\/)\/+/g, '$1')
 }
 
-exports.urlAtPublicGw = urlAtPublicGw
+exports.pathAtHttpGateway = pathAtHttpGateway
 
 function createIpfsPathValidator (getState, dnsLink) {
   const ipfsPathValidator = {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -51,12 +51,18 @@ exports.storeMissingOptions = (read, defaults, storage) => {
 }
 
 function normalizeGatewayURL (url) {
+  if (typeof url === 'string') {
+    url = new URL(url)
+  }
   // https://github.com/ipfs/ipfs-companion/issues/328
-  return url
-    .replace('/localhost:', '/127.0.0.1:')
+  if (url.hostname.toLowerCase() === 'localhost') {
+    url.hostname = '127.0.0.1'
+  }
+  // Return string without trailing slash
+  return url.toString().replace(/\/$/, '')
 }
-
 exports.normalizeGatewayURL = normalizeGatewayURL
+exports.safeURL = (url) => new URL(normalizeGatewayURL(url))
 
 exports.migrateOptions = async (storage) => {
   // <= v2.4.4

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -1,6 +1,7 @@
 'use strict'
 /* eslint-env browser, webextensions */
 
+const { safeURL } = require('./options')
 const offlinePeerCount = -1
 
 function initState (options) {
@@ -9,13 +10,17 @@ function initState (options) {
   const state = Object.assign({}, options)
   // generate some additional values
   state.peerCount = offlinePeerCount
-  state.pubGwURL = new URL(options.publicGatewayUrl)
+  state.pubGwURL = safeURL(options.publicGatewayUrl)
   state.pubGwURLString = state.pubGwURL.toString()
+  delete state.publicGatewayUrl
   state.redirect = options.useCustomGateway
-  state.apiURL = new URL(options.ipfsApiUrl)
+  delete state.useCustomGateway
+  state.apiURL = safeURL(options.ipfsApiUrl)
   state.apiURLString = state.apiURL.toString()
-  state.gwURL = new URL(options.customGatewayUrl)
+  delete state.ipfsApiUrl
+  state.gwURL = safeURL(options.customGatewayUrl)
   state.gwURLString = state.gwURL.toString()
+  delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
   return state
 }

--- a/add-on/src/options/forms/api-form.js
+++ b/add-on/src/options/forms/api-form.js
@@ -26,7 +26,7 @@ function apiForm ({ ipfsApiUrl, ipfsApiPollMs, automaticMode, onOptionChange }) 
             type="url"
             inputmode="url"
             required
-            pattern="^https?://[^/]+$"
+            pattern="^https?://[^/]+/?$"
             spellcheck="false"
             title="Enter URL without any sub-path"
             onchange=${onIpfsApiUrlChange}

--- a/add-on/src/options/forms/gateways-form.js
+++ b/add-on/src/options/forms/gateways-form.js
@@ -33,7 +33,7 @@ function gatewaysForm ({
                 type="url"
                 inputmode="url"
                 required
-                pattern="^https?://[^/]+$"
+                pattern="^https?://[^/]+/?$"
                 spellcheck="false"
                 title="Enter URL without any sub-path"
                 onchange=${onCustomGatewayUrlChange}
@@ -67,7 +67,7 @@ function gatewaysForm ({
             type="url"
             inputmode="url"
             required
-            pattern="^https?://[^/]+$"
+            pattern="^https?://[^/]+/?$"
             spellcheck="false"
             title="Enter URL without any sub-path"
             onchange=${onPublicGatewayUrlChange}

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -22,6 +22,9 @@ module.exports = function optionsPage (state, emit) {
     }
 
     emit('optionChange', { key, value: modifyValue ? modifyValue(value) : value })
+    if (modifyValue) {
+      emit('render')
+    }
   }
 
   const onOptionsReset = (e) => {

--- a/test/functional/lib/dnslink.test.js
+++ b/test/functional/lib/dnslink.test.js
@@ -7,6 +7,11 @@ const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
 const { initState } = require('../../../add-on/src/lib/state')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
 
+const testOptions = Object.assign({}, optionDefaults, {
+  customGatewayUrl: 'http://127.0.0.1:8080',
+  publicGatewayUrl: 'https://gateway.foobar.io'
+})
+
 function spoofDnsTxtRecord (fqdn, dnslinkResolver, value) {
   // pass 'false' to spoof "no DNS TXT record"
   value = String(value) === 'false' ? undefined : '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
@@ -24,26 +29,18 @@ describe('dnslinkResolver', function () {
     global.URL = URL
   })
 
-  const getState = () => Object.assign(initState(optionDefaults), {
-    gwURL: new URL('http://127.0.0.1:8080'),
-    pubGwURL: new URL('https://gateway.foobar.io'),
+  const getState = () => Object.assign(initState(testOptions), {
     peerCount: 1
   })
   const getExternalNodeState = () => Object.assign({}, getState(), { ipfsNodeType: 'external' })
-  const getEmbeddedNodeState = () => Object.assign({}, getState(), { ipfsNodeType: 'embedded' })
+  // const getEmbeddedNodeState = () => Object.assign({}, getState(), { ipfsNodeType: 'embedded' })
 
-  describe('convertToIpnsUrl(url)', function () {
-    it('should return IPNS path at a custom gateway when external API is used', function () {
+  describe('convertToIpnsPath(url)', function () {
+    it('should return IPNS path', function () {
       const url = new URL('http://ipfs.git.sexy/sketches/ipld_intro.html?a=b#c=d')
       const dnslinkResolver = createDnslinkResolver(getExternalNodeState)
-      expect(dnslinkResolver.convertToIpnsUrl(url))
-        .to.equal('http://127.0.0.1:8080/ipns/ipfs.git.sexy/sketches/ipld_intro.html?a=b#c=d')
-    })
-    it('should return IPNS path at a public gateway if embedded node is used', function () {
-      const url = new URL('http://ipfs.git.sexy/sketches/ipld_intro.html?a=b#c=d')
-      const dnslinkResolver = createDnslinkResolver(getEmbeddedNodeState)
-      expect(dnslinkResolver.convertToIpnsUrl(url))
-        .to.equal('https://gateway.foobar.io/ipns/ipfs.git.sexy/sketches/ipld_intro.html?a=b#c=d')
+      expect(dnslinkResolver.convertToIpnsPath(url))
+        .to.equal('/ipns/ipfs.git.sexy/sketches/ipld_intro.html?a=b#c=d')
     })
   })
 })
@@ -54,9 +51,7 @@ describe('dnslinkResolver (dnslinkPolicy=detectIpfsPathHeader)', function () {
     global.URL = URL
   })
 
-  const getState = () => Object.assign(initState(optionDefaults), {
-    gwURL: new URL('http://127.0.0.1:8080'),
-    pubGwURL: new URL('https://gateway.foobar.io'),
+  const getState = () => Object.assign(initState(testOptions), {
     ipfsNodeType: 'external',
     dnslinkPolicy: 'detectIpfsPathHeader',
     peerCount: 1
@@ -140,9 +135,7 @@ describe('dnslinkResolver (dnslinkPolicy=enabled)', function () {
     global.URL = URL
   })
 
-  const getState = () => Object.assign(initState(optionDefaults), {
-    gwURL: new URL('http://127.0.0.1:8080'),
-    pubGwURL: new URL('https://gateway.foobar.io'),
+  const getState = () => Object.assign(initState(testOptions), {
     ipfsNodeType: 'external',
     dnslinkPolicy: 'enabled',
     peerCount: 1

--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -37,7 +37,9 @@ describe('modifyRequest.onBeforeRequest:', function () {
       dnslinkPolicy: false, // dnslink testi suite is in ipfs-request-dnslink.test.js
       catchUnhandledProtocols: true,
       gwURLString: 'http://127.0.0.1:8080',
-      pubGwURLString: 'https://ipfs.io'
+      gwURL: new URL('http://127.0.0.1:8080'),
+      pubGwURLString: 'https://ipfs.io',
+      pubGwURL: new URL('https://ipfs.io')
     })
     const getState = () => state
     dnslinkResolver = createDnslinkResolver(getState)
@@ -265,6 +267,25 @@ describe('modifyRequest.onBeforeRequest:', function () {
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
       })
+    })
+  })
+
+  describe('request for IPFS Path with redirect to custom gateway at port 80', function () {
+    beforeEach(function () {
+      state.ipfsNodeType = 'external'
+      state.redirect = true
+    })
+    it('should work for HTTP GW without explicit port in URL', function () {
+      state.gwURLString = 'http://foo:80/'
+      state.gwURL = new URL(state.gwURLString)
+      const request = url2request('https://bar.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('http://foo/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should work for HTTPS GW without explicit port in URL', function () {
+      state.gwURLString = 'https://foo:443/'
+      state.gwURL = new URL(state.gwURLString)
+      const request = url2request('https://bar.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://foo/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
   })
 


### PR DESCRIPTION
1. Small cleanup of the way we construct destination URL:
  Previously URL was created by hand in multiple places,
  this change introduces `pathAtHttpGateway(path, gateway)`
  utility and reuses it in all those places.

2. As a result, It is now possible to set local gateway URL to http://localhost/ (Chrome will not mangle it into http://localhost:0/)
  Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/580

3. UX improvement: allow training slash in URL inputs on Preferences screen