### PR TITLE
Improvements for Adding to IPFS via Context Menu

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -87,16 +87,20 @@
     "message": "Add Selected Text to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsSelection)"
   },
-  "contextMenu_AddToIpfsRawCid": {
-    "message": "Add This Object to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsRawCid)"
+  "contextMenu_AddToIpfsImage": {
+    "message": "Add this Image to IPFS",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsImage)"
   },
-  "contextMenu_AddToIpfsKeepFilename": {
-    "message": "Add This Object to IPFS (Keep Filename)",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
+  "contextMenu_AddToIpfsVideo": {
+    "message": "Add this Video to IPFS",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsVideo)"
+  },
+  "contextMenu_AddToIpfsAudio": {
+    "message": "Add this Audio to IPFS",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsAudio)"
   },
   "contextMenu_AddToIpfsLink": {
-    "message": "Add This Link to IPFS",
+    "message": "Add Link Destination to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsLink)"
   },
   "notify_addonIssueTitle": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -64,12 +64,12 @@
     "description": "A menu item in Browser Action pop-up (panel_unpinCurrentIpfsAddress)"
   },
   "panelCopy_currentIpfsAddress": {
-    "message": "Copy Canonical Address",
+    "message": "Copy IPFS Path",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
-  "panelCopy_copyDirectCid": {
-    "message": "Copy Direct CID",
-    "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyDirectCid)"
+  "panelCopy_copyRawCid": {
+    "message": "Copy Resolved CID",
+    "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyRawCid)"
   },
   "panel_copyCurrentPublicGwUrl": {
     "message": "Copy Public Gateway URL",
@@ -87,25 +87,41 @@
     "message": "Non-IPFS resource",
     "description": "Default label for icon hidden in Page Action menu (pageAction_titleNonIpfs)"
   },
+  "contextMenu_parentImage": {
+    "message": "Selected Image",
+    "description": "An item in right-click context menu (contextMenu_parentImage)"
+  },
+  "contextMenu_parentVideo": {
+    "message": "Selected Video",
+    "description": "An item in right-click context menu (contextMenu_parentVideo)"
+  },
+  "contextMenu_parentAudio": {
+    "message": "Selected Audio",
+    "description": "An item in right-click context menu (contextMenu_parentAudio)"
+  },
+  "contextMenu_parentLink": {
+    "message": "Linked Content",
+    "description": "An item in right-click context menu (contextMenu_parentLink)"
+  },
+  "contextMenu_parentText": {
+    "message": "Selected Text",
+    "description": "An item in right-click context menu (contextMenu_parentText)"
+  },
+  "contextMenu_parentPage": {
+    "message": "This Page",
+    "description": "An item in right-click context menu (contextMenu_parentPage)"
+  },
+  "contextMenu_AddToIpfsKeepFilename": {
+    "message": "Add to IPFS (Keep Filename)",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
+  },
+  "contextMenu_AddToIpfsRawCid": {
+    "message": "Add to IPFS (Raw CID)",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsRawCid)"
+  },
   "contextMenu_AddToIpfsSelection": {
     "message": "Add Selected Text to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsSelection)"
-  },
-  "contextMenu_AddToIpfsImage": {
-    "message": "Add this Image to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsImage)"
-  },
-  "contextMenu_AddToIpfsVideo": {
-    "message": "Add this Video to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsVideo)"
-  },
-  "contextMenu_AddToIpfsAudio": {
-    "message": "Add this Audio to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsAudio)"
-  },
-  "contextMenu_AddToIpfsLink": {
-    "message": "Add Linked Content to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsLink)"
   },
   "notify_addonIssueTitle": {
     "message": "IPFS Add-on Issue",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -67,6 +67,10 @@
     "message": "Copy Canonical Address",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
+  "panelCopy_copyDirectCid": {
+    "message": "Copy Direct CID",
+    "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyDirectCid)"
+  },
   "panel_copyCurrentPublicGwUrl": {
     "message": "Copy Public Gateway URL",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPublicGwUrl)"
@@ -111,13 +115,9 @@
     "message": "See Browser Console for more details",
     "description": "A message in system notification (notify_addonIssueMsg)"
   },
-  "notify_copiedPublicURLTitle": {
-    "message": "Copied Public URL",
-    "description": "A title of system notification (notify_copiedPublicURLTitle)"
-  },
-  "notify_copiedCanonicalAddressTitle": {
-    "message": "Copied Canonical Address",
-    "description": "A title of system notification (notify_copiedCanonicalAddressTitle)"
+  "notify_copiedTitle": {
+    "message": "Copied",
+    "description": "A title of system notification (notify_copiedTitle)"
   },
   "notify_pinnedIpfsResourceTitle": {
     "message": "IPFS Resource is now pinned",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -84,16 +84,20 @@
     "description": "Default label for icon hidden in Page Action menu (pageAction_titleNonIpfs)"
   },
   "contextMenu_AddToIpfsSelection": {
-    "message": "Add selected text to IPFS",
+    "message": "Add Selected Text to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsSelection)"
   },
   "contextMenu_AddToIpfsRawCid": {
-    "message": "Add to IPFS",
+    "message": "Add This Object to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsRawCid)"
   },
   "contextMenu_AddToIpfsKeepFilename": {
-    "message": "Add to IPFS (Keep Filename)",
+    "message": "Add This Object to IPFS (Keep Filename)",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
+  },
+  "contextMenu_AddToIpfsLink": {
+    "message": "Add This Link to IPFS",
+    "description": "An item in right-click context menu (contextMenu_AddToIpfsLink)"
   },
   "notify_addonIssueTitle": {
     "message": "IPFS Add-on Issue",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -100,7 +100,7 @@
     "description": "An item in right-click context menu (contextMenu_AddToIpfsAudio)"
   },
   "contextMenu_AddToIpfsLink": {
-    "message": "Add Link Destination to IPFS",
+    "message": "Add Linked Content to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsLink)"
   },
   "notify_addonIssueTitle": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -112,7 +112,7 @@
     "description": "An item in right-click context menu (contextMenu_parentPage)"
   },
   "contextMenu_AddToIpfsKeepFilename": {
-    "message": "Add to IPFS with Filename",
+    "message": "Add to IPFS (Keep Filename)",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
   },
   "contextMenu_AddToIpfsRawCid": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -68,7 +68,7 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
   "panelCopy_copyRawCid": {
-    "message": "Copy Resolved CID",
+    "message": "Copy CID",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyRawCid)"
   },
   "panel_copyCurrentPublicGwUrl": {
@@ -112,11 +112,11 @@
     "description": "An item in right-click context menu (contextMenu_parentPage)"
   },
   "contextMenu_AddToIpfsKeepFilename": {
-    "message": "Add to IPFS (Keep Filename)",
+    "message": "Add to IPFS with Filename",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
   },
   "contextMenu_AddToIpfsRawCid": {
-    "message": "Add to IPFS (Raw CID)",
+    "message": "Add to IPFS",
     "description": "An item in right-click context menu (contextMenu_AddToIpfsRawCid)"
   },
   "contextMenu_AddToIpfsSelection": {

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -2,10 +2,23 @@
 
 const browser = require('webextension-polyfill')
 
-async function findUrlForContext (context, contextField) {
+// mapping between context name and field with data for it
+// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/ContextType
+const contextSources = {
+  selection: 'selectionText',
+  image: 'srcUrl',
+  video: 'srcUrl',
+  audio: 'srcUrl',
+  link: 'linkUrl',
+  page: 'pageUrl'
+}
+
+async function findValueForContext (context, contextType) {
   if (context) {
-    if (contextField) {
-      return context[contextField]
+    console.log(context)
+    if (contextType) {
+      const field = contextSources[contextType]
+      return context[field]
     }
     if (context.srcUrl) {
       // present when clicked on page element such as image or video
@@ -25,69 +38,110 @@ async function findUrlForContext (context, contextField) {
   return currentTab.url
 }
 
-module.exports.findUrlForContext = findUrlForContext
+module.exports.findValueForContext = findValueForContext
 
+// Context Roots
+const menuParentImage = 'contextMenu_parentImage'
+const menuParentVideo = 'contextMenu_parentVideo'
+const menuParentAudio = 'contextMenu_parentAudio'
+const menuParentLink = 'contextMenu_parentLink'
+const menuParentPage = 'contextMenu_parentPage'
+// const menuParentText = 'contextMenu_parentText'
+// Generic Add to IPFS
+const contextMenuAddToIpfsRawCid = 'contextMenu_AddToIpfsRawCid'
+const contextMenuAddToIpfsKeepFilename = 'contextMenu_AddToIpfsKeepFilename'
 // Add X to IPFS
 const contextMenuAddToIpfsSelection = 'contextMenu_AddToIpfsSelection'
-const contextMenuAddToIpfsImage = 'contextMenu_AddToIpfsImage'
-const contextMenuAddToIpfsVideo = 'contextMenu_AddToIpfsVideo'
-const contextMenuAddToIpfsAudio = 'contextMenu_AddToIpfsAudio'
-const contextMenuAddToIpfsLink = 'contextMenu_AddToIpfsLink'
 // Copy X
 const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpfsAddress'
-const contextMenuCopyDirectCid = 'panelCopy_copyDirectCid'
+const contextMenuCopyRawCid = 'panelCopy_copyRawCid'
 const contextMenuCopyAddressAtPublicGw = 'panel_copyCurrentPublicGwUrl'
 module.exports.contextMenuCopyCanonicalAddress = contextMenuCopyCanonicalAddress
-module.exports.contextMenuCopyDirectCid = contextMenuCopyDirectCid
+module.exports.contextMenuCopyRawCid = contextMenuCopyRawCid
 module.exports.contextMenuCopyAddressAtPublicGw = contextMenuCopyAddressAtPublicGw
 
 // menu items that are enabled only when API is online
-const apiMenuItems = [
-  contextMenuAddToIpfsSelection,
-  contextMenuAddToIpfsImage,
-  contextMenuAddToIpfsVideo,
-  contextMenuAddToIpfsAudio,
-  contextMenuAddToIpfsLink,
-  contextMenuCopyDirectCid
-]
+const apiMenuItems = new Set()
+// menu items enabled only in IPFS context
+const ipfsContextItems = new Set()
 
-function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromContext, onCopyCanonicalAddress, onCopyDirectCid, onCopyAddressAtPublicGw }) {
-  let copyAddressContexts = ['page', 'image', 'video', 'audio', 'link']
-  if (runtime.isFirefox) {
-    // https://github.com/ipfs-shipyard/ipfs-companion/issues/398
-    copyAddressContexts.push('page_action')
-  }
+function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromContext, onCopyCanonicalAddress, onCopyRawCid, onCopyAddressAtPublicGw }) {
   try {
-    const createAddToIpfsMenuItem = (menuItemId, contextName, contextField, ipfsAddOptions) => {
+    const createSubmenu = (id, contextType, menuBuilder) => {
       browser.contextMenus.create({
-        id: menuItemId,
-        title: browser.i18n.getMessage(menuItemId),
-        contexts: [contextName],
+        id,
+        title: browser.i18n.getMessage(id),
+        documentUrlPatterns: ['<all_urls>'],
+        contexts: [contextType]
+      })
+    }
+    const createSeparator = (parentId, id, contextType) => {
+      return browser.contextMenus.create({
+        id: `${parentId}_${id}`,
+        parentId,
+        type: 'separator',
+        contexts: ['all']
+      })
+    }
+    const createAddToIpfsMenuItem = (parentId, id, contextType, ipfsAddOptions) => {
+      const itemId = `${parentId}_${id}`
+      apiMenuItems.add(itemId)
+      return browser.contextMenus.create({
+        id: itemId,
+        parentId,
+        title: browser.i18n.getMessage(id),
+        contexts: [contextType],
         documentUrlPatterns: ['<all_urls>'],
         enabled: false,
-        onclick: (context) => onAddFromContext(context, contextField, ipfsAddOptions)
+        /* no support for 'icons' in Chrome
+        icons: {
+          '48': '/ui-kit/icons/stroke_cube.svg'
+        },*/
+        onclick: (context) => onAddFromContext(context, contextType, ipfsAddOptions)
       })
     }
-    createAddToIpfsMenuItem(contextMenuAddToIpfsSelection, 'selection', 'selectionText')
-    createAddToIpfsMenuItem(contextMenuAddToIpfsImage, 'image', 'srcUrl', { wrapWithDirectory: true })
-    createAddToIpfsMenuItem(contextMenuAddToIpfsVideo, 'video', 'srcUrl', { wrapWithDirectory: true })
-    createAddToIpfsMenuItem(contextMenuAddToIpfsAudio, 'audio', 'srcUrl', { wrapWithDirectory: true })
-    createAddToIpfsMenuItem(contextMenuAddToIpfsLink, 'link', 'linkUrl', { wrapWithDirectory: true })
-
-    const createCopierMenuItem = (menuItemId, handler) => {
-      browser.contextMenus.create({
-        id: menuItemId,
-        title: browser.i18n.getMessage(menuItemId),
-        contexts: copyAddressContexts,
+    const createCopierMenuItem = (parentId, id, contextType, handler) => {
+      const itemId = `${parentId}_${id}`
+      ipfsContextItems.add(itemId)
+      // some items also require API access
+      if (id === contextMenuCopyRawCid) {
+        apiMenuItems.add(itemId)
+      }
+      return browser.contextMenus.create({
+        id: itemId,
+        parentId,
+        title: browser.i18n.getMessage(id),
+        contexts: [contextType],
         documentUrlPatterns: ['*://*/ipfs/*', '*://*/ipns/*'],
-        onclick: handler
+        /* no support for 'icons' in Chrome
+        icons: {
+          '48': '/ui-kit/icons/stroke_copy.svg'
+        },*/
+        onclick: (context) => handler(context, contextType)
       })
     }
-    createCopierMenuItem(contextMenuCopyCanonicalAddress, onCopyCanonicalAddress)
-    createCopierMenuItem(contextMenuCopyDirectCid, onCopyDirectCid)
-    createCopierMenuItem(contextMenuCopyAddressAtPublicGw, onCopyAddressAtPublicGw)
+    const buildSubmenu = (parentId, contextType) => {
+      createSubmenu(parentId, contextType)
+      createAddToIpfsMenuItem(parentId, contextMenuAddToIpfsKeepFilename, contextType, { wrapWithDirectory: true })
+      createAddToIpfsMenuItem(parentId, contextMenuAddToIpfsRawCid, contextType, { wrapWithDirectory: false })
+      createSeparator(parentId, 'separator-1', contextType)
+      createCopierMenuItem(parentId, contextMenuCopyCanonicalAddress, contextType, onCopyCanonicalAddress)
+      createCopierMenuItem(parentId, contextMenuCopyRawCid, contextType, onCopyRawCid)
+      createCopierMenuItem(parentId, contextMenuCopyAddressAtPublicGw, contextType, onCopyAddressAtPublicGw)
+    }
+
+    /*
+    createSubmenu(menuParentText, 'selection')
+    createAddToIpfsMenuItem(menuParentText, contextMenuAddToIpfsSelection, 'selection')
+    */
+    createAddToIpfsMenuItem(null, contextMenuAddToIpfsSelection, 'selection')
+    buildSubmenu(menuParentImage, 'image')
+    buildSubmenu(menuParentVideo, 'video')
+    buildSubmenu(menuParentAudio, 'audio')
+    buildSubmenu(menuParentLink, 'link')
+    buildSubmenu(menuParentPage, 'page')
   } catch (err) {
-    // documentUrlPatterns is not supported in Brave
+    // documentUrlPatterns is not supported in Muon-Brave
     if (err.message.indexOf('createProperties.documentUrlPatterns of contextMenus.create is not supported yet') > -1) {
       console.warn('[ipfs-companion] Context menus disabled - createProperties.documentUrlPatterns of contextMenus.create is not supported yet')
       return { update: () => Promise.resolve() }
@@ -112,8 +166,9 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
           const currentTab = await browser.tabs.query({ active: true, currentWindow: true }).then(tabs => tabs[0])
           if (currentTab && currentTab.id === changedTabId) {
             const ipfsContext = ipfsPathValidator.isIpfsPageActionsContext(currentTab.url)
-            browser.contextMenus.update(contextMenuCopyCanonicalAddress, { enabled: ipfsContext })
-            browser.contextMenus.update(contextMenuCopyAddressAtPublicGw, { enabled: ipfsContext })
+            for (let item of ipfsContextItems) {
+              browser.contextMenus.update(item, { enabled: ipfsContext })
+            }
           }
         }
       } catch (err) {

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -15,7 +15,6 @@ const contextSources = {
 
 async function findValueForContext (context, contextType) {
   if (context) {
-    console.log(context)
     if (contextType) {
       const field = contextSources[contextType]
       return context[field]
@@ -96,7 +95,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
         /* no support for 'icons' in Chrome
         icons: {
           '48': '/ui-kit/icons/stroke_cube.svg'
-        },*/
+        }, */
         onclick: (context) => onAddFromContext(context, contextType, ipfsAddOptions)
       })
     }
@@ -116,7 +115,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
         /* no support for 'icons' in Chrome
         icons: {
           '48': '/ui-kit/icons/stroke_copy.svg'
-        },*/
+        }, */
         onclick: (context) => handler(context, contextType)
       })
     }
@@ -125,9 +124,9 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
       createAddToIpfsMenuItem(parentId, contextMenuAddToIpfsKeepFilename, contextType, { wrapWithDirectory: true })
       createAddToIpfsMenuItem(parentId, contextMenuAddToIpfsRawCid, contextType, { wrapWithDirectory: false })
       createSeparator(parentId, 'separator-1', contextType)
+      createCopierMenuItem(parentId, contextMenuCopyAddressAtPublicGw, contextType, onCopyAddressAtPublicGw)
       createCopierMenuItem(parentId, contextMenuCopyCanonicalAddress, contextType, onCopyCanonicalAddress)
       createCopierMenuItem(parentId, contextMenuCopyRawCid, contextType, onCopyRawCid)
-      createCopierMenuItem(parentId, contextMenuCopyAddressAtPublicGw, contextType, onCopyAddressAtPublicGw)
     }
 
     /*

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -2,7 +2,7 @@
 
 const browser = require('webextension-polyfill')
 const { safeIpfsPath, trimHashAndSearch } = require('./ipfs-path')
-const { findUrlForContext } = require('./context-menus')
+const { findValueForContext } = require('./context-menus')
 
 async function copyTextToClipboard (copyText) {
   const currentTab = await browser.tabs.query({ active: true, currentWindow: true }).then(tabs => tabs[0])
@@ -36,17 +36,17 @@ async function copyTextToClipboard (copyText) {
 
 function createCopier (getState, getIpfs, notify) {
   return {
-    async copyCanonicalAddress (context) {
-      const url = await findUrlForContext(context)
+    async copyCanonicalAddress (context, contextType) {
+      const url = await findValueForContext(context, contextType)
       const rawIpfsAddress = safeIpfsPath(url)
       copyTextToClipboard(rawIpfsAddress)
       notify('notify_copiedTitle', rawIpfsAddress)
     },
 
-    async copyDirectCid (context) {
+    async copyRawCid (context, contextType) {
       try {
         const ipfs = getIpfs()
-        const url = await findUrlForContext(context)
+        const url = await findValueForContext(context, contextType)
         const rawIpfsAddress = trimHashAndSearch(safeIpfsPath(url))
         const directCid = (await ipfs.resolve(rawIpfsAddress, { recursive: true })).split('/')[2]
         copyTextToClipboard(directCid)
@@ -57,8 +57,8 @@ function createCopier (getState, getIpfs, notify) {
       }
     },
 
-    async copyAddressAtPublicGw (context) {
-      const url = await findUrlForContext(context)
+    async copyAddressAtPublicGw (context, contextType) {
+      const url = await findValueForContext(context, contextType)
       const state = getState()
       const urlAtPubGw = url.replace(state.gwURLString, state.pubGwURLString)
       copyTextToClipboard(urlAtPubGw)

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -53,7 +53,17 @@ function createCopier (getState, getIpfs, notify) {
         notify('notify_copiedTitle', directCid)
       } catch (error) {
         console.error('Unable to resolve/copy direct CID:', error.message)
-        if (notify) notify('notify_addonIssueTitle', 'notify_inlineErrorMsg', error.message)
+        if (notify) {
+          const errMsg = error.toString()
+          if (errMsg.startsWith('Error: no link')) {
+            // Sharding support is limited:
+            // - https://github.com/ipfs/js-ipfs/issues/1279
+            // - https://github.com/ipfs/go-ipfs/issues/5270
+            notify('notify_addonIssueTitle', 'Unable to resolve CID within HAMT-sharded directory, sorry! Will be fixed soon.')
+          } else {
+            notify('notify_addonIssueTitle', 'notify_inlineErrorMsg', error.message)
+          }
+        }
       }
     },
 

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -48,12 +48,12 @@ function createCopier (getState, getIpfs, notify) {
         const ipfs = getIpfs()
         const url = await findValueForContext(context, contextType)
         const rawIpfsAddress = trimHashAndSearch(safeIpfsPath(url))
-        const directCid = (await ipfs.resolve(rawIpfsAddress, { recursive: true })).split('/')[2]
+        const directCid = (await ipfs.resolve(rawIpfsAddress, { recursive: true, dhtt: '5s', dhtrc: 1 })).split('/')[2]
         copyTextToClipboard(directCid)
         notify('notify_copiedTitle', directCid)
       } catch (error) {
         console.error('Unable to resolve/copy direct CID:', error.message)
-        if (notify) notify('notify_addonIssueTitle', 'notify_addonIssueMsg')
+        if (notify) notify('notify_addonIssueTitle', 'notify_inlineErrorMsg', error.message)
       }
     },
 

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -59,8 +59,7 @@ module.exports = async function init () {
     dnslinkResolver = createDnslinkResolver(getState)
     ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
     contextMenus = createContextMenus(getState, runtime, ipfsPathValidator, {
-      onAddToIpfs: addFromContext,
-      onAddToIpfsKeepFilename: (info) => addFromContext(info, { wrapWithDirectory: true }),
+      onAddFromContext,
       onCopyCanonicalAddress: copier.copyCanonicalAddress,
       onCopyAddressAtPublicGw: copier.copyAddressAtPublicGw
     })
@@ -256,20 +255,20 @@ module.exports = async function init () {
   // Context Menu Uploader
   // -------------------------------------------------------------------
 
-  async function addFromContext (info, options) {
+  async function onAddFromContext (context, contextField, options) {
     let result
     try {
-      const srcUrl = await findUrlForContext(info)
-      if (info.selectionText) {
-        result = await ipfs.files.add(Buffer.from(info.selectionText), options)
+      const srcUrl = await findUrlForContext(context, contextField)
+      if (context.selectionText) {
+        result = await ipfs.files.add(Buffer.from(context.selectionText), options)
       } else if (runtime.isFirefox) {
         // workaround due to https://github.com/ipfs/ipfs-companion/issues/227
         const fetchOptions = {
           cache: 'force-cache',
-          referrer: info.pageUrl
+          referrer: context.pageUrl
         }
-        // console.log('addFromContext.info', info)
-        // console.log('addFromContext.fetchOptions', fetchOptions)
+        // console.log('onAddFromContext.context', context)
+        // console.log('onAddFromContext.fetchOptions', fetchOptions)
         const response = await fetch(srcUrl, fetchOptions)
         const blob = await response.blob()
         const buffer = await new Promise((resolve, reject) => {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -100,6 +100,9 @@ module.exports = async function init () {
     browser.webNavigation.onCommitted.addListener(onNavigationCommitted)
     browser.tabs.onUpdated.addListener(onUpdatedTab)
     browser.tabs.onActivated.addListener(onActivatedTab)
+    if (browser.windows) {
+      browser.windows.onFocusChanged.addListener(onWindowFocusChanged)
+    }
     browser.runtime.onMessage.addListener(onRuntimeMessage)
     browser.runtime.onConnect.addListener(onRuntimeConnect)
 
@@ -341,6 +344,15 @@ module.exports = async function init () {
 
   // Page-specific Actions
   // -------------------------------------------------------------------
+
+  async function onWindowFocusChanged (windowId) {
+    // Note: On some Linux window managers, WINDOW_ID_NONE will always be sent
+    // immediately preceding a switch from one browser window to another.
+    if (windowId !== browser.windows.WINDOW_ID_NONE) {
+      const currentTab = await browser.tabs.query({ active: true, windowId }).then(tabs => tabs[0])
+      await contextMenus.update(currentTab.id)
+    }
+  }
 
   async function onActivatedTab (activeInfo) {
     await contextMenus.update(activeInfo.tabId)

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -10,6 +10,7 @@ function safeIpfsPath (urlOrPath) {
   // better safe than sorry: https://github.com/ipfs/ipfs-companion/issues/303
   return decodeURIComponent(urlOrPath.replace(/^.*(\/ip(f|n)s\/.+)$/, '$1'))
 }
+exports.safeIpfsPath = safeIpfsPath
 
 function subdomainToIpfsPath (url) {
   if (typeof url === 'string') {
@@ -21,14 +22,22 @@ function subdomainToIpfsPath (url) {
   return `/${protocol}/${cid}${url.pathname}`
 }
 
-exports.safeIpfsPath = safeIpfsPath
-
 function pathAtHttpGateway (path, gatewayUrl) {
   // return URL without duplicated slashes
-  return new URL(`${gatewayUrl}${path}`).toString().replace(/([^:]\/)\/+/g, '$1')
+  return trimDoubleSlashes(new URL(`${gatewayUrl}${path}`).toString())
 }
-
 exports.pathAtHttpGateway = pathAtHttpGateway
+
+function trimDoubleSlashes (urlString) {
+  return urlString.replace(/([^:]\/)\/+/g, '$1')
+}
+exports.trimDoubleSlashes = trimDoubleSlashes
+
+function trimHashAndSearch (urlString) {
+  // https://github.com/ipfs-shipyard/ipfs-companion/issues/567
+  return urlString.split('#')[0].split('?')[0]
+}
+exports.trimHashAndSearch = trimHashAndSearch
 
 function createIpfsPathValidator (getState, dnsLink) {
   const ipfsPathValidator = {

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 const html = require('choo/html')
 const navItem = require('./nav-item')
-const { contextMenuCopyAddressAtPublicGw, contextMenuCopyDirectCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
+const { contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
 
 module.exports = function contextActions ({
   active,
@@ -28,8 +28,8 @@ module.exports = function contextActions ({
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
   })}
   ${navItem({
-    text: browser.i18n.getMessage(contextMenuCopyDirectCid),
-    onClick: () => onCopy(contextMenuCopyDirectCid)
+    text: browser.i18n.getMessage(contextMenuCopyRawCid),
+    onClick: () => onCopy(contextMenuCopyRawCid)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -4,6 +4,7 @@
 const browser = require('webextension-polyfill')
 const html = require('choo/html')
 const navItem = require('./nav-item')
+const { contextMenuCopyAddressAtPublicGw, contextMenuCopyDirectCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
 
 module.exports = function contextActions ({
   active,
@@ -14,8 +15,7 @@ module.exports = function contextActions ({
   isPinned,
   isIpfsOnline,
   isApiAvailable,
-  onCopyIpfsAddr,
-  onCopyPublicGwAddr,
+  onCopy,
   onPin,
   onUnPin
 }) {
@@ -24,12 +24,16 @@ module.exports = function contextActions ({
   return html`
     <div class='fade-in pv1'>
   ${navItem({
-    text: browser.i18n.getMessage('panelCopy_currentIpfsAddress'),
-    onClick: onCopyIpfsAddr
+    text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
+    onClick: () => onCopy(contextMenuCopyCanonicalAddress)
   })}
   ${navItem({
-    text: browser.i18n.getMessage('panel_copyCurrentPublicGwUrl'),
-    onClick: onCopyPublicGwAddr
+    text: browser.i18n.getMessage(contextMenuCopyDirectCid),
+    onClick: () => onCopy(contextMenuCopyDirectCid)
+  })}
+  ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
+    onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
   })}
   ${!isPinned ? (
     navItem({

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -24,16 +24,16 @@ module.exports = function contextActions ({
   return html`
     <div class='fade-in pv1'>
   ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
+    onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
+  })}
+  ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),
     onClick: () => onCopy(contextMenuCopyRawCid)
-  })}
-  ${navItem({
-    text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
-    onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
   })}
   ${!isPinned ? (
     navItem({

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -10,8 +10,7 @@ const operations = require('./operations')
 // Passed current app `state` from the store and `emit`, a function to create
 // events, allowing views to signal back to the store that something happened.
 module.exports = function browserActionPage (state, emit) {
-  const onCopyIpfsAddr = () => emit('copyIpfsAddr')
-  const onCopyPublicGwAddr = () => emit('copyPublicGwAddr')
+  const onCopy = (copyAction) => emit('copy', copyAction)
   const onPin = () => emit('pin')
   const onUnPin = () => emit('unPin')
 
@@ -23,7 +22,7 @@ module.exports = function browserActionPage (state, emit) {
   const onToggleActive = () => emit('toggleActive')
 
   const headerProps = Object.assign({ onToggleNodeType, onToggleActive, onOpenPrefs }, state)
-  const contextActionsProps = Object.assign({ onCopyIpfsAddr, onCopyPublicGwAddr, onPin, onUnPin }, state)
+  const contextActionsProps = Object.assign({ onCopy, onPin, onUnPin }, state)
   const opsProps = Object.assign({ onQuickUpload, onOpenWebUi, onToggleRedirect }, state)
 
   return html`

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -3,7 +3,7 @@
 
 const browser = require('webextension-polyfill')
 const { safeIpfsPath, trimHashAndSearch } = require('../../lib/ipfs-path')
-const { contextMenuCopyAddressAtPublicGw, contextMenuCopyDirectCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
+const { contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
 
 // The store contains and mutates the state for the app
 module.exports = (state, emitter) => {
@@ -61,8 +61,8 @@ module.exports = (state, emitter) => {
       case contextMenuCopyCanonicalAddress:
         port.postMessage({ event: contextMenuCopyCanonicalAddress })
         break
-      case contextMenuCopyDirectCid:
-        port.postMessage({ event: contextMenuCopyDirectCid })
+      case contextMenuCopyRawCid:
+        port.postMessage({ event: contextMenuCopyRawCid })
         break
       case contextMenuCopyAddressAtPublicGw:
         port.postMessage({ event: contextMenuCopyAddressAtPublicGw })

--- a/add-on/src/popup/page-action/page.js
+++ b/add-on/src/popup/page-action/page.js
@@ -9,11 +9,10 @@ const contextActions = require('../browser-action/context-actions')
 // Passed current app `state` from the store and `emit`, a function to create
 // events, allowing views to signal back to the store that something happened.
 module.exports = function pageActionPage (state, emit) {
-  const onCopyIpfsAddr = () => emit('copyIpfsAddr')
-  const onCopyPublicGwAddr = () => emit('copyPublicGwAddr')
+  const onCopy = (copyAction) => emit('copy', copyAction)
   const onPin = () => emit('pin')
   const onUnPin = () => emit('unPin')
-  const contextActionsProps = Object.assign({ onCopyIpfsAddr, onCopyPublicGwAddr, onPin, onUnPin }, state)
+  const contextActionsProps = Object.assign({ onCopy, onPin, onUnPin }, state)
 
   // Instant init: page-action is shown only in ipfsContext
   contextActionsProps.isIpfsContext = true

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:copy:ui-kit:ipfs-css": "run-p build:copy:ui-kit:ipfs-css:*",
     "build:copy:ui-kit:ipfs-css:css": "shx mkdir -p add-on/ui-kit && shx cp node_modules/ipfs-css/ipfs.css add-on/ui-kit",
     "build:copy:ui-kit:ipfs-css:fonts": "shx mkdir -p add-on/ui-kit/fonts && shx cp node_modules/ipfs-css/fonts/* add-on/ui-kit/fonts",
+    "build:copy:ui-kit:ipfs-css:icons": "shx mkdir -p add-on/ui-kit/icons && shx cp node_modules/ipfs-css/icons/* add-on/ui-kit/icons",
     "build:copy:ui-kit:tachyons": "shx mkdir -p add-on/ui-kit && shx cp node_modules/tachyons/css/tachyons.css add-on/ui-kit",
     "build:js": "run-p build:js:*",
     "build:js:webpack": "webpack -p",


### PR DESCRIPTION
(Closes #579, https://github.com/ipfs-shipyard/ipfs-companion/issues/592, https://github.com/ipfs-shipyard/ipfs-companion/issues/599)

I played a bit with the concept from #579 and it is not enough to change the order.
Instead we should have clear, separate labels for each context. So far I've added a separate menu item for adding link destination and kept common label for images,videos and audio as "Add This Object to IPFS".

Screenshot below illustrates the most extreme case is when you select part of a page and then click on an image that is also a link (so you get actions for all those contexts):

> ![screenshot_28](https://user-images.githubusercontent.com/157609/45722588-5be0de00-bbad-11e8-900d-7823f4de383d.png)


@alanshaw  @olizilla  would appreciate quick review of _"Add ... to IPFS"_ menu  labels, do they sound ok or awkward? How we could improve it to make English locale better?




