### PR TITLE
fix: make global toggle checkbox less ambiguous

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -8,7 +8,7 @@
     "description": "A label for IPFS icon (panel_headerIpfsNodeIconLabel)"
   },
   "panel_headerActiveToggleTitle": {
-    "message": "Global toggle: activate or suspend all IPFS integrations",
+    "message": "Global toggle: Suspend all IPFS integrations",
     "description": "A label for an embedded IPFS node (panel_headerActiveToggleTitle)"
   },
   "panel_statusOffline": {


### PR DESCRIPTION
_what will happen if I uncheck the box?_
<img width="439" alt="screenshot 2018-09-19 10 04 52" src="https://user-images.githubusercontent.com/58871/45743294-99685a00-bbf3-11e8-9e30-aec5e0b6106a.png">

This PR is just a tiny tweak so the checkbox label says what it will do if it is checked.

- [ ] **Global toggle: Suspend all IPFS integrations**

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>