### PR TITLE
Fix random UI glitches: check only for recursive pins

### DIFF
--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -245,7 +245,7 @@ module.exports = (state, emitter) => {
     if (state.isPinning || state.isUnPinning) return
     try {
       const currentPath = await resolveToPinPath(ipfs, status.currentTab.url)
-      const response = await ipfs.pin.ls(currentPath, { quiet: true })
+      const response = await ipfs.pin.ls(currentPath, { type: 'recursive', quiet: true })
       console.log(`positive ipfs.pin.ls for ${currentPath}: ${JSON.stringify(response)}`)
       state.isPinned = true
     } catch (error) {


### PR DESCRIPTION
> `ipfs swarm peers` should be fast, `ipfs pin ls` may get really slow for mid-large repos, especially when called without `-t recursive` flag (mine repo has few 100k's of pins, pin ls can take minutes to finish)

As a workaround until #415  lands we only check for explicit (recursive) ones,
as suggested in https://github.com/ipfs-shipyard/ipfs-companion/issues/360#issuecomment-380631986

Closes #360