### PR TITLE
Fix Chromium crash on 150MB upload

### DIFF
--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -62,15 +62,6 @@ async function processFiles (state, emitter, files) {
     const { ipfsCompanion } = await browser.runtime.getBackgroundPage()
     const uploadTab = await browser.tabs.getCurrent()
     let { streams, totalSize } = files2streams(files)
-    if (!browser.runtime.id.includes('@')) {
-      // we are in non-Firefox runtime (we know for a fact that Chrome puts no @ in id)
-      if (state.ipfsNodeType === 'external' && totalSize >= 134217728) {
-        // avoid crashing Chrome until the source of issue is fixed in js-ipfs-api
-        // - https://github.com/ipfs-shipyard/ipfs-companion/issues/464
-        // - https://github.com/ipfs/js-ipfs-api/issues/654
-        throw new Error('Unable to process payload bigger than 128MiB in Chrome. See: js-ipfs-api/issues/654')
-      }
-    }
     progressHandler(0, totalSize, state, emitter)
     emitter.emit('render')
     const wrapFlag = (state.wrapWithDirectory || streams.length > 1)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "private": true,
   "preferGlobal": false,
   "resolutions": {
+    "stream-http": "https://github.com/jhiesey/stream-http/tarball/2a8467dd84da9ab93cb43ca6cf78a75fef07f282/stream-http.tar.gz",
     "uglify-es": "npm:terser"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,9 +10687,9 @@ stream-each@^1.1.0:
     end-of-stream "^1.1.0"
     stream-shift "^1.0.0"
 
-stream-http@^2.7.2, stream-http@^2.8.3:
+stream-http@^2.7.2, stream-http@^2.8.3, "stream-http@https://github.com/jhiesey/stream-http/tarball/2a8467dd84da9ab93cb43ca6cf78a75fef07f282/stream-http.tar.gz":
   version "2.8.3"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  resolved "https://github.com/jhiesey/stream-http/tarball/2a8467dd84da9ab93cb43ca6cf78a75fef07f282/stream-http.tar.gz#6975289c60e4f2061fb6f544472357ffd13c9170"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"


### PR DESCRIPTION
This PR closes https://github.com/ipfs-shipyard/ipfs-companion/issues/464 (crash when dropping a big file) by switching to stream-http with [this fix](https://github.com/jhiesey/stream-http/pull/93).

TL;DR it makes this go away when user uploads >150MB in Chromium-based browser.

>  ![2018-09-24-223713_736x252_scrot](https://user-images.githubusercontent.com/157609/45979927-dd72b900-c050-11e8-8b0a-d9c011b74648.png)

More context: https://github.com/ipfs-shipyard/ipfs-companion/issues/464

