### PR TITLE
Fix edge cases around localhost redirects

### DIFF
--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -19,6 +19,11 @@ const fakeRequestId = () => {
   return Math.floor(Math.random() * 100000).toString()
 }
 
+const expectNoRedirect = (modifyRequest, request) => {
+  expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+  expect(modifyRequest.onHeadersReceived(request)).to.equal(undefined)
+}
+
 const nodeTypes = ['external', 'embedded']
 
 describe('modifyRequest.onBeforeRequest:', function () {
@@ -76,28 +81,28 @@ describe('modifyRequest.onBeforeRequest:', function () {
         it(`should be left untouched if redirect is disabled (${nodeType} node)`, function () {
           state.redirect = false
           const request = url2request('https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
         it(`should be left untouched if redirect is enabled but global active flag is OFF (${nodeType} node)`, function () {
           state.active = false
           state.redirect = true
           const request = url2request('https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
         it(`should be left untouched if URL includes opt-out hint (${nodeType} node)`, function () {
           // A safe way for preloading data at arbitrary gateways - it should arrive at original destination
           const request = url2request('https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?x-ipfs-companion-no-redirect#hashTest')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
           expect(redirectOptOutHint).to.equal('x-ipfs-companion-no-redirect')
         })
         it(`should be left untouched if CID is invalid (${nodeType} node)`, function () {
           const request = url2request('https://google.com/ipfs/notacid?argTest#hashTest')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
         it(`should be left untouched if its is a HEAD preload with explicit opt-out in URL hash (${nodeType} node)`, function () {
           // HTTP HEAD is a popular way for preloading data at arbitrary gateways, so we have a dedicated test to make sure it works as expected
           const headRequest = { url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#x-ipfs-companion-no-redirect', method: 'HEAD' }
-          expect(modifyRequest.onBeforeRequest(headRequest)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, headRequest)
         })
       })
     })
@@ -214,12 +219,12 @@ describe('modifyRequest.onBeforeRequest:', function () {
         it(`should be left untouched if redirect is disabled' (${nodeType} node)`, function () {
           state.redirect = false
           const request = url2request('https://google.com/ipns/ipfs.io?argTest#hashTest')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
         it(`should be left untouched if FQDN is not a real domain nor a valid CID (${nodeType} node)`, function () {
           const request = url2request('https://google.com/ipns/notafqdnorcid?argTest#hashTest')
           dnslinkResolver.readDnslinkFromTxtRecord = sinon.stub().returns(false)
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
       })
     })
@@ -229,27 +234,31 @@ describe('modifyRequest.onBeforeRequest:', function () {
   nodeTypes.forEach(function (nodeType) {
     beforeEach(function () {
       state.ipfsNodeType = nodeType
+      state.redirect = true
     })
     describe(`with ${nodeType} node:`, function () {
       describe('request for IPFS path at a localhost', function () {
         // we do not touch local requests, as it may interfere with other nodes running at the same machine
         // or could produce false-positives such as redirection from 127.0.0.1:5001/ipfs/path to 127.0.0.1:8080/ipfs/path
         it('should be left untouched if 127.0.0.1 is used', function () {
-          state.redirect = true
           const request = url2request('http://127.0.0.1:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
         it('should be left untouched if localhost is used', function () {
           // https://github.com/ipfs/ipfs-companion/issues/291
-          state.redirect = true
           const request = url2request('http://localhost:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
+        })
+        it('should be left untouched if localhost is used, even when x-ipfs-path is present', function () {
+          // https://github.com/ipfs-shipyard/ipfs-companion/issues/604
+          const request = url2request('http://localhost:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+          request.responseHeaders = [{ name: 'X-Ipfs-Path', value: '/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ' }]
+          expectNoRedirect(modifyRequest, request)
         })
         it('should be left untouched if [::1] is used', function () {
           // https://github.com/ipfs/ipfs-companion/issues/291
-          state.redirect = true
           const request = url2request('http://[::1]:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
       })
 
@@ -259,12 +268,12 @@ describe('modifyRequest.onBeforeRequest:', function () {
         it('should be left untouched for IPFS', function () {
           state.redirect = true
           const request = url2request('http://bafybeigxjv2o4jse2lajbd5c7xxl5rluhyqg5yupln42252e5tcao7hbge.ipfs.dweb.link/')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
         it('should be left untouched for IPNS', function () {
           state.redirect = true
           const request = url2request('http://bafybeigxjv2o4jse2lajbd5c7xxl5rluhyqg5yupln42252e5tcao7hbge.ipns.dweb.link/')
-          expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+          expectNoRedirect(modifyRequest, request)
         })
       })
     })


### PR DESCRIPTION
- Ignored requests are identified early and cached across all
  [`browser.webRequest.*` hooks](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest)
- Global toggle now correctly disables all hooks and workarounds
- Tests now use `expectNoRedirect` which checks both `onBeforeRequest` and `onHeadersReceived`
- Closes #604