### PR TITLE
fix: CORS false-positive in Chrome 71

### DIFF
--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -108,8 +108,8 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
     onBeforeSendHeaders (request) {
       const state = getState()
 
-      // Skip if IPFS integrations are inactive or request is marked as ignored
-      if (!state.active || isIgnored(request.requestId)) {
+      // Skip if IPFS integrations are inactive
+      if (!state.active) {
         return
       }
 
@@ -150,10 +150,9 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
             request.requestHeaders.push(expectHeader)
           }
         }
-        // For some reason js-ipfs-api sent requests with "Origin: null" under Chrome
-        // which produced '403 - Forbidden' error.
+        // For some reason js-ipfs-api sends requests with "Origin: null" under Chrome
+        // which produces '403 - Forbidden' error.
         // This workaround removes bogus header from API requests
-        // TODO: check if still necessary
         for (let i = 0; i < request.requestHeaders.length; i++) {
           let header = request.requestHeaders[i]
           if (header.name === 'Origin' && (header.value == null || header.value === 'null')) {

--- a/test/functional/lib/ipfs-request-workarounds.test.js
+++ b/test/functional/lib/ipfs-request-workarounds.test.js
@@ -40,6 +40,7 @@ describe('modifyRequest processing', function () {
         type: 'xmlhttprequest',
         url: `${state.apiURLString}api/v0/add?progress=true&wrapWithDirectory=true&pin=true&wrap-with-directory=true&stream-channels=true`
       }
+      modifyRequest.onBeforeRequest(request) // executes before onBeforeSendHeaders, may mutate state
       expect(modifyRequest.onBeforeSendHeaders(request).requestHeaders).to.deep.include(expectHeader)
     })
   })
@@ -52,6 +53,7 @@ describe('modifyRequest processing', function () {
         type: 'xmlhttprequest',
         url: `${state.apiURLString}api/v0/id`
       }
+      modifyRequest.onBeforeRequest(request) // executes before onBeforeSendHeaders, may mutate state
       expect(modifyRequest.onBeforeSendHeaders(request).requestHeaders).to.not.include(bogusOriginHeader)
     })
   })


### PR DESCRIPTION
This PR restores [this workaround](https://github.com/ipfs-shipyard/ipfs-companion/blob/7a6fac1d9dc344b426120e121e158d220d377be5/add-on/src/lib/ipfs-request.js#L153-L161) for localhost API closes #615

(Fast tracking as this needs to land in Beta and Stable)