### PR TITLE
Disable redirect for CID-in-subdomain even when X-Ipfs-Path is present

### DIFF
--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -306,6 +306,12 @@ function isSafeToRedirect (request, runtime) {
     return false
   }
 
+  // For now we do not redirect if cid-in-subdomain is used
+  // as it would break origin-based security perimeter
+  if (IsIpfs.subdomain(request.url)) {
+    return false
+  }
+
   // Ignore XHR requests for which redirect would fail due to CORS bug in Firefox
   // See: https://github.com/ipfs-shipyard/ipfs-companion/issues/436
   // TODO: revisit when upstream bug is addressed

--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -268,11 +268,13 @@ describe('modifyRequest.onBeforeRequest:', function () {
         it('should be left untouched for IPFS', function () {
           state.redirect = true
           const request = url2request('http://bafybeigxjv2o4jse2lajbd5c7xxl5rluhyqg5yupln42252e5tcao7hbge.ipfs.dweb.link/')
+          request.responseHeaders = [{ name: 'X-Ipfs-Path', value: '/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ' }]
           expectNoRedirect(modifyRequest, request)
         })
         it('should be left untouched for IPNS', function () {
           state.redirect = true
           const request = url2request('http://bafybeigxjv2o4jse2lajbd5c7xxl5rluhyqg5yupln42252e5tcao7hbge.ipns.dweb.link/')
+          request.responseHeaders = [{ name: 'X-Ipfs-Path', value: '/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ' }]
           expectNoRedirect(modifyRequest, request)
         })
       })


### PR DESCRIPTION
This is a fix of a regression for https://github.com/ipfs-shipyard/ipfs-companion/pull/537 that was introduced when a redirect based on the presence of `X-Ipfs-Path` header support got added.

Until we are able to provide the same origin-based security guarantees at a local gateway, we should not redirect resources that use  cid-in-subdomain deployment (https://github.com/ipfs/in-web-browsers/issues/89), as it is a strong hint they care about Origin-based isolation and we should not relax those guarantees.