### PR TITLE
Copy improvements for x-ipfs-path documentation

### DIFF
--- a/docs/x-ipfs-path-header.md
+++ b/docs/x-ipfs-path-header.md
@@ -12,7 +12,7 @@ The detection of the `x-ipfs-path` header can be disabled in the _Preferences_ s
 
 ## Use Cases
 
-### Fallback for edge cases when the IPFS path is not present in URL
+### Fallback for edge cases where the IPFS path is not present in the URL
 
 The website owner can have the HTTP gateway behind a reverse-proxy but configure it to expose `/ipfs/<cid>/` under `/` in which case path-based IPFS detection, by the IPFS Companion add-on (see [onBeforeRequest][]), won't work.
 

--- a/docs/x-ipfs-path-header.md
+++ b/docs/x-ipfs-path-header.md
@@ -1,43 +1,37 @@
 # `x-ipfs-path` Header Support in IPFS Companion
 
-> ### **TL;DR** Companion will upgrade request to IPFS if the header is found in HTTP response headers
+> **TL;DR:** The Companion add-on can redirect traditional HTTP requests to IPFS if the `x-ipfs-path` response header is provided.
 
 ## Overview
 
-HTTP Gateways return `x-ipfs-path` header with every response. The value of the
-header is IPFS path of returned payload.
+IPFS HTTP gateways can return an `x-ipfs-path` header with each response. The value of the header is the IPFS path of the returned payload.
 
-WebExtension API [onHeadersReceived][] allows for cancelling and redirecting
-HTTP request when response headers start arriving. In case of redirect it means
-dropping the old connection before actual payload is read, avoiding duplicate
-reads of the same data.
+The WebExtension API [onHeadersReceived][] can cancel and redirect the HTTP request as soon as the response headers arrive. This means the client can drop the initial request, avoiding duplicate downloads of the content.
 
-Detection of `x-ipfs-path` header is enabled by default on _Preferences_ screen.
+The detection of the `x-ipfs-path` header can be disabled in the _Preferences_ screen (but is enabled by default).
 
 ## Use Cases
 
-### Fallback for edge cases when IPFS path is not present in URL
+### Fallback for edge cases when the IPFS path is not present in URL
 
-It is possible for website owner to put HTTP Gateway behind reverse-proxy and
-set it up to expose `/ipfs/<cid>/` under `/`, in which case path-based IPFS
-detection, done by IPFS Companion in [onBeforeRequest][], will not work.
+The website owner can have the HTTP gateway behind a reverse-proxy but configure it to expose `/ipfs/<cid>/` under `/` in which case path-based IPFS detection, by the IPFS Companion add-on (see [onBeforeRequest][]), won't work.
 
-Thanks to `x-ipfs-path` header we have a reliable fallback for those setups.
+Thanks to the `x-ipfs-path` header we have a reliable fallback for these configurations.
 
-### Reliable hint for doing DNSLink lookup
+### Hinting DNSLink lookups
 
-Presence of `x-ipfs-path` header is a clear indicator website uses IPFS.
+The presence of the `x-ipfs-path` header is a clear indicator website uses IPFS.
 
 There is a "best-effort" [DNSLink policy][] enabled by default to execute blocking DNS TXT lookups for FQDNs that returned the header.
 
-Note: `x-ipfs-path` starting with `/ipns/` will be ignored if [DNSLink policy][] is "off" or DNS TXT record is missing.
+Note that `x-ipfs-path` values starting with `/ipns/` will be ignored if [DNSLink policy][] is "off" or the DNS TXT record is missing.
 
 ----
 
-#### See Also:
+See Also:
 
-- Context for `onBeforeRequest` and `onHeadersReceived`: [WebExtensions API: webRequest](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest)
-- Notes on [DNSLink policy][] in IPFS Companion
+- An overview of the `onBeforeRequest` and `onHeadersReceived` listeners can be found in the [WebExtensions API: webRequest](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest) documentation.
+- Notes on [DNSLink policy][] can be found in the IPFS companion add-on itself.
 
 [dnslink policy]: dnslink.md
 [onBeforeRequest]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/onBeforeRequest


### PR DESCRIPTION
I found it hard to understand the `x-ipfs-path` readme and took a shot at rephrasing some of the documentation. It's a small change but it, hopefully, helps the next newbie to more easily understand the `x-ipfs-path` header.

I am not a native English speaker myself so I hope I slightly improved the copy and didn't make it worse. :wink: