### PR TITLE
Match Mozilla Necko's DNS cache

### DIFF
--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -9,7 +9,7 @@ const { pathAtHttpGateway } = require('./ipfs-path')
 
 module.exports = function createDnslinkResolver (getState) {
   // DNSLink lookup result cache
-  const cacheOptions = { max: 1000, maxAge: 1000 * 60 * 60 * 12 }
+  const cacheOptions = { max: 400, maxAge: 1000 * 60 * 2 }
   const cache = new LRU(cacheOptions)
   // upper bound for concurrent background lookups done by preloadDnslink(url)
   const lookupQueue = new PQueue({ concurrency: 8 })


### PR DESCRIPTION
Match Firefox's DNS cache of 400 entries for up to 2 minutes. Mozilla experimented in 2018 with doubling their DNS cache [from 400 to 800](https://bugzilla.mozilla.org/show_bug.cgi?id=1475781), but saw negligible improvements in cache hit ratios.

Browsers cache TTL naïvely for 15 sec to 2 min. (See my [DNS TTL client survey](https://www.ctrl.blog/entry/dns-client-ttl) for details.) 12 hours is much too long. Serving stale content for up to half a day isn’t a great user experience.

Note that Windows DNS Cache, macOS’ mDNSResponder, and so on may cache DNS responses for up to their TTL so this change shouldn’t be a massive performance reduction. Negative DNS responses (websites without DNSLink) mybe a different story, however as caching is usually limited to just a few seconds to a minute.

Optimization potential:
* Cache negative DNS responses (no DNSLink found) for longer than positive responses. Reduces unnecessary lookups for websites without IPFS.
* Implement DNS TTL-aware caching.
* Implement IPNS TTL-aware caching.
* Implement "IPNS lifetime - now()" aware caching.
