### PR TITLE
Add warning about mixed content issues

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -239,6 +239,10 @@
     "message": "URL of preferred HTTP2IPFS Gateway",
     "description": "An option description on the Preferences screen (option_customGatewayUrl_description)"
   },
+  "option_customGatewayUrl_warning": {
+    "message": "Warning: IPFS content can be blocked from loading on HTTPS websites unless your gateway URL starts with “http://127.0.0.1” or “https://”",
+    "description": "A warning on the Preferences screen, displayed when URL does not belong to Secure Context (option_customGatewayUrl_warning)"
+  },
   "option_useCustomGateway_title": {
     "message": "Use Custom Gateway",
     "description": "An option title on the Preferences screen (option_useCustomGateway_title)"

--- a/add-on/src/options/forms/gateways-form.js
+++ b/add-on/src/options/forms/gateways-form.js
@@ -5,6 +5,10 @@ const browser = require('webextension-polyfill')
 const html = require('choo/html')
 const { normalizeGatewayURL } = require('../../lib/options')
 
+// Warn about mixed content issues when changing the gateway
+// https://github.com/ipfs-shipyard/ipfs-companion/issues/648
+const secureContextUrl = /^https:\/\/.*|^http:\/\/127.0.0.1/
+
 function gatewaysForm ({
   ipfsNodeType,
   customGatewayUrl,
@@ -15,6 +19,7 @@ function gatewaysForm ({
   const onCustomGatewayUrlChange = onOptionChange('customGatewayUrl', normalizeGatewayURL)
   const onUseCustomGatewayChange = onOptionChange('useCustomGateway')
   const onPublicGatewayUrlChange = onOptionChange('publicGatewayUrl', normalizeGatewayURL)
+  const mixedContentWarning = !secureContextUrl.test(customGatewayUrl)
 
   return html`
     <form>
@@ -25,7 +30,9 @@ function gatewaysForm ({
               <label for="customGatewayUrl">
                 <dl>
                   <dt>${browser.i18n.getMessage('option_customGatewayUrl_title')}</dt>
-                  <dd>${browser.i18n.getMessage('option_customGatewayUrl_description')}</dd>
+                  <dd>${browser.i18n.getMessage('option_customGatewayUrl_description')}
+                    ${mixedContentWarning ? html`<p class="red i">${browser.i18n.getMessage('option_customGatewayUrl_warning')}</p>` : null}
+                  </dd>
                 </dl>
               </label>
               <input
@@ -38,6 +45,7 @@ function gatewaysForm ({
                 title="Enter URL without any sub-path"
                 onchange=${onCustomGatewayUrlChange}
                 value=${customGatewayUrl} />
+
             </div>
           ` : null}
           ${ipfsNodeType === 'external' ? html`


### PR DESCRIPTION
> Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/648

This PR checks if URL would trigger mixed content error and if check is positive displays an inline warning message:

> ![2019-01-02--11-56-33](https://user-images.githubusercontent.com/157609/50589215-16a79a00-0e86-11e9-8b92-3b8735270e8b.png)

@olizilla does the copy look ok?