### PR TITLE
fix: support ipfs.add and ipfs.files.add

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -265,7 +265,7 @@ module.exports = async function init () {
     try {
       const dataSrc = await findValueForContext(context, contextType)
       if (contextType === 'selection') {
-        result = await ipfs.files.add(Buffer.from(dataSrc), options)
+        result = await ipfs.add(Buffer.from(dataSrc), options)
       } else {
         // Enchanced addFromURL
         // --------------------
@@ -294,7 +294,7 @@ module.exports = async function init () {
           path: decodeURIComponent(filename),
           content: buffer
         }
-        result = await ipfs.files.add(data, options)
+        result = await ipfs.add(data, options)
       }
     } catch (error) {
       console.error('Error in upload to IPFS context menu', error)

--- a/add-on/src/lib/ipfs-proxy/access-control.js
+++ b/add-on/src/lib/ipfs-proxy/access-control.js
@@ -70,7 +70,7 @@ class AccessControl extends EventEmitter {
   }
 
   // Get a Map of granted permissions for a given scope
-  // e.g. Map { 'files.add' => true, 'object.new' => false }
+  // e.g. Map { 'add' => true, 'object.new' => false }
   async _getAllAccess (scope) {
     const key = this._getAccessKey(scope)
     return new Map(

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -153,20 +153,20 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         // Fix "http: invalid Read on closed Body"
         // ----------------------------------
         // There is a bug in go-ipfs related to keep-alive connections
-        // that results in partial response for ipfs.files.add
+        // that results in partial response for ipfs.add
         // mangled by error "http: invalid Read on closed Body"
         // More info (ipfs-companion): https://github.com/ipfs-shipyard/ipfs-companion/issues/480
         // More info (go-ipfs): https://github.com/ipfs/go-ipfs/issues/5168
         if (request.url.includes('/api/v0/add') && request.url.includes('stream-channels=true')) {
           let addExpectHeader = true
           const expectHeader = { name: 'Expect', value: '100-continue' }
-          const warningMsg = '[ipfs-companion] Executing "Expect: 100-continue" workaround for ipfs.files.add due to https://github.com/ipfs/go-ipfs/issues/5168'
+          const warningMsg = '[ipfs-companion] Executing "Expect: 100-continue" workaround for ipfs.add due to https://github.com/ipfs/go-ipfs/issues/5168'
           for (let header of request.requestHeaders) {
             // Workaround A: https://github.com/ipfs/go-ipfs/issues/5168#issuecomment-401417420
             // (works in Firefox, but Chromium does not expose Connection header)
             /* (disabled so we use the workaround B in all browsers)
             if (header.name === 'Connection' && header.value !== 'close') {
-              console.warn('[ipfs-companion] Executing "Connection: close" workaround for ipfs.files.add due to https://github.com/ipfs/go-ipfs/issues/5168')
+              console.warn('[ipfs-companion] Executing "Connection: close" workaround for ipfs.add due to https://github.com/ipfs/go-ipfs/issues/5168')
               header.value = 'close'
               addExpectHeader = false
               break

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -72,14 +72,14 @@ async function processFiles (state, emitter, files) {
     }
     let result
     try {
-      result = await ipfsCompanion.ipfs.files.add(streams, options)
+      result = await ipfsCompanion.ipfs.add(streams, options)
       // This is just an additional safety check, as in past combination
       // of specific go-ipfs/js-ipfs-http-client versions
       // produced silent errors in form of partial responses:
       // https://github.com/ipfs-shipyard/ipfs-companion/issues/480
       const partialResponse = result.length !== streams.length + (options.wrapWithDirectory ? 1 : 0)
       if (partialResponse) {
-        throw new Error('Result of ipfs.files.add call is missing entries. This may be due to a bug in HTTP API similar to https://github.com/ipfs/go-ipfs/issues/5168')
+        throw new Error('Result of ipfs.add call is missing entries. This may be due to a bug in HTTP API similar to https://github.com/ipfs/go-ipfs/issues/5168')
       }
       await ipfsCompanion.uploadResultHandler({ result, openRootInNewTab: true })
     } catch (err) {


### PR DESCRIPTION
This PR adds support for backends before and after breaking change introduced in https://github.com/ipfs/interface-ipfs-core/pull/378 by manually adding the new version in case old backend is used. 