### PR TITLE
fix: support HTTPS API endpoints

### DIFF
--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -7,7 +7,8 @@ exports.init = async function (opts) {
   console.log('[ipfs-companion] External ipfs init', opts.apiURLString)
 
   const url = opts.apiURL
-  const api = IpfsApi({ host: url.hostname, port: url.port, procotol: url.protocol })
+  const protocol = url.protocol.substr(0, url.protocol.length - 1) // http: -> http
+  const api = IpfsApi({ host: url.hostname, port: url.port, protocol })
   return api
 }
 


### PR DESCRIPTION
This commit fixes the issue that a protocol name (http or https) is not passed to `ipfs-http-client` as intended.

Closes #652