### PR TITLE
Add bundle:brave npm script and Brave manifest

### DIFF
--- a/add-on/manifest.brave.json
+++ b/add-on/manifest.brave.json
@@ -1,0 +1,15 @@
+{
+  "sockets": {
+    "udp": {
+      "send": "*",
+      "bind": "*"
+    },
+    "tcp": {
+      "connect": "*"
+    },
+    "tcpServer": {
+      "listen": "*:*"
+    }
+  },
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAi+PCLMME8x15VZQqUn+vBUJH8oqGqNiUX6lYLBi5w3HwSGcknEyCF5LDJv7tR3yeSxD8PhohQVJd2+5WB4BJkvzVR3F6uHS7hrgZ0lcq+xa+q4c1At35332C//ahX+ZvK3/n9v20jzJ8xdesQmfG8coFIyOZfOQ/owTno+QoPrUO9syXeG6nbYQnyfDip+UXe663zfBiNmwuVPo8R58zAOmpz7yAlCH+yEmj1YjQYpqbtYHwJwvN4elGF9wthgFNxoIZiqbe0wTUZiNjC1bZPiAed3+WftK0/P6czFpIP4SzjXszVps93l+yI15OB7VoeFu6oQk5G0d1/38W7GotUwIDAQAB"
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bundle:generic": "shx cp add-on/manifest.common.json add-on/manifest.json && web-ext build -a build/generic",
     "bundle:firefox": "shx cat add-on/manifest.common.json add-on/manifest.firefox.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/",
     "bundle:firefox:beta": "shx cat add-on/manifest.common.json add-on/manifest.firefox.json add-on/manifest.firefox-beta.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/firefox/beta/",
+    "bundle:brave": "shx cat add-on/manifest.common.json add-on/manifest.brave.json | json --deep-merge > add-on/manifest.json && web-ext build -a build/brave/",
     "watch": "npm-run-all build:copy --parallel watch:*",
     "watch:js": "run-p watch:js:*",
     "watch:js:webpack": "webpack --watch --progress -d --devtool inline-source-map",


### PR DESCRIPTION
These changes makes it so a bundle for Brave can be created which have chrome.socket APIs exposed. 

Note that `key` manifest JSON property is needed to get a consistent
extension ID when developing across machines.  Since the APIs are only whitelisted for this extension ID, this is needed. 

If you're wondering where the `key` manifest JSON property value can be obtained from, you can get it by installing IPFS Companion from the Chrome store and looking in your profile directory at the written manifest.  For example, on macOS it would be here: `~/Library/Application\ Support/BraveSoftware/Brave-Browser-Dev/Default/Extensions/nibjojkomfdiaoajekhjakgkdhaomnch/2.7.0_0/manifest.json`

This will not work with the current live release of Brave, however you can build a new `ipfs` branch that I created to get it working. We can continue to work within that `ipfs` branch until we're ready to ship something.

I have a branch of brave/brave-browser and brave/brave-core named `ipfs`.

To get a build of Brave with this branch, follow the build-instructions here:
https://github.com/brave/brave-browser/wiki

But after cloning checkout the branch `ipfs`

If you already have a build of Brave, you can just switch to the `ipfs` branch in the root of your `brave/brave-browser` clone.
Then run `npm run init` one time so the dependency brave-core (https://github.com/brave/brave-core) which is mounted in `src/brave` gets updated to use its `ipfs` branch.
Then run `npm run build` to build the changes.

Load unpacked but bundle IPFS companion with `npm run build bundle:brave`.

