### PR TITLE
fix: support API listening on ipv6

### DIFF
--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -8,7 +8,8 @@ exports.init = async function (opts) {
 
   const url = opts.apiURL
   const protocol = url.protocol.substr(0, url.protocol.length - 1) // http: -> http
-  const api = IpfsApi({ host: url.hostname, port: url.port, protocol })
+  const host = url.hostname.replace(/[[\]]+/g, '') // temporary fix for ipv6: https://github.com/ipfs-shipyard/ipfs-companion/issues/668
+  const api = IpfsApi({ host, port: url.port, protocol })
   return api
 }
 


### PR DESCRIPTION
Context: https://github.com/ipfs-shipyard/ipfs-companion/issues/668#issuecomment-458537766

As a workaround, we are removing square brackets from API hostname until the problem is fixed upstream in `stream-http` (https://github.com/jhiesey/stream-http/pull/104).



Closes #668