### PR TITLE
feat: load Web UI from IPFS

### DIFF
--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -25,10 +25,33 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
   const runtimeRoot = browser.runtime.getURL('/')
   const webExtensionOrigin = runtimeRoot ? new URL(runtimeRoot).origin : 'null'
 
-  // Ignored requests are identified once and cached across all browser.webRequest hooks
-  const ignoredRequests = new LRU({ max: 128, maxAge: 1000 * 30 })
+  // Various types of requests are identified once and cached across all browser.webRequest hooks
+  const requestCacheCfg = { max: 128, maxAge: 1000 * 30 }
+  const ignoredRequests = new LRU(requestCacheCfg)
   const ignore = (id) => ignoredRequests.set(id, true)
   const isIgnored = (id) => ignoredRequests.get(id) !== undefined
+
+  const acrhHeaders = new LRU(requestCacheCfg) // webui cors fix in Chrome
+  const originUrls = new LRU(requestCacheCfg) // request.originUrl workaround for Chrome
+  const originUrl = (request) => {
+    // Firefox and Chrome provide relevant value in different fields:
+    // (Firefox) request object includes full URL of origin document, return as-is
+    if (request.originUrl) return request.originUrl
+    // (Chrome) is lacking: `request.initiator` is just the origin (protocol+hostname+port)
+    // To reconstruct originUrl we read full URL from Referer header in onBeforeSendHeaders
+    // and cache it for short time
+    // TODO: when request.originUrl is available in Chrome the `originUrls` cache can be removed
+    let cachedUrl = originUrls.get(request.requestId)
+    if (cachedUrl) return cachedUrl
+    if (request.requestHeaders) {
+      const referer = request.requestHeaders.find(h => h.name === 'Referer')
+      if (referer) {
+        originUrls.set(request.requestId, referer.value)
+        return referer.value
+      }
+    }
+  }
+
   const preNormalizationSkip = (state, request) => {
     // skip requests to the custom gateway or API (otherwise we have too much recursion)
     if (request.url.startsWith(state.gwURLString) || request.url.startsWith(state.apiURLString)) {
@@ -44,6 +67,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
     }
     return isIgnored(request.requestId)
   }
+
   const postNormalizationSkip = (state, request) => {
     // skip requests to the public gateway if embedded node is running (otherwise we have too much recursion)
     if (state.ipfsNodeType === 'embedded' && request.url.startsWith(state.pubGwURLString)) {
@@ -115,12 +139,40 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         return
       }
 
+      // Special handling of requests made to API
       if (request.url.startsWith(state.apiURLString)) {
+        // Requests made by 'blessed' Web UI
+        // --------------------------------------------
+        // Goal: Web UI works without setting CORS at go-ipfs
+        // (Without this snippet go-ipfs will return HTTP 403 due to additional origin check on the backend)
+        const origin = originUrl(request)
+        if (origin && origin.startsWith(state.webuiRootUrl)) {
+          // console.log('onBeforeSendHeaders', request)
+          // console.log('onBeforeSendHeaders.origin', origin)
+          // Swap Origin to pass server-side check
+          // (go-ipfs returns HTTP 403 on origin mismatch if there are no CORS headers)
+          const swapOrigin = (at) => {
+            request.requestHeaders[at].value = request.requestHeaders[at].value.replace(state.gwURL.origin, state.apiURL.origin)
+          }
+          let foundAt = request.requestHeaders.findIndex(h => h.name === 'Origin')
+          if (foundAt > -1) swapOrigin(foundAt)
+          foundAt = request.requestHeaders.findIndex(h => h.name === 'Referer')
+          if (foundAt > -1) swapOrigin(foundAt)
+
+          // Save access-control-request-headers from preflight
+          foundAt = request.requestHeaders.findIndex(h => h.name && h.name.toLowerCase() === 'access-control-request-headers')
+          if (foundAt > -1) {
+            acrhHeaders.set(request.requestId, request.requestHeaders[foundAt].value)
+            // console.log('onBeforeSendHeaders FOUND access-control-request-headers', acrhHeaders.get(request.requestId))
+          }
+          // console.log('onBeforeSendHeaders fixed headers', request.requestHeaders)
+        }
+
         // '403 - Forbidden' fix for Chrome and Firefox
         // --------------------------------------------
-        // We remove Origin header from requests made to API URL
+        // We remove Origin header from requests made to API URL and WebUI
         // by js-ipfs-http-client running in WebExtension context to remove need
-        // for manual whitelisting Access-Control-Allow-Origin at go-ipfs
+        // for manual CORS whitelisting via Access-Control-Allow-Origin at go-ipfs
         // More info:
         // Firefox: https://github.com/ipfs-shipyard/ipfs-companion/issues/622
         // Chromium 71: https://github.com/ipfs-shipyard/ipfs-companion/pull/616
@@ -142,13 +194,10 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
           }
           return false
         }
-        for (let i = 0; i < request.requestHeaders.length; i++) {
-          let header = request.requestHeaders[i]
-          if (header.name === 'Origin' && isWebExtensionOrigin(header.value)) {
-            request.requestHeaders.splice(i, 1)
-            break
-          }
-        }
+
+        // Remove Origin header matching webExtensionOrigin
+        const foundAt = request.requestHeaders.findIndex(h => h.name === 'Origin' && isWebExtensionOrigin(h.value))
+        if (foundAt > -1) request.requestHeaders.splice(foundAt, 1)
 
         // Fix "http: invalid Read on closed Body"
         // ----------------------------------
@@ -200,8 +249,48 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
     onHeadersReceived (request) {
       const state = getState()
 
-      // Skip if IPFS integrations are inactive or request is marked as ignored
-      if (!state.active || isIgnored(request.requestId)) {
+      // Skip if IPFS integrations are inactive
+      if (!state.active) {
+        return
+      }
+
+      // Special handling of requests made to API
+      if (request.url.startsWith(state.apiURLString)) {
+        // Special handling of requests made by 'blessed' Web UI from local Gateway
+        // Goal: Web UI works without setting CORS at go-ipfs
+        // (This includes 'ignored' requests: CORS needs to be fixed even if no redirect is done)
+        const origin = originUrl(request)
+        if (origin && origin.startsWith(state.webuiRootUrl) && request.responseHeaders) {
+          // console.log('onHeadersReceived', request)
+          const acaOriginHeader = { name: 'Access-Control-Allow-Origin', value: state.gwURL.origin }
+          const foundAt = findHeaderIndex(acaOriginHeader.name, request.responseHeaders)
+          if (foundAt > -1) {
+            request.responseHeaders[foundAt].value = acaOriginHeader.value
+          } else {
+            request.responseHeaders.push(acaOriginHeader)
+          }
+
+          // Restore access-control-request-headers from preflight
+          const acrhValue = acrhHeaders.get(request.requestId)
+          if (acrhValue) {
+            const acahHeader = { name: 'Access-Control-Allow-Headers', value: acrhValue }
+            const foundAt = findHeaderIndex(acahHeader.name, request.responseHeaders)
+            if (foundAt > -1) {
+              request.responseHeaders[foundAt].value = acahHeader.value
+            } else {
+              request.responseHeaders.push(acahHeader)
+            }
+            acrhHeaders.del(request.requestId)
+            // console.log('onHeadersReceived SET  Access-Control-Allow-Headers', header)
+          }
+
+          // console.log('onHeadersReceived fixed headers', request.responseHeaders)
+          return { responseHeaders: request.responseHeaders }
+        }
+      }
+
+      // Skip if request is marked as ignored
+      if (isIgnored(request.requestId)) {
         return
       }
 
@@ -418,4 +507,8 @@ function normalizedUnhandledIpfsProtocol (request, pubGwUrl) {
     // (will be redirected later, if needed)
     return { redirectUrl: pathAtHttpGateway(path, pubGwUrl) }
   }
+}
+
+function findHeaderIndex (name, headers) {
+  return headers.findIndex(x => x.name && x.name.toLowerCase() === name.toLowerCase())
 }

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -22,6 +22,10 @@ function initState (options) {
   state.gwURLString = state.gwURL.toString()
   delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
+  // store info about 'blessed' release of Web UI
+  // which should work without setting CORS headers
+  state.webuiCid = 'QmXc9raDM1M5G5fpBnVyQ71vR4gbnskwnB9iMEzBuLgvoZ' // v2.3.3
+  state.webuiRootUrl = `${state.gwURLString}ipfs/${state.webuiCid}/`
   return state
 }
 

--- a/add-on/src/popup/browser-action/operations.js
+++ b/add-on/src/popup/browser-action/operations.js
@@ -16,7 +16,7 @@ module.exports = function operations ({
   onToggleRedirect
 }) {
   const activeQuickUpload = active && isIpfsOnline && isApiAvailable
-  const activeWebUI = active && isIpfsOnline // (js-ipfs >=0.34.0-rc.0 is ok) && ipfsNodeType === 'external'
+  const activeWebUI = active && isIpfsOnline && ipfsNodeType === 'external'
   const activeGatewaySwitch = active && ipfsNodeType === 'external'
 
   return html`

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -125,8 +125,7 @@ module.exports = (state, emitter) => {
 
   emitter.on('openWebUi', async () => {
     try {
-      // Open bundled version of WebUI
-      await browser.tabs.create({ url: '/webui/index.html' })
+      browser.tabs.create({ url: state.webuiRootUrl })
       window.close()
     } catch (error) {
       console.error(`Unable Open Web UI due to ${error}`)
@@ -236,6 +235,7 @@ module.exports = (state, emitter) => {
       state.isIpfsOnline = state.active && status.peerCount > -1
       state.gatewayVersion = state.active && status.gatewayVersion ? status.gatewayVersion : null
       state.ipfsApiUrl = state.active ? options.ipfsApiUrl : null
+      state.webuiRootUrl = status.webuiRootUrl
     } else {
       state.ipfsNodeType = 'external'
       state.swarmPeers = null

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "build:copy:ui-kit:ipfs-css:fonts": "shx mkdir -p add-on/ui-kit/fonts && shx cp node_modules/ipfs-css/fonts/* add-on/ui-kit/fonts",
     "build:copy:ui-kit:ipfs-css:icons": "shx mkdir -p add-on/ui-kit/icons && shx cp node_modules/ipfs-css/icons/* add-on/ui-kit/icons",
     "build:copy:ui-kit:tachyons": "shx mkdir -p add-on/ui-kit && shx cp node_modules/tachyons/css/tachyons.css add-on/ui-kit",
-    "build:webui": "cross-env CID=QmXc9raDM1M5G5fpBnVyQ71vR4gbnskwnB9iMEzBuLgvoZ npm run build:webui:with-cid",
-    "build:webui:with-cid": "cross-env-shell \"shx test -d add-on/webui/ || (npm run build:webui:dir && (npm run build:webui:fetch-ipfs || npm run build:webui:fetch-http) && npm run build:webui:minimize)\"",
-    "build:webui:dir": "shx mkdir -p add-on/webui",
-    "build:webui:fetch-ipfs": "cross-env-shell \"ipfs get $CID -o add-on/webui/\"",
-    "build:webui:fetch-http": "cross-env-shell \"node scripts/fetch-webui-from-gateway.js $CID add-on/webui/\"",
-    "build:webui:minimize": "shx rm -rf add-on/webui/static/js/*.map && shx rm -rf add-on/webui/static/css/*.map && shx rm -rf add-on/webui/manifest.json",
+    "DISABLED:issue679:build:webui": "cross-env CID=QmXc9raDM1M5G5fpBnVyQ71vR4gbnskwnB9iMEzBuLgvoZ npm run build:webui:with-cid",
+    "DISABLED:issue679:build:webui:with-cid": "cross-env-shell \"shx test -d add-on/webui/ || (npm run build:webui:dir && (npm run build:webui:fetch-ipfs || npm run build:webui:fetch-http) && npm run build:webui:minimize)\"",
+    "DISABLED:issue679:build:webui:dir": "shx mkdir -p add-on/webui",
+    "DISABLED:issue679:build:webui:fetch-ipfs": "cross-env-shell \"ipfs get $CID -o add-on/webui/\"",
+    "DISABLED:issue679:build:webui:fetch-http": "cross-env-shell \"node scripts/fetch-webui-from-gateway.js $CID add-on/webui/\"",
+    "DISABLED:issue679:build:webui:minimize": "shx rm -rf add-on/webui/static/js/*.map && shx rm -rf add-on/webui/static/css/*.map && shx rm -rf add-on/webui/manifest.json",
     "build:js": "run-s build:js:*",
     "build:js:webpack": "webpack -p",
     "build:minimize-dist": "shx rm -rf add-on/dist/lib add-on/dist/contentScripts/ add-on/dist/bundles/ipfsProxyContentScriptPayload.bundle.js",
@@ -127,6 +127,7 @@
     "piggybacker": "2.0.0",
     "pull-file-reader": "1.0.2",
     "tachyons": "4.11.1",
+    "uri-to-multiaddr": "3.0.1",
     "webextension-polyfill": "0.3.1"
   }
 }

--- a/scripts/fetch-webui-from-gateway.js
+++ b/scripts/fetch-webui-from-gateway.js
@@ -1,5 +1,6 @@
 /* This is a fallback script used when ipfs cli fails or is not available
  * More details: https://github.com/ipfs-shipyard/ipfs-webui/issues/843
+ * See also why this is not used: https://github.com/ipfs-shipyard/ipfs-companion/issues/679
  */
 const tar = require('tar')
 const request = require('request')
@@ -7,10 +8,6 @@ const progress = require('request-progress')
 
 const cid = process.argv[2]
 const destination = process.argv[3]
-
-// pick random preloader
-// const no = Math.round(Math.random()) // 0 or 1
-// const url = 'https://node' + no + '.preload.ipfs.io/api/v0/get?arg=' + cid + '&archive=true&compress=true'
 
 // use public gw
 const url = 'https://ipfs.io/api/v0/get?arg=' + cid + '&archive=true&compress=true'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,9 @@ const commonConfig = {
     net: 'empty',
     tls: 'empty'
   },
+  watchOptions: {
+    ignored: ['add-on/dist/**/*', 'node_modules']
+  },
   performance: {
     maxEntrypointSize: Infinity,
     maxAssetSize: 4194304 // https://github.com/mozilla/addons-linter/pull/892

--- a/yarn.lock
+++ b/yarn.lock
@@ -13367,6 +13367,14 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uri-to-multiaddr@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uri-to-multiaddr/-/uri-to-multiaddr-3.0.1.tgz#460bd5d78074002c47b60fdc456efd009e7168ae"
+  integrity sha512-77slJiNB/IxM35zgflBEgp8T8ywpyYAbEh8Ezdnq7kAuA6TRg6wfvNTi4Uixfh6CsPv9K2fAkI5+E4C2dw3tXA==
+  dependencies:
+    is-ip "^2.0.0"
+    multiaddr "^6.0.3"
+
 urijs@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"


### PR DESCRIPTION
> This is a prerequisite for  #679, so **I am merging in fast-track mode to create a new release and fix #679 ASAP**.
>  Feel free to comment – will address any concerns in separate PRs. 


Before, webui was bundled with extension itself. Unfortunately this
caused issues with reviews at addon (webui build was not reproducible).

**This PR replaces bundled webui with one loaded from custom gateway.**

- To make it work we modify HTTP headers to make cross-origin requests
from 'blessed' webuiRootUrl work without changing default go-ipfs configuration.
- To improve UX, content script sets `ipfsApi` in webui's `localStorage`
to the same endpoint as one defined in Companion (unless it was already
customized by the user).
  - Switched programmatic content script injections from `browser.tabs.onUpdated` to `browser.webNavigation.onDOMContentLoaded` it executes only once and in case of `linkify` experiment DOM updates are handled via `MutationObserver` anyway 
- Sadly Web UI for js-ipfs had to be disabled for now (it may come back thanks to lunet experiment from https://github.com/ipfs/in-web-browsers/issues/137)

Digressions / notes to self:
  - The amount of differences in HTTP header and CORS handling between Firefox and Chrome in WebExtension context is baffling :'( 
    - Example: Chrome requires additional handling of values in preflight request, namely value from `Access-Control-Request-Headers` needs to be manually restored in `Access-Control-Allow-Headers` (Firefox allowed whitelisting cross-origin webui access without this step)
    - Fun fact: Chrome 72 removed access to arbitrary headers from [webRequest](https://developer.chrome.com/extensions/webRequest).  If one wants to peek at `Referer` header, they need to add `extraHeaders`  to listener's constructor. This works only in Chrome     – Firefox breaks, so now one needs to provide a different arguments to `browser.webRequest.onBeforeSendHeaders.addListener` depending on which browser is the runtime