### PR TITLE
Avoid creating world-writable build results

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ci": "run-s ci:*",
     "ci:install": "npx yarn@1.12.3 install --frozen-lockfile || npx yarn@1.12.3 install --frozen-lockfile",
     "ci:test": "npx yarn@1.12.3 test",
-    "ci:build": "./ci/update-manifest.sh ; npx yarn@1.12.3 build ; chmod -R ugo+rwX build/ add-on/",
+    "ci:build": "./ci/update-manifest.sh ; npx yarn@1.12.3 build ; chmod -R ugo+rX build/ add-on/",
     "beta-build": "docker build -t ipfs-companion . && docker run -it --net=host -e RELEASE_CHANNEL=beta -v $(pwd)/build:/usr/src/app/build ipfs-companion yarn ci:build",
     "release-build": "docker build -t ipfs-companion . && docker run -it --net=host -e RELEASE_CHANNEL=stable -v $(pwd)/build:/usr/src/app/build ipfs-companion yarn ci:build",
     "dev-build": "npx yarn@1.12.3 && npx yarn@1.12.3 build",


### PR DESCRIPTION
World writable files are a severe security issue
because any process on the system can modify them.

Without this patch, the build dir and everything within
had 777 or 666 as permission bits.