### PR TITLE
Add Privacy Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [Install](#install)
 - [Contribute](#contribute)
 - [Troubleshooting](#troubleshooting)
+- [Privacy Policy](#privacy-policy)
 - [License](#license)
 
 ## Background
@@ -235,6 +236,10 @@ Deny
 ```
 
 Feel free to modify it, but get familiar with [ABE rule syntax](https://noscript.net/abe/abe_rules.pdf) first.
+
+## Privacy Policy
+
+See [`docs/privacy-policy.md`](docs/privacy-policy.md)
 
 ## License
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,59 @@
+# <strong>IPFS Companion Privacy Policy</strong>
+
+Effective Date: 2019-02-15
+
+The IPFS Companion browser extension created by the IPFS Project. We know you
+care about how your personal data is used and we take your privacy seriously.
+That is why we don’t track nor collect any Personal Data.
+
+<strong>What Does this Privacy Policy Cover?</strong>
+
+This Privacy Policy explains that we don’t gather, track, nor permanently store
+any Personal Data. It also covers Additional Privacy Protocols related to the
+way extension exposes access to IPFS p2p network. It is also informing user that
+this Privacy Policy doesn’t apply to projects run by other organizations outside
+IPFS and Protocol Labs, even if we promote the use of those projects or happen
+to contribute to them.
+
+<strong>What Information Do We Collect?</strong>
+
+None. We don’t collect your data, period.
+
+<strong>Explicitly Shared Data will be Publicly Available over IPFS</strong>
+
+We do not collect, rent or sell your Personal Information to anyone. However
+because IPFS Companion is a web extension that provides access to real-time,
+peer-to-peer IPFS  platform for anyone to join and participate, the data that
+you add to IPFS using IPFS Companion is publicly available and accessible to
+everyone participating in IPFS network.
+
+<strong>Additional Privacy Protocols</strong>
+
+If you share files using this extension they will be stored on your local IPFS
+node and also  cached on the IPFS network. All content on IPFS is public by
+default. This means your files will be accessible to everyone who knows the
+Content Identifier (CID) or queries the data on IPFS. If you want to share
+privately, encrypt your data before adding it to IPFS.
+
+If you are using embedded JS IPFS node it will connect to bootstrap servers
+hosted by Protocol Labs and some of your Personal Information, such as public
+key and IP address of your IPFS node will be stored on the IPFS network publicly
+as well to facilitate p2p exchanges.
+
+If you are using “window.ipfs”, “Linkify IPFS Addresses” or “Catch Unhandled
+IPFS Protocols” experiments, websites will be able to detect you are running
+IPFS Companion. This behavior can be disabled on Preferences screen by disabling
+mentioned experiments.
+
+<strong>Will We Ever Change this Privacy Policy?</strong>
+
+We’re constantly trying to improve IPFS Companion, so we may need to change this
+Privacy Policy sometimes. When we do, we will update the date at the top of the
+Privacy Policy. We encourage you to periodically review this Privacy Policy to
+stay informed. If you use IPFS Companion after any changes to the Privacy Policy
+have been posted, that means you agree to all of those changes.
+
+<strong>What if I have questions about this policy?</strong>
+
+If you have any questions or concerns regarding our privacy policies, please
+send us a message at <em>legalrequests@protocol.ai</em>

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,39 +1,54 @@
-# <strong>IPFS Companion Privacy Policy</strong>
+# **IPFS Companion Privacy Policy**
 
-Effective Date: 2019-02-15
+<em>First Posted: 2019-02-15<br/>
+Last Update: 2019-02-20</em> ([change history](https://github.com/ipfs-shipyard/ipfs-companion/commits/master/docs/privacy-policy.md))
 
-The IPFS Companion browser extension created by the IPFS Project. We know you
-care about how your personal data is used and we take your privacy seriously.
-That is why we don’t track nor collect any Personal Data.
+The IPFS Companion browser extension is owned by Protocol Labs Inc. and created
+by the IPFS Project. We know you care about how your personal data is used and
+we take your privacy seriously. That is why, at the moment, we don’t track or
+collect any of your Personal Data, nor do we sell it to anyone else or use it
+for advertising. If that changes, we'll let you know by updating this policy. By
+using IPFS Companion, you are accepting and agreeing to this Privacy Policy.
 
-<strong>What Does this Privacy Policy Cover?</strong>
+**What Does This Privacy Policy Cover?**
 
 This Privacy Policy explains that we don’t gather, track, nor permanently store
-any Personal Data. It also covers Additional Privacy Protocols related to the
-way extension exposes access to IPFS p2p network. It is also informing user that
-this Privacy Policy doesn’t apply to projects run by other organizations outside
-IPFS and Protocol Labs, even if we promote the use of those projects or happen
-to contribute to them.
+any of your Personal Data. It also covers Additional Privacy Protocols related
+to the way the IPFS Companion extension allows people to add and retrieve data
+to and from the IPFS Network (which is a peer-to-peer network). This Privacy
+Policy doesn’t apply to projects run by other organizations outside IPFS and
+Protocol Labs, even if we promote the use of those projects or happen to
+contribute to them.
 
-<strong>What Information Do We Collect?</strong>
+**What Information Do We Collect?**
 
-None. We don’t collect your data, period.
+None. We don’t collect your Personal Data, period.
 
-<strong>Explicitly Shared Data will be Publicly Available over IPFS</strong>
+**Explicitly Shared Data Will Be Publicly Available over IPFS**
 
-We do not collect, rent or sell your Personal Information to anyone. However
-because IPFS Companion is a web extension that provides access to real-time,
-peer-to-peer IPFS  platform for anyone to join and participate, the data that
-you add to IPFS using IPFS Companion is publicly available and accessible to
-everyone participating in IPFS network.
+We do not collect, rent, store or sell your Personal Data to anyone. However
+because IPFS Companion is a web extension that provides access to the real-time,
+peer-to-peer IPFS Network (which is a public platform for which anyone may join
+and participate) the data that you add or upload to the IPFS Network using IPFS
+Companion is then publicly available and accessible to everyone participating in
+IPFS Network.
 
-<strong>Additional Privacy Protocols</strong>
+**Additional Privacy Protocols**
 
-If you share files using this extension they will be stored on your local IPFS
-node and also  cached on the IPFS network. All content on IPFS is public by
-default. This means your files will be accessible to everyone who knows the
-Content Identifier (CID) or queries the data on IPFS. If you want to share
-privately, encrypt your data before adding it to IPFS.
+If you add files to the IPFS Network using the IPFS Companion extension, they
+will be stored on your local IPFS Network node. Those files are also then cached
+by anyone who retrieves those files from the IPFS network and co-hosted on that
+user’s local IPFS Network node. Generally, cached files will eventually expire,
+but it’s possible for a user with whom you have shared access to such files (by
+sharing the relevant Content Identifier or CID) to pin that data, which means
+the cached files then will not expire and will remain stored on such user’s
+local IPFS Network node.
+
+All content shared with the IPFS Network is public by default. This means your
+files and data that you’ve added will be accessible to everyone who knows the
+CID or queries the data on the IPFS Network. If you want to share certain
+materials or data privately, you must encrypt such data before adding it to the
+IPFS Network.
 
 If you are using embedded JS IPFS node it will connect to bootstrap servers
 hosted by Protocol Labs and some of your Personal Information, such as public
@@ -42,18 +57,21 @@ as well to facilitate p2p exchanges.
 
 If you are using “window.ipfs”, “Linkify IPFS Addresses” or “Catch Unhandled
 IPFS Protocols” experiments, websites will be able to detect you are running
-IPFS Companion. This behavior can be disabled on Preferences screen by disabling
+IPFS Companion. This behavior can be changed on Preferences screen by disabling
 mentioned experiments.
 
-<strong>Will We Ever Change this Privacy Policy?</strong>
+**Will We Ever Change This Privacy Policy?**
 
 We’re constantly trying to improve IPFS Companion, so we may need to change this
-Privacy Policy sometimes. When we do, we will update the date at the top of the
-Privacy Policy. We encourage you to periodically review this Privacy Policy to
-stay informed. If you use IPFS Companion after any changes to the Privacy Policy
-have been posted, that means you agree to all of those changes.
+Privacy Policy sometimes. When we do, we will update the date at the top of this
+Privacy Policy and will also post an update
+[here](https://ipfs-shipyard.github.io/ipfs-companion/docs/privacy-policy). We
+encourage you to periodically review this Privacy Policy to stay informed, which
+is ultimately your responsibility. If you use IPFS Companion after any changes
+to the Privacy Policy have been posted, that means you agree to all of those
+changes.
 
-<strong>What if I have questions about this policy?</strong>
+**What If I Have Questions About This Policy?**
 
 If you have any questions or concerns regarding our privacy policies, please
-send us a message at <em>legalrequests@protocol.ai</em>
+send us a message at <legalrequests@protocol.ai>.


### PR DESCRIPTION
This PR adds Privacy Policy in Markdown format (to make it easier to maintain and audit)

- human-readable permalink: https://ipfs-shipyard.github.io/ipfs-companion/docs/privacy-policy
- change history: https://github.com/ipfs-shipyard/ipfs-companion/commits/master/docs/privacy-policy.md

Merging this as-is: Privacy Policy was reviewed by legal, any changes to existing Privacy Policy text need to be submitted as separate PR.