### PR TITLE
Show IPFS Actions on DNSLink Sites

### DIFF
--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -40,8 +40,8 @@ function createCopier (notify, ipfsPathValidator) {
     },
 
     async copyRawCid (context, contextType) {
+      const url = await findValueForContext(context, contextType)
       try {
-        const url = await findValueForContext(context, contextType)
         const cid = await ipfsPathValidator.resolveToCid(url)
         await copyTextToClipboard(cid, notify)
       } catch (error) {

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { safeIpfsPath, trimHashAndSearch } = require('./ipfs-path')
 const { findValueForContext } = require('./context-menus')
 
 async function copyTextToClipboard (text, notify) {
@@ -32,21 +31,19 @@ async function copyTextToClipboard (text, notify) {
   }
 }
 
-function createCopier (getState, getIpfs, notify) {
+function createCopier (notify, ipfsPathValidator) {
   return {
     async copyCanonicalAddress (context, contextType) {
       const url = await findValueForContext(context, contextType)
-      const rawIpfsAddress = safeIpfsPath(url)
-      await copyTextToClipboard(rawIpfsAddress, notify)
+      const ipfsPath = ipfsPathValidator.resolveToIpfsPath(url)
+      await copyTextToClipboard(ipfsPath, notify)
     },
 
     async copyRawCid (context, contextType) {
       try {
-        const ipfs = getIpfs()
         const url = await findValueForContext(context, contextType)
-        const rawIpfsAddress = trimHashAndSearch(safeIpfsPath(url))
-        const directCid = (await ipfs.resolve(rawIpfsAddress, { recursive: true, dhtt: '5s', dhtrc: 1 })).split('/')[2]
-        await copyTextToClipboard(directCid, notify)
+        const cid = await ipfsPathValidator.resolveToCid(url)
+        await copyTextToClipboard(cid, notify)
       } catch (error) {
         console.error('Unable to resolve/copy direct CID:', error.message)
         if (notify) {
@@ -65,9 +62,8 @@ function createCopier (getState, getIpfs, notify) {
 
     async copyAddressAtPublicGw (context, contextType) {
       const url = await findValueForContext(context, contextType)
-      const state = getState()
-      const urlAtPubGw = url.replace(state.gwURLString, state.pubGwURLString)
-      await copyTextToClipboard(urlAtPubGw, notify)
+      const publicUrl = ipfsPathValidator.resolveToPublicUrl(url)
+      await copyTextToClipboard(publicUrl, notify)
     }
   }
 }

--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -7,6 +7,8 @@ const PQueue = require('p-queue')
 const { offlinePeerCount } = require('./state')
 const { pathAtHttpGateway } = require('./ipfs-path')
 
+// TODO: add Preferences toggle to disable redirect of DNSLink  websites (while keeping async dnslink lookup)
+
 module.exports = function createDnslinkResolver (getState) {
   // DNSLink lookup result cache
   const cacheOptions = { max: 1000, maxAge: 1000 * 60 * 60 * 12 }

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -3,23 +3,32 @@
 
 const IsIpfs = require('is-ipfs')
 
-function safeIpfsPath (urlOrPath) {
+function normalizedIpfsPath (urlOrPath) {
+  let result = urlOrPath
+  // Convert CID-in-subdomain URL to /ipns/<fqdn>/ path
   if (IsIpfs.subdomain(urlOrPath)) {
-    urlOrPath = subdomainToIpfsPath(urlOrPath)
+    result = subdomainToIpfsPath(urlOrPath)
   }
-  // better safe than sorry: https://github.com/ipfs/ipfs-companion/issues/303
-  return decodeURIComponent(urlOrPath.replace(/^.*(\/ip(f|n)s\/.+)$/, '$1'))
+  // Drop everything before the IPFS path
+  result = result.replace(/^.*(\/ip(f|n)s\/.+)$/, '$1')
+  // Remove Unescape special characters
+  // https://github.com/ipfs/ipfs-companion/issues/303
+  result = decodeURIComponent(result)
+  // Return a valid IPFS path or null otherwise
+  return IsIpfs.path(result) ? result : null
 }
-exports.safeIpfsPath = safeIpfsPath
+exports.normalizedIpfsPath = normalizedIpfsPath
 
 function subdomainToIpfsPath (url) {
   if (typeof url === 'string') {
     url = new URL(url)
   }
   const fqdn = url.hostname.split('.')
+  // TODO: support CID split with commas
   const cid = fqdn[0]
+  // TODO: support .ip(f|n)s. being at deeper levels
   const protocol = fqdn[1]
-  return `/${protocol}/${cid}${url.pathname}`
+  return `/${protocol}/${cid}${url.pathname}${url.search}${url.hash}`
 }
 
 function pathAtHttpGateway (path, gatewayUrl) {
@@ -39,14 +48,14 @@ function trimHashAndSearch (urlString) {
 }
 exports.trimHashAndSearch = trimHashAndSearch
 
-function createIpfsPathValidator (getState, dnsLink) {
+function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
   const ipfsPathValidator = {
     // Test if URL is a Public IPFS resource
     // (pass validIpfsOrIpnsUrl(url) and not at the local gateway or API)
     publicIpfsOrIpnsResource (url) {
       // exclude custom gateway and api, otherwise we have infinite loops
       if (!url.startsWith(getState().gwURLString) && !url.startsWith(getState().apiURLString)) {
-        return validIpfsOrIpnsUrl(url, dnsLink)
+        return validIpfsOrIpnsUrl(url, dnslinkResolver)
       }
       return false
     },
@@ -54,19 +63,23 @@ function createIpfsPathValidator (getState, dnsLink) {
     // Test if URL is a valid IPFS or IPNS
     // (IPFS needs to be a CID, IPNS can be PeerId or have dnslink entry)
     validIpfsOrIpnsUrl (url) {
-      return validIpfsOrIpnsUrl(url, dnsLink)
+      return validIpfsOrIpnsUrl(url, dnslinkResolver)
     },
 
     // Same as validIpfsOrIpnsUrl (url) but for paths
     // (we have separate methods to avoid 'new URL' where possible)
     validIpfsOrIpnsPath (path) {
-      return validIpfsOrIpnsPath(path, dnsLink)
+      return validIpfsOrIpnsPath(path, dnslinkResolver)
     },
 
     // Test if actions such as 'copy URL', 'pin/unpin' should be enabled for the URL
-    // TODO: include hostname check for DNSLink and display option to copy CID even if no redirect
     isIpfsPageActionsContext (url) {
-      return (IsIpfs.url(url) && !url.startsWith(getState().apiURLString)) || IsIpfs.subdomain(url)
+      console.log(url)
+      return Boolean(url && !url.startsWith(getState().apiURLString) && (
+        IsIpfs.url(url) ||
+        IsIpfs.subdomain(url) ||
+        dnslinkResolver.cachedDnslink(new URL(url).hostname)
+      ))
     },
 
     // Test if actions such as 'per site redirect toggle' should be enabled for the URL
@@ -77,7 +90,89 @@ function createIpfsPathValidator (getState, dnsLink) {
         (url.startsWith('http') && // hide on non-HTTP pages
          !url.startsWith(state.gwURLString) && // hide on /ipfs/*
           !url.startsWith(state.apiURLString))) // hide on api port
+    },
+
+    // Resolve URL or path to HTTP URL:
+    // - IPFS paths are attached to HTTP Gateway root
+    // - URL of DNSLinked websites are returned as-is
+    // The purpose of this resolver is to always return a meaningful, publicly
+    // accessible URL that can be accessed without the need of IPFS client.
+    resolveToPublicUrl (urlOrPath, optionalGatewayUrl) {
+      const input = urlOrPath
+      // CID-in-subdomain is good as-is
+      if (IsIpfs.subdomain(input)) return input
+      // IPFS Paths should be attached to the public gateway
+      const ipfsPath = normalizedIpfsPath(input)
+      const gateway = optionalGatewayUrl || getState().pubGwURLString
+      if (ipfsPath) return pathAtHttpGateway(ipfsPath, gateway)
+      // Return original URL (eg. DNSLink domains) or null if not an URL
+      return input.startsWith('http') ? input : null
+    },
+
+    // Resolve URL or path to IPFS Path:
+    // - The path can be /ipfs/ or /ipns/
+    // - Keeps pathname + ?search + #hash from original URL
+    // - Returns null if no valid path can be produced
+    // The purpose of this resolver is to return a valid IPFS path
+    // that can be accessed with IPFS client.
+    resolveToIpfsPath (urlOrPath) {
+      const input = urlOrPath
+      // Try to normalize to IPFS path (gateway path or CID-in-subdomain)
+      const ipfsPath = normalizedIpfsPath(input)
+      if (ipfsPath) return ipfsPath
+      // Check URL for DNSLink
+      if (!input.startsWith('http')) return null
+      const { hostname } = new URL(input)
+      const dnslink = dnslinkResolver.cachedDnslink(hostname)
+      if (dnslink) {
+        // Return full IPNS path (keeps pathname + ?search + #hash)
+        return dnslinkResolver.convertToIpnsPath(input)
+      }
+      // No IPFS path by this point
+      return null
+    },
+
+    // Resolve URL or path to Immutable IPFS Path:
+    // - Same as resolveToIpfsPath, but the path is always immutable /ipfs/
+    // - Keeps pathname + ?search + #hash from original URL
+    // - Returns null if no valid path can be produced
+    // The purpose of this resolver is to return immutable /ipfs/ address
+    // even if /ipns/ is present in its input.
+    async resolveToImmutableIpfsPath (urlOrPath) {
+      const path = ipfsPathValidator.resolveToIpfsPath(urlOrPath)
+      // Fail fast if no IPFS Path
+      if (!path) return null
+      // Resolve /ipns/ → /ipfs/
+      if (IsIpfs.ipnsPath(path)) {
+        const labels = path.split('/')
+        // We resolve /ipns/<fqdn> as value in DNSLink cache may be out of date
+        const ipnsRoot = `/ipns/${labels[2]}`
+        const result = await getIpfs().name.resolve(ipnsRoot, { recursive: true, nocache: false })
+        // Old API returned object, latest one returns string ¯\_(ツ)_/¯
+        const ipfsRoot = result.Path ? result.Path : result
+        // Return original path with swapped root (keeps pathname + ?search + #hash)
+        return path.replace(ipnsRoot, ipfsRoot)
+      }
+      // Return /ipfs/ path
+      return path
+    },
+
+    // TODO: add description and tests
+    // Resolve URL or path to a raw CID:
+    // - Result is the direct CID
+    // - Ignores ?search and #hash from original URL
+    // - Returns null if no CID can be produced
+    async resolveToCid (urlOrPath) {
+      const path = ipfsPathValidator.resolveToIpfsPath(urlOrPath)
+      // Fail fast if no IPFS Path
+      if (!path) return null
+      // Resolve to raw CID
+      const rawPath = trimHashAndSearch(path)
+      const result = await getIpfs().resolve(rawPath, { recursive: true, dhtt: '5s', dhtrc: 1 })
+      const directCid = result.split('/')[2]
+      return directCid
     }
+
   }
 
   return ipfsPathValidator
@@ -122,6 +217,7 @@ function validIpnsPath (path, dnsLink) {
       return true
     }
     // then see if there is an DNSLink entry for 'ipnsRoot' hostname
+    // TODO: use dnslink cache only
     if (dnsLink.readAndCacheDnslink(ipnsRoot)) {
       // console.log('==> IPNS for FQDN with valid dnslink: ', ipnsRoot)
       return true

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -155,7 +155,6 @@ function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
             return await resolve()
           } catch (err) {
             const fqdn = ipnsRoot.replace(/^.*\/ipns\/([^/]+).*/, '$1')
-            console.log('fqdn:' + ipnsRoot, fqdn)
             if (err.message === 'Non-base58 character' && isFQDN(fqdn)) {
               // js-ipfs without dnslink support, fallback to the value read from DNSLink
               const dnslink = dnslinkResolver.readAndCacheDnslink(fqdn)

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -93,7 +93,6 @@ module.exports = (state, emitter) => {
     }
     state.isPinning = false
     emitter.emit('render')
-    window.close()
   })
 
   emitter.on('unPin', async function unPinCurrentResource () {
@@ -112,7 +111,6 @@ module.exports = (state, emitter) => {
     }
     state.isUnPinning = false
     emitter.emit('render')
-    window.close()
   })
 
   async function handlePinError (errorMessageKey, error) {

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -322,6 +322,6 @@ async function resolveToPinPath (ipfs, url) {
   // https://github.com/ipfs-shipyard/ipfs-companion/issues/567
   // https://github.com/ipfs/ipfs-companion/issues/303
   const pathValidator = await getIpfsPathValidator()
-  const pinPath = trimHashAndSearch(pathValidator.resolveToImmutableIpfsPath(url))
+  const pinPath = trimHashAndSearch(await pathValidator.resolveToImmutableIpfsPath(url))
   return pinPath
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "request-progress": "3.0.0",
     "shx": "0.3.2",
     "simple-progress-webpack-plugin": "1.1.2",
-    "sinon": "7.2.3",
+    "sinon": "7.2.7",
     "sinon-chrome": "2.3.2",
     "standard": "12.0.1",
     "tar": "4.4.8",

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -1,42 +1,96 @@
 'use strict'
+const { stub } = require('sinon')
 const { describe, it, beforeEach } = require('mocha')
 const { expect } = require('chai')
 const { URL } = require('url')
-const { safeIpfsPath, createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
+const { normalizedIpfsPath, createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
 const { initState } = require('../../../add-on/src/lib/state')
 const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
+const { spoofCachedDnslink } = require('./dnslink.test.js')
+
+function spoofIpnsRecord (ipfs, ipnsPath, value) {
+  if (ipfs.name.resolve.reset) ipfs.name.resolve.reset()
+  const resolve = stub(ipfs.name, 'resolve')
+  resolve.withArgs(ipnsPath).resolves(value)
+  resolve.throws((arg) => new Error(`Unexpected stubbed call ipfs.name.resolve(${arg})`))
+}
+
+function spoofIpfsResolve (ipfs, path, value) {
+  if (ipfs.resolve.reset) ipfs.resolve.reset()
+  const resolve = stub(ipfs, 'resolve')
+  resolve.withArgs(path).resolves(value)
+  resolve.throws((arg) => new Error(`Unexpected stubbed call ipfs.resolve(${arg})`))
+}
 
 // https://github.com/ipfs/ipfs-companion/issues/303
 describe('ipfs-path.js', function () {
-  let state, dnslinkResolver, ipfsPathValidator
+  let ipfs, state, dnslinkResolver, ipfsPathValidator
+
   beforeEach(function () {
     global.URL = URL
     state = Object.assign(initState(optionDefaults), { peerCount: 1 })
-    const getState = () => state
-    dnslinkResolver = createDnslinkResolver(getState)
-    ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
+    ipfs = {
+      name: {
+        resolve (arg) {
+          throw new Error(`Unexpected call ipfs.name.resolve(${arg})`)
+        }
+      },
+      resolve (arg) {
+        throw new Error(`Unexpected call ipfs.resolve(${arg})`)
+      }
+    }
+    dnslinkResolver = createDnslinkResolver(() => state)
+    ipfsPathValidator = createIpfsPathValidator(() => state, () => ipfs, dnslinkResolver)
   })
-  describe('safeIpfsPath(pathOrUrl) should produce no changes', function () {
-    it('for URL without special characters', function () {
-      const path = 'https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
-      expect(safeIpfsPath(path)).to.equal('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+
+  describe('normalizedIpfsPath', function () {
+    it('should detect /ipfs/ path in URL from a public gateway', function () {
+      const url = 'https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
+      expect(normalizedIpfsPath(url)).to.equal('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar')
     })
-    it('for path without special characters', function () {
+    it('should detect /ipfs/ path in detached IPFS path', function () {
+      const path = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
+      expect(normalizedIpfsPath(path)).to.equal('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar')
+    })
+    it('should detect /ipns/ path in URL from a public gateway', function () {
+      const url = 'https://ipfs.io/ipns/libp2p.io/bundles/'
+      expect(normalizedIpfsPath(url)).to.equal('/ipns/libp2p.io/bundles/')
+    })
+    it('should detect /ipns/ path in detached IPFS path', function () {
+      const path = '/ipns/libp2p.io/bundles/'
+      expect(normalizedIpfsPath(path)).to.equal('/ipns/libp2p.io/bundles/')
+    })
+    it('should preserve search and hash in URL from a public gateway', function () {
+      const url = 'https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
+      expect(normalizedIpfsPath(url)).to.equal('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+    })
+    it('should preserve search and hash in detached IPFS path', function () {
       const path = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
-      expect(safeIpfsPath(path)).to.equal('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      expect(normalizedIpfsPath(path)).to.equal('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
     })
-  })
-  describe('safeIpfsPath(pathOrUrl) should normalize', function () {
-    it('URL with special characters', function () {
+    it('should decode special characters in URL', function () {
       const url = 'https://ipfs.io/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1%20-%20Barrel%20-%20Part%201'
-      expect(safeIpfsPath(url)).to.equal('/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1 - Barrel - Part 1')
+      expect(normalizedIpfsPath(url)).to.equal('/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1 - Barrel - Part 1')
     })
-    it('path with special characters', function () {
+    it('should decode special characters in path', function () {
       const path = '/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1%20-%20Barrel%20-%20Part%201'
-      expect(safeIpfsPath(path)).to.equal('/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1 - Barrel - Part 1')
+      expect(normalizedIpfsPath(path)).to.equal('/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1 - Barrel - Part 1')
+    })
+    it('should resolve CID-in-subdomain URL to IPFS path', function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(normalizedIpfsPath(url)).to.equal('/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('should return null if there is no valid path for input URL', function () {
+      const url = 'https://foo.io/invalid/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
+      expect(normalizedIpfsPath(url)).to.equal(null)
+    })
+    it('should return null if there is no valid path for input path', function () {
+      const path = '/invalid/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      expect(normalizedIpfsPath(path)).to.equal(null)
     })
   })
+
   describe('validIpfsOrIpnsPath', function () {
     // this is just a smoke test, extensive tests are in is-ipfs package
     it('should return true for IPFS NURI', function () {
@@ -48,6 +102,7 @@ describe('ipfs-path.js', function () {
       expect(ipfsPathValidator.validIpfsOrIpnsPath(path)).to.equal(false)
     })
   })
+
   describe('validIpfsOrIpnsUrl', function () {
     // this is just a smoke test, extensive tests are in is-ipfs package
     it('should return true for URL at IPFS Gateway', function () {
@@ -59,6 +114,7 @@ describe('ipfs-path.js', function () {
       expect(ipfsPathValidator.validIpfsOrIpnsUrl(url)).to.equal(false)
     })
   })
+
   describe('publicIpfsOrIpnsResource', function () {
     it('should return true for URL at Public IPFS Gateway', function () {
       const url = `${state.pubGwURL}ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest`
@@ -99,6 +155,7 @@ describe('ipfs-path.js', function () {
       })
     })
   })
+
   describe('isIpfsPageActionsContext', function () {
     it('should return true for URL at a Gateway', function () {
       const url = 'https://example.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
@@ -119,6 +176,7 @@ describe('ipfs-path.js', function () {
       expect(ipfsPathValidator.isIpfsPageActionsContext(url)).to.equal(false)
     })
   })
+
   describe('isRedirectPageActionsContext', function () {
     it('should return true for /ipfs/ URL at a Gateway', function () {
       const url = 'https://example.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
@@ -142,16 +200,211 @@ describe('ipfs-path.js', function () {
       expect(ipfsPathValidator.isRedirectPageActionsContext(url)).to.equal(true)
     })
     it('should return true for non-IPFS HTTP URL', function () {
-      const url = 'https://en.wikipedia.org/wiki/Main_Page'
+      const url = 'http://en.wikipedia.org/wiki/Main_Page'
       expect(ipfsPathValidator.isRedirectPageActionsContext(url)).to.equal(true)
     })
     it('should return true for non-IPFS HTTPS URL', function () {
-      const url = 'http://en.wikipedia.org/wiki/Main_Page'
+      const url = 'https://en.wikipedia.org/wiki/Main_Page'
       expect(ipfsPathValidator.isRedirectPageActionsContext(url)).to.equal(true)
     })
     it('should return false for non-HTTP URL', function () {
       const url = 'moz-extension://85076b5e-900c-428f-4bf6-e6c1a33042a7/blank-page.html'
       expect(ipfsPathValidator.isRedirectPageActionsContext(url)).to.equal(false)
+    })
+  })
+
+  describe('resolveToPublicUrl', function () {
+    it('should resolve URL with CID-in-subdomain to itself', function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(url)).to.equal(url)
+    })
+    it('should resolve URL with /ipfs/ path to the default public gateway', function () {
+      const url = 'https://example.com/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(url)).to.equal(`${state.pubGwURL}ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest`)
+    })
+    it('should resolve URL with /ipfs/ path to the custom gateway if provided', function () {
+      const url = 'https://example.com/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(url, 'https://example.com/')).to.equal(`https://example.com/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest`)
+    })
+    it('should resolve /ipfs/ path to itself attached to the default public gateway', function () {
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(path)).to.equal(`${state.pubGwURL}ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest`)
+    })
+    it('should resolve URL with /ipns/ path to the default public gateway', function () {
+      const url = 'https://example.com/ipns/docs.ipfs.io/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(url)).to.equal(`${state.pubGwURL}ipns/docs.ipfs.io/?argTest#hashTest`)
+    })
+    it('should resolve /ipns/ path to itself at the default public gateway', function () {
+      const path = '/ipns/docs.ipfs.io/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(path)).to.equal(`${state.pubGwURL}ipns/docs.ipfs.io/?argTest#hashTest`)
+    })
+    it('should resolve non-IPFS URL to itself (DNSLink websites)', function () {
+      const url = 'https://example.com/foo/bar/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(url)).to.equal(url)
+    })
+    it('should resolve to null if input is an invalid path', function () {
+      const path = '/foo/bar/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(path)).to.equal(null)
+    })
+    it('should resolve to null if input is an invalid URL', function () {
+      const url = 'example.com/foo/bar/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToPublicUrl(url)).to.equal(null)
+    })
+  })
+
+  describe('resolveToIpfsPath', function () {
+    it('should resolve URL with CID-in-subdomain to /ipfs/<cid> path', function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(url)).to.equal('/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('should resolve URL with /ipfs/ path to the path itself', function () {
+      const url = 'https://example.com/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(url)).to.equal('/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('should resolve /ipfs/ path to itself', function () {
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(path)).to.equal(path)
+    })
+    it('should resolve URL with /ipns/ path to the path itself', function () {
+      const url = 'https://example.com/ipns/docs.ipfs.io/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(url)).to.equal('/ipns/docs.ipfs.io/?argTest#hashTest')
+    })
+    it('should resolve /ipns/ path to itself', function () {
+      const path = '/ipns/docs.ipfs.io/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(path)).to.equal(path)
+    })
+    it('should resolve URL of a DNSLink website to null if the value if DNSLink is not in cache', function () {
+      const url = 'https://docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest'
+      spoofCachedDnslink(new URL(url).hostname, dnslinkResolver, undefined)
+      expect(ipfsPathValidator.resolveToIpfsPath(url)).to.equal(null)
+    })
+    it('should resolve URL of a DNSLink website to /ipns/<fqdn> path if DNSLink is in cache', function () {
+      const url = 'https://docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest'
+      const dnslinkValue = '/ipns/QmRV5iNhGoxBaAcbucMAW9WtVHbeehXhAdr5CZQDhL55Xk'
+      spoofCachedDnslink(new URL(url).hostname, dnslinkResolver, dnslinkValue)
+      expect(ipfsPathValidator.resolveToIpfsPath(url)).to.equal('/ipns/docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest')
+    })
+    it('should resolve to null if input is an invalid path', function () {
+      const path = '/foo/bar/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(path)).to.equal(null)
+    })
+    it('should resolve to null if input is an invalid URL', function () {
+      const url = 'example.com/foo/bar/?argTest#hashTest'
+      expect(ipfsPathValidator.resolveToIpfsPath(url)).to.equal(null)
+    })
+  })
+
+  describe('async resolveToImmutableIpfsPath', function () {
+    it('should resolve URL with CID-in-subdomain to the same value as resolveToIpfsPath', async function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(ipfsPathValidator.resolveToIpfsPath(url))
+    })
+    it('should resolve URL with /ipfs/ path to the same value as resolveToIpfsPath', async function () {
+      const url = 'https://example.com/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(ipfsPathValidator.resolveToIpfsPath(url))
+    })
+    it('should resolve /ipfs/ path to the same value as resolveToIpfsPath', async function () {
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(path)).to.equal(ipfsPathValidator.resolveToIpfsPath(path))
+    })
+    it('should resolve URL with /ipns/ path to the immutable /ipfs/ path', async function () {
+      const url = 'https://example.com/ipns/docs.ipfs.io/?argTest#hashTest'
+      const ipnsPointer = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      spoofIpnsRecord(ipfs, '/ipns/docs.ipfs.io', ipnsPointer)
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(ipnsPointer + '/?argTest#hashTest')
+    })
+    it('should resolve /ipns/ path to the immutable /ipfs/ one', async function () {
+      const ipnsPointer = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      spoofIpnsRecord(ipfs, '/ipns/libp2p.io', ipnsPointer)
+      const path = '/ipns/libp2p.io/?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(path)).to.equal(ipnsPointer + '/?argTest#hashTest')
+    })
+    it('should resolve URL of a DNSLink website to null if the value if DNSLink is not in cache', async function () {
+      const url = 'https://docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest'
+      spoofCachedDnslink(new URL(url).hostname, dnslinkResolver, undefined)
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(null)
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(ipfsPathValidator.resolveToIpfsPath(url))
+    })
+    it('should resolve URL of a DNSLink website to the immutable /ipfs/ address behind mutable /ipns/ DNSLink in cache', async function () {
+      const url = 'https://docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest'
+      // Use IPNS in DNSLINK to ensure resolveToImmutableIpfsPath does resursive resolv to immutable address
+      const dnslinkValue = '/ipns/QmRV5iNhGoxBaAcbucMAW9WtVHbeehXhAdr5CZQDhL55Xk'
+      const ipnsPointer = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      const { hostname } = new URL(url)
+      spoofCachedDnslink(hostname, dnslinkResolver, dnslinkValue)
+      // We need to spoof IPNS lookup for /ipns/<fqdn> because value from DNSLink cache
+      // may be out of date and resolveToImmutableIpfsPath does additional resolv
+      // to return latest IPNS value
+      spoofIpnsRecord(ipfs, `/ipns/${hostname}`, ipnsPointer)
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(ipnsPointer + '/guides/concepts/dnslink/?argTest#hashTest')
+    })
+    it('should resolve to null if input is an invalid path', async function () {
+      const path = '/foo/bar/?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(path)).to.equal(null)
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(path)).to.equal(ipfsPathValidator.resolveToIpfsPath(path))
+    })
+    it('should resolve to null if input is an invalid URL', async function () {
+      const url = 'example.com/foo/bar/?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(null)
+      expect(await ipfsPathValidator.resolveToImmutableIpfsPath(url)).to.equal(ipfsPathValidator.resolveToIpfsPath(url))
+    })
+  })
+
+  describe('async resolveToCid', function () {
+    it('should resolve URL with CID-in-subdomain', async function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      const expectedCid = 'bafkreig6ltd5dojmrhlsweuiaxt3ag2p5644wwcyjmqt6gajmbrbylke4m'
+      spoofIpfsResolve(ipfs, '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html', '/ipfs/' + expectedCid)
+      expect(await ipfsPathValidator.resolveToCid(url)).to.equal(expectedCid)
+    })
+    it('should resolve URL with /ipfs/ path', async function () {
+      const url = 'https://example.com/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      const expectedCid = 'bafkreig6ltd5dojmrhlsweuiaxt3ag2p5644wwcyjmqt6gajmbrbylke4m'
+      spoofIpfsResolve(ipfs, '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html', '/ipfs/' + expectedCid)
+      expect(await ipfsPathValidator.resolveToCid(url)).to.equal(expectedCid)
+    })
+    it('should resolve /ipfs/ path', async function () {
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      const expectedCid = 'bafkreig6ltd5dojmrhlsweuiaxt3ag2p5644wwcyjmqt6gajmbrbylke4m'
+      spoofIpfsResolve(ipfs, '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html', '/ipfs/' + expectedCid)
+      expect(await ipfsPathValidator.resolveToCid(path)).to.equal(expectedCid)
+    })
+    it('should resolve URL with /ipns/ path', async function () {
+      const url = 'https://example.com/ipns/docs.ipfs.io/foo/bar?argTest#hashTest'
+      const expectedCid = 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      spoofIpfsResolve(ipfs, `/ipns/docs.ipfs.io/foo/bar`, `/ipfs/${expectedCid}`)
+      expect(await ipfsPathValidator.resolveToCid(url)).to.equal(expectedCid)
+    })
+    it('should resolve /ipns/ path to the immutable /ipfs/ one', async function () {
+      const path = '/ipns/libp2p.io/foo/bar?argTest#hashTest'
+      const expectedCid = 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      spoofIpfsResolve(ipfs, `/ipns/libp2p.io/foo/bar`, `/ipfs/${expectedCid}`)
+      expect(await ipfsPathValidator.resolveToCid(path)).to.equal(expectedCid)
+    })
+    it('should resolve URL of a DNSLink website to null if the value if DNSLink is not in cache', async function () {
+      const url = 'https://docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest'
+      spoofCachedDnslink(new URL(url).hostname, dnslinkResolver, undefined)
+      expect(await ipfsPathValidator.resolveToCid(url)).to.equal(null)
+    })
+    it('should resolve URL of a DNSLink website if DNSLink is in cache', async function () {
+      const url = 'https://docs.ipfs.io/guides/concepts/dnslink/?argTest#hashTest'
+      // Use IPNS in DNSLINK to ensure resolveToImmutableIpfsPath does resursive resolv to immutable address
+      const expectedCid = 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+      const dnslinkValue = '/ipns/QmRV5iNhGoxBaAcbucMAW9WtVHbeehXhAdr5CZQDhL55Xk'
+      const { hostname } = new URL(url)
+      spoofCachedDnslink(hostname, dnslinkResolver, dnslinkValue)
+      // Note the DNSLink value is ignored, and /ipns/<fqdn> is passed to ipfs.resolv internally
+      // This ensures the latest pointer is returned, instead of stale value from DNSLink cache
+      spoofIpfsResolve(ipfs, `/ipns/docs.ipfs.io/guides/concepts/dnslink/`, `/ipfs/${expectedCid}`)
+      expect(await ipfsPathValidator.resolveToCid(url)).to.equal(expectedCid)
+    })
+    it('should resolve to null if input is an invalid path', async function () {
+      const path = '/foo/bar/?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToCid(path)).to.equal(null)
+    })
+    it('should resolve to null if input is an invalid URL', async function () {
+      const url = 'example.com/foo/bar/?argTest#hashTest'
+      expect(await ipfsPathValidator.resolveToCid(url)).to.equal(null)
     })
   })
 })

--- a/test/functional/lib/ipfs-request-dnslink.test.js
+++ b/test/functional/lib/ipfs-request-dnslink.test.js
@@ -39,9 +39,10 @@ describe('modifyRequest processing', function () {
       pubGwURLString: 'https://ipfs.io'
     })
     const getState = () => state
+    const getIpfs = () => {}
     dnslinkResolver = createDnslinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
-    ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
+    ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
     modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
   })
 

--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -47,9 +47,10 @@ describe('modifyRequest.onBeforeRequest:', function () {
       pubGwURL: new URL('https://ipfs.io')
     })
     const getState = () => state
+    const getIpfs = () => {}
     dnslinkResolver = createDnslinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
-    ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
+    ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
     modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
   })
 

--- a/test/functional/lib/ipfs-request-protocol-handlers.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.js
@@ -35,9 +35,10 @@ describe('modifyRequest.onBeforeRequest:', function () {
       pubGwURLString: 'https://ipfs.io'
     })
     const getState = () => state
+    const getIpfs = () => {}
     dnslinkResolver = createDnslinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
-    ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
+    ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
     modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
   })
 

--- a/test/functional/lib/ipfs-request-workarounds.test.js
+++ b/test/functional/lib/ipfs-request-workarounds.test.js
@@ -32,9 +32,10 @@ describe('modifyRequest processing', function () {
   beforeEach(async function () {
     state = initState(optionDefaults)
     getState = () => state
+    const getIpfs = () => {}
     dnslinkResolver = createDnslinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
-    ipfsPathValidator = createIpfsPathValidator(getState, dnslinkResolver)
+    ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
     modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,7 +728,14 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.1":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^1.0.2":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
   integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
@@ -749,7 +756,15 @@
   dependencies:
     "@sinonjs/samsam" "^2 || ^3"
 
-"@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.0.2":
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^2 || ^3":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
   integrity sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==
@@ -757,6 +772,20 @@
     "@sinonjs/commons" "^1.0.2"
     array-from "^2.1.1"
     lodash.get "^4.4.2"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.2.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.0.tgz#9557ea89cd39dbc94ffbd093c8085281cac87416"
+  integrity sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash "^4.17.11"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@types/node@*":
   version "10.12.15"
@@ -8288,10 +8317,10 @@ lolex@^2.2.0, lolex@^2.3.2:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
   integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
 
-lolex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
-  integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
+lolex@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
+  integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
 
 looper@^3.0.0, looper@~3.0.0:
   version "3.0.0"
@@ -9169,7 +9198,7 @@ nigel@2.x.x:
     hoek "4.x.x"
     vise "2.x.x"
 
-nise@^1.2.0, nise@^1.4.8:
+nise@^1.2.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.8.tgz#ce91c31e86cf9b2c4cac49d7fcd7f56779bfd6b0"
   integrity sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==
@@ -9179,6 +9208,17 @@ nise@^1.2.0, nise@^1.4.8:
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
+
+nise@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.10.tgz#ae46a09a26436fae91a38a60919356ae6db143b6"
+  integrity sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -11840,17 +11880,17 @@ sinon-chrome@2.3.2:
     sinon "^4.4.2"
     urijs "^1.18.2"
 
-sinon@7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.3.tgz#f8bfd956df32ddf592f8c102fd46982366412d8e"
-  integrity sha512-i6j7sqcLEqTYqUcMV327waI745VASvYuSuQMCjbAwlpAeuCgKZ3LtrjDxAbu+GjNQR0FEDpywtwGCIh8GicNyg==
+sinon@7.2.7:
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.7.tgz#ee90f83ce87d9a6bac42cf32a3103d8c8b1bfb68"
+  integrity sha512-rlrre9F80pIQr3M36gOdoCEWzFAMDgHYD8+tocqOw+Zw9OZ8F84a80Ds69eZfcjnzDqqG88ulFld0oin/6rG/g==
   dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    "@sinonjs/formatio" "^3.1.0"
-    "@sinonjs/samsam" "^3.0.2"
+    "@sinonjs/commons" "^1.3.1"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.2.0"
     diff "^3.5.0"
-    lolex "^3.0.0"
-    nise "^1.4.8"
+    lolex "^3.1.0"
+    nise "^1.4.10"
     supports-color "^5.5.0"
 
 sinon@^4.4.2:


### PR DESCRIPTION
> cc #689 

When we introduced option to opt-out from redirect per site (#687 ) it came with a side effect of removing IPFS context actions. 

This PR:

-  Adds context actions on DNSLink sites (when redirect is disabled)
   ![Peek 2019-03-12 13-56](https://user-images.githubusercontent.com/157609/54201719-a133f780-44ce-11e9-8d39-fa39e1d9548a.gif)
    >  This adds context actions such as "Copy IPFS path", "Copy CID", "Pin" to DNSLink websites without redirect. 
    > 
    > It includes refactoring of ipfsPathValidator to expose high level resolvers used in various places by the Companion:
    > 
    > - `resolveToPublicUrl`: always return a meaningful, publicly accessible URL that can be accessed without the need of IPFS client.
    > - `resolveToIpfsPath`: return a valid IPFS path that can be accessed with IPFS client.
    > - `resolveToImmutableIpfsPath`: same as resolveToIpfsPath, but the path is always immutable /ipfs/
    > - `resolveToCid`: returns direct CID without anything else
- Adds a bunch of tests
- Tweaks behavior of pin/unpin via browser action menu
  > In the past we closed menu after toggling pin status, but now we have a nice visual toggle switch and other uses of the switch do not close the menu, so we unified behavior and toggle action no longer closes the popup menu.
- Works around missing dnslink resolver under js-ipfs
  > js-ipfs v0.34 does not support DNSLinks in `ipfs*resolve` methods yet: ipfs/js-ipfs#1918
  > This temporary workaround detects known errors and falls back to using path from DNSLink cache. It won't be as fresh as original, but at least resolv will work.