### PR TITLE
Fix flashing of pin/unpin toggle

### DIFF
--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -26,7 +26,8 @@ function contextActions ({
   onPin,
   onUnPin
 }) {
-  const activePinControls = active && isIpfsOnline && isApiAvailable && !(isPinning || isUnPinning)
+  const activeCidResolver = active && isIpfsOnline && isApiAvailable
+  const activePinControls = active && isIpfsOnline && isApiAvailable
 
   const renderIpfsContextItems = () => {
     if (!isIpfsContext) return
@@ -41,14 +42,14 @@ function contextActions ({
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),
-    disabled: !activePinControls,
+    disabled: !activeCidResolver,
     onClick: () => onCopy(contextMenuCopyRawCid)
   })}
   ${navItem({
     text: browser.i18n.getMessage('panel_pinCurrentIpfsAddress'),
     title: browser.i18n.getMessage('panel_pinCurrentIpfsAddressTooltip'),
     disabled: !activePinControls,
-    switchValue: isPinned,
+    switchValue: (isPinned || isPinning) && !isUnPinning,
     onClick: isPinned ? onUnPin : onPin
   })}
   </div>


### PR DESCRIPTION
This removes flashing/jitter during pinning caused by brief
disabled/enabled state change.

(Since we now have a toggle, there is no need for disabling the toggle during pinning/unpinning states)

![Peek 2019-03-18 01-20](https://user-images.githubusercontent.com/157609/54500337-144ccc00-491c-11e9-8d04-327c903d26ee.gif)
