### PR TITLE
manifest.common.json: disallow running in incognito mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "firefox": 65,
+          "firefox": 67,
           "chrome": 70
         }
       }

--- a/add-on/manifest.common.json
+++ b/add-on/manifest.common.json
@@ -58,5 +58,6 @@
     }
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'; frame-src 'self';",
-  "default_locale": "en"
+  "default_locale": "en",
+  "incognito": "not_allowed"
 }

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "ipfs-firefox-addon@lidel.org",
-      "strict_min_version": "65.0"
+      "strict_min_version": "67.0"
     }
   },
   "page_action": {


### PR DESCRIPTION
I am not entirely sure this came to the correct spot as there are no examples that I could see and I think `incognito` could logically be a permission. 

Requested in https://github.com/ipfs-shipyard/ipfs-companion/issues/704#issuecomment-478929763. Closes #704