### PR TITLE
Support configurable logger namespaces

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -399,6 +399,14 @@
     "message": "Enables automatic preload of uploaded assets via asynchronous HTTP HEAD request to a Public Gateway",
     "description": "An option description on the Preferences screen (option_preloadAtPublicGateway_description)"
   },
+  "option_logNamespaces_title": {
+    "message": "Log Namespaces",
+    "description": "An option title for tweaking log level (option_logNamespaces_title)"
+  },
+  "option_logNamespaces_description": {
+    "message": "Customize which namespaces are logged to Browser Console. Changing this value will trigger extension restart.",
+    "description": "An option description for the log level (option_logNamespaces_description)"
+  },
   "option_resetAllOptions_title": {
     "message": "Reset Everything",
     "description": "An option title and button label on the Preferences screen (option_resetAllOptions_title)"

--- a/add-on/src/background/background.js
+++ b/add-on/src/background/background.js
@@ -1,19 +1,18 @@
 'use strict'
 /* eslint-env browser, webextensions */
 
-// Enable some debug output from js-ipfs
-// (borrowed from https://github.com/ipfs-shipyard/ipfs-companion/pull/557)
-// to include everything (mplex, libp2p, mss): localStorage.debug = '*'
-localStorage.debug = 'jsipfs*,ipfs*,-*:mfs*,-*:ipns*,-ipfs:preload*'
-
 const browser = require('webextension-polyfill')
-const createIpfsCompanion = require('../lib/ipfs-companion')
 const { onInstalled } = require('../lib/on-installed')
+const { optionDefaults } = require('../lib/options')
 
 // register onInstalled hook early, otherwise we miss first install event
 browser.runtime.onInstalled.addListener(onInstalled)
 
 // init add-on after all libs are loaded
 document.addEventListener('DOMContentLoaded', async () => {
+  // setting debug level early
+  localStorage.debug = (await browser.storage.local.get({ logNamespaces: optionDefaults.logNamespaces })).logNamespaces
+  // init inlined to read updated localStorage.debug
+  const createIpfsCompanion = require('../lib/ipfs-companion')
   window.ipfsCompanion = await createIpfsCompanion()
 })

--- a/add-on/src/landing-pages/welcome/store.js
+++ b/add-on/src/landing-pages/welcome/store.js
@@ -10,7 +10,6 @@ function createWelcomePageStore (i18n, runtime) {
       emitter.emit('render')
       port = runtime.connect({ name: 'browser-action-port' })
       port.onMessage.addListener(async (message) => {
-        console.log('port.onMessage', message)
         if (message.statusUpdate) {
           const peerCount = message.statusUpdate.peerCount
           const isIpfsOnline = peerCount > -1

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -2,6 +2,10 @@
 
 const browser = require('webextension-polyfill')
 
+const debug = require('debug')
+const log = debug('ipfs-companion:context-menus')
+log.error = debug('ipfs-companion:context-menus:error')
+
 // mapping between context name and field with data for it
 // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/ContextType
 const contextSources = {
@@ -142,12 +146,12 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
   } catch (err) {
     // documentUrlPatterns is not supported in Muon-Brave
     if (err.message.indexOf('createProperties.documentUrlPatterns of contextMenus.create is not supported yet') > -1) {
-      console.warn('[ipfs-companion] Context menus disabled - createProperties.documentUrlPatterns of contextMenus.create is not supported yet')
+      log('context menus disabled - createProperties.documentUrlPatterns of contextMenus.create is not supported yet')
       return { update: () => Promise.resolve() }
     }
     // contextMenus are not supported in Firefox for Android
     if (err.message === 'browser.contextMenus is undefined' || typeof browser.contextMenus === 'undefined') {
-      console.warn('[ipfs-companion] Context menus disabled - browser.contextMenus is undefined')
+      log('context menus disabled - browser.contextMenus is undefined')
       return { update: () => Promise.resolve() }
     }
     throw err
@@ -179,7 +183,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
           await browser.contextMenus.update(item, { enabled: (ifApi && ipfsContext) })
         }
       } catch (err) {
-        console.log('[ipfs-companion] Error updating context menus', err)
+        log.error('Error updating context menus', err)
       }
     }
 

--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -1,6 +1,10 @@
 'use strict'
 /* eslint-env browser */
 
+const debug = require('debug')
+const log = debug('ipfs-companion:dnslink')
+log.error = debug('ipfs-companion:dnslink:error')
+
 const IsIpfs = require('is-ipfs')
 const LRU = require('lru-cache')
 const PQueue = require('p-queue')
@@ -64,18 +68,18 @@ module.exports = function createDnslinkResolver (getState) {
       let dnslink = dnslinkResolver.cachedDnslink(fqdn)
       if (typeof dnslink === 'undefined') {
         try {
-          console.info(`[ipfs-companion] dnslink cache miss for '${fqdn}', running DNS TXT lookup`)
+          log(`dnslink cache miss for '${fqdn}', running DNS TXT lookup`)
           dnslink = dnslinkResolver.readDnslinkFromTxtRecord(fqdn)
           if (dnslink) {
             // TODO: set TTL as maxAge: setDnslink(fqdn, dnslink, maxAge)
             dnslinkResolver.setDnslink(fqdn, dnslink)
-            console.info(`[ipfs-companion] found dnslink: '${fqdn}' -> '${dnslink}'`)
+            log(`found dnslink: '${fqdn}' -> '${dnslink}'`)
           } else {
             dnslinkResolver.setDnslink(fqdn, false)
-            console.info(`[ipfs-companion] found NO dnslink for '${fqdn}'`)
+            log(`found NO dnslink for '${fqdn}'`)
           }
         } catch (error) {
-          console.error(`[ipfs-companion] Error in readAndCacheDnslink for '${fqdn}'`)
+          log.error(`error in readAndCacheDnslink for '${fqdn}'`, error)
           console.error(error)
         }
       } else {

--- a/add-on/src/lib/ipfs-client/embedded-chromesockets.js
+++ b/add-on/src/lib/ipfs-client/embedded-chromesockets.js
@@ -1,7 +1,10 @@
 'use strict'
 /* eslint-env browser, webextensions */
 const browser = require('webextension-polyfill')
+
 const debug = require('debug')
+const log = debug('ipfs-companion:client:embedded')
+log.error = debug('ipfs-companion:client:embedded:error')
 
 // Polyfills required by embedded HTTP server
 const uptimeStart = Date.now()
@@ -23,9 +26,6 @@ let nodeHttpApi = null
 // additional servers for smoke-tests
 // let httpServer = null
 // let hapiServer = null
-
-const log = debug('ipfs-companion:client:embedded')
-log.error = debug('ipfs-companion:client:embedded:error')
 
 exports.init = function init (opts) {
   /*

--- a/add-on/src/lib/ipfs-client/embedded.js
+++ b/add-on/src/lib/ipfs-client/embedded.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const debug = require('debug')
+const log = debug('ipfs-companion:client:embedded')
+log.error = debug('ipfs-companion:client:embedded:error')
+
 const mergeOptions = require('merge-options')
 const Ipfs = require('ipfs')
 const { optionDefaults } = require('../options')
@@ -7,7 +11,7 @@ const { optionDefaults } = require('../options')
 let node = null
 
 exports.init = function init (opts) {
-  console.log('[ipfs-companion] Embedded ipfs init')
+  log('init')
 
   const defaultOpts = JSON.parse(optionDefaults.ipfsNodeConfig)
   const userOpts = JSON.parse(opts.ipfsNodeConfig)
@@ -17,7 +21,7 @@ exports.init = function init (opts) {
 
   return new Promise((resolve, reject) => {
     node.once('error', (error) => {
-      console.error('[ipfs-companion] Something went terribly wrong during startup of js-ipfs!', error)
+      log.error('something went terribly wrong during startup of js-ipfs!', error)
       reject(error)
     })
     node.once('ready', async () => {
@@ -25,7 +29,7 @@ exports.init = function init (opts) {
         resolve(node)
       })
       node.on('error', error => {
-        console.error('[ipfs-companion] Something went terribly wrong in embedded js-ipfs!', error)
+        log.error('something went terribly wrong in embedded js-ipfs!', error)
       })
       try {
         await node.start()
@@ -37,7 +41,7 @@ exports.init = function init (opts) {
 }
 
 exports.destroy = async function () {
-  console.log('[ipfs-companion] Embedded ipfs destroy')
+  log('destroy')
   if (!node) return
 
   await node.stop()

--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -1,10 +1,14 @@
 'use strict'
 /* eslint-env browser */
 
+const debug = require('debug')
+const log = debug('ipfs-companion:client:external')
+log.error = debug('ipfs-companion:client:external:error')
+
 const IpfsApi = require('ipfs-http-client')
 
 exports.init = async function (opts) {
-  console.log('[ipfs-companion] External ipfs init', opts.apiURLString)
+  log(`init with API: ${opts.apiURLString}`)
 
   const url = opts.apiURL
   const protocol = url.protocol.substr(0, url.protocol.length - 1) // http: -> http
@@ -14,7 +18,7 @@ exports.init = async function (opts) {
 }
 
 exports.destroy = async function () {
-  console.log('[ipfs-companion] External ipfs destroy')
+  log('destroy')
 }
 
 // TODO: Upgrade to a caching proxy for ipfs-http-client

--- a/add-on/src/lib/ipfs-proxy/enable-command.js
+++ b/add-on/src/lib/ipfs-proxy/enable-command.js
@@ -1,3 +1,7 @@
+const debug = require('debug')
+const log = debug('ipfs-companion:proxy')
+log.error = debug('ipfs-companion:proxy:error')
+
 const { inCommandWhitelist, createCommandWhitelistError } = require('./pre-command')
 const { createProxyAclError } = require('./pre-acl')
 
@@ -6,7 +10,7 @@ const { createProxyAclError } = require('./pre-acl')
 function createEnableCommand (getIpfs, getState, getScope, accessControl, requestAccess) {
   return async (opts) => {
     const scope = await getScope()
-    console.log(`[ipfs-companion] received window.ipfs.enable request from ${scope}`, opts)
+    log(`received window.ipfs.enable request from ${scope}`, opts)
 
     // Check if all access to the IPFS node is disabled
     if (!getState().ipfsProxy) throw new Error('User disabled access to API proxy in IPFS Companion')

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,6 @@
 const browser = require('webextension-polyfill')
 
 exports.onInstalled = async (details) => {
-  console.log('[ipfs-companion] onInstalled event', details)
   // details.temporary === run via `npm run firefox`
   if (details.reason === 'install' || details.temporary) {
     await browser.storage.local.set({ showLandingPage: 'onInstallWelcome' })

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -26,7 +26,8 @@ exports.optionDefaults = Object.freeze({
   customGatewayUrl: buildCustomGatewayUrl(),
   ipfsApiUrl: buildIpfsApiUrl(),
   ipfsApiPollMs: 3000,
-  ipfsProxy: true // window.ipfs
+  ipfsProxy: true, // window.ipfs
+  logNamespaces: 'jsipfs*,ipfs*,-*:mfs*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*'
 })
 
 function buildCustomGatewayUrl () {
@@ -129,7 +130,7 @@ exports.migrateOptions = async (storage) => {
   // DNSLINK: convert old on/off 'dnslink' flag to text-based 'dnslinkPolicy'
   const { dnslink } = await storage.get('dnslink')
   if (dnslink) {
-    console.log(`[ipfs-companion] migrating old dnslink policy '${dnslink}' to 'best-effort'`)
+    // migrating old dnslink policy to 'best-effort'
     await storage.set({
       dnslinkPolicy: 'best-effort',
       detectIpfsPathHeader: true
@@ -140,7 +141,7 @@ exports.migrateOptions = async (storage) => {
   // Upgrade js-ipfs to js-ipfs + chrome.sockets
   const { ipfsNodeType } = await storage.get('ipfsNodeType')
   if (ipfsNodeType === 'embedded' && hasChromeSocketsForTcp()) {
-    console.log(`[ipfs-companion] migrating ipfsNodeType: ${ipfsNodeType} → embedded:chromesockets`)
+    // migrating ipfsNodeType to embedded:chromesockets
     await storage.set({
       ipfsNodeType: 'embedded:chromesockets',
       ipfsNodeConfig: buildDefaultIpfsNodeConfig()

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -13,6 +13,7 @@ function experimentsForm ({
   dnslinkPolicy,
   detectIpfsPathHeader,
   ipfsProxy,
+  logNamespaces,
   onOptionChange,
   onOptionsReset
 }) {
@@ -126,6 +127,20 @@ function experimentsForm ({
             </dl>
           </label>
           <div>${switchToggle({ id: 'ipfsProxy', checked: ipfsProxy, onchange: onIpfsProxyChange })}</div>
+        </div>
+        <div>
+          <label for="logNamespaces">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_logNamespaces_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_logNamespaces_description')}</dd>
+            </dl>
+          </label>
+          <input
+            id="logNamespaces"
+            type="text"
+            required
+            onchange=${onOptionChange('logNamespaces')}
+            value=${logNamespaces} />
         </div>
         <div>
           <label for="resetAllOptions">

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -77,6 +77,7 @@ module.exports = function optionsPage (state, emit) {
     dnslinkPolicy: state.options.dnslinkPolicy,
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,
+    logNamespaces: state.options.logNamespaces,
     onOptionChange,
     onOptionsReset
   })}


### PR DESCRIPTION
JS IPFS ecosystem is using [debug](https://www.npmjs.com/package/debug) for logs.

This PR supersedes #557 and adds support for latest `debug` in IPFS Companion:

- Replaced `console.log` calls with  debug-based `log` and `log.error`
- Different parts of extension and JS IPFS stack log to own namespaces
- User can tweak which logs should be printed to Browser Console using input on Preferences screen:
  > ![2019-04-16--23-42-32](https://user-images.githubusercontent.com/157609/56246151-775b8b00-60a1-11e9-98a9-0756e4a191e3.png)
- Setting _Log Level_ to `*` will show all logs:
  > ![2019-04-16--23-42-51](https://user-images.githubusercontent.com/157609/56246164-7d516c00-60a1-11e9-913c-1454603084ca.png)
- If _Embedded_ node is used logs will include low level libp2p:
  > ![2019-04-16--23-43-21](https://user-images.githubusercontent.com/157609/56246198-99eda400-60a1-11e9-9030-a154a212c595.png)



