### PR TITLE
Require Firefox 65.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "firefox": 60,
+          "firefox": 65,
           "chrome": 70
         }
       }

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "ipfs-firefox-addon@lidel.org",
-      "strict_min_version": "60.0"
+      "strict_min_version": "65.0"
     }
   },
   "page_action": {


### PR DESCRIPTION
## TL;DR

This change updates minimal version in manifest, so new releases will not break Firefox ESR.

## Details

Browserfied js-ipfs-http-client does not seem to work as expected in Firefox <65 
(`TypeError: response.body is undefined` due to [this line](https://github.com/hugomrdias/iso-stream-http/blob/98e9e59718fcdc6f869bd2bc60641719357fe66b/lib/incoming-message.js#L71), probably due to lack of Streaming APIs).

I confirmed v2.7.5 of ipfs-companion works fine, so I marked all following releases to require 65.0 or later, making the last working version the default for ESR users.

ESR userbase is small enough (~5% of firefox users) to just wait for the next ESR scheduled to land in July.