### PR TITLE
feat(ux): suggest ipfs-desktop when no node is found

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -556,12 +556,8 @@
     "description": "Install steps title (page_landingWelcome_installSteps_title_desktop)"
   },
   "page_landingWelcome_installSteps_cli_install": {
-    "message": "<0>Follow these instructions</0>.",
+    "message": "Follow <0>these instructions</0>, then start an IPFS daemon in your terminal:",
     "description": "Install steps copy (page_landingWelcome_installSteps_install)"
-  },
-  "page_landingWelcome_installSteps_cli_run": {
-    "message": "Then make sure to have an IPFS daemon running in your terminal:",
-    "description": "Install steps run message (page_landingWelcome_installSteps_run)"
   },
   "page_landingWelcome_resources_title_new_ipfs": {
     "message": "New to IPFS?",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -543,23 +543,23 @@
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
     "description": "Ready message copy (page_landingWelcome_welcome_discover)"
   },
-  "page_landingWelcome_installSteps_title": {
-    "message": "Is your IPFS daemon running?",
+  "page_landingWelcome_installSteps_notRunning_title": {
+    "message": "IPFS does not seem to be running",
     "description": "Install steps title (page_landingWelcome_installSteps_title)"
   },
-  "page_landingWelcome_installSteps_install": {
-    "message": "If you haven't installed IPFS please do so <0>with these instructions</0>.",
-    "description": "Install steps copy (page_landingWelcome_installSteps_install)"
-  },
-  "page_landingWelcome_installSteps_title_desktop": {
-    "message": "Don't want to use the command line?",
-    "description": "Install steps title (page_landingWelcome_installSteps_title_desktop)"
-  },
-  "page_landingWelcome_installSteps_install_desktop": {
-    "message": "Give <0>IPFS Desktop</0> a go!",
+  "page_landingWelcome_installSteps_desktop_install": {
+    "message": "Get <0>IPFS Desktop</0> and you will be all set!",
     "description": "Install steps copy (page_landingWelcome_installSteps_install_desktop)"
   },
-  "page_landingWelcome_installSteps_run": {
+  "page_landingWelcome_installSteps_cli_title": {
+    "message": "Prefer to use the command line?",
+    "description": "Install steps title (page_landingWelcome_installSteps_title_desktop)"
+  },
+  "page_landingWelcome_installSteps_cli_install": {
+    "message": "<0>Follow these instructions</0>.",
+    "description": "Install steps copy (page_landingWelcome_installSteps_install)"
+  },
+  "page_landingWelcome_installSteps_cli_run": {
     "message": "Then make sure to have an IPFS daemon running in your terminal:",
     "description": "Install steps run message (page_landingWelcome_installSteps_run)"
   },

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -551,6 +551,14 @@
     "message": "If you haven't installed IPFS please do so <0>with these instructions</0>.",
     "description": "Install steps copy (page_landingWelcome_installSteps_install)"
   },
+  "page_landingWelcome_installSteps_title_desktop": {
+    "message": "Don't want to use the command line?",
+    "description": "Install steps title (page_landingWelcome_installSteps_title_desktop)"
+  },
+  "page_landingWelcome_installSteps_install_desktop": {
+    "message": "Give <0>IPFS Desktop</0> a go!",
+    "description": "Install steps copy (page_landingWelcome_installSteps_install_desktop)"
+  },
   "page_landingWelcome_installSteps_run": {
     "message": "Then make sure to have an IPFS daemon running in your terminal:",
     "description": "Install steps run message (page_landingWelcome_installSteps_run)"

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -96,13 +96,15 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
   return html`
     <div class="w-80 mt3 flex flex-column transition-all ${stateUnknown && 'state-unknown'}">
       <p class="mt0 mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_title')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_install', ['https://docs.ipfs.io/introduction/install/'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="${copyClass}">${i18n.getMessage('page_landingWelcome_installSteps_run')}</p>
-      <div className='db w-100 mt3 pa3 bg-black-70 bt bw4 br2 snow f7'>
+      <div className='db w-100 mw6 mv3 pa3 bg-black-70 bt bw4 br2 snow f7'>
         <code className='db'>$ ipfs daemon</code>
         <code className='db'>Initializing daemon...</code>
         <code className='db'>API server listening on /ip4/127.0.0.1/tcp/5001</code>
       </div>
+      <p class="mt0 mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_title_desktop')}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_install_desktop', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
     </div>
   `
 }
@@ -128,7 +130,7 @@ const renderResources = (i18n) => {
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_resources_got_questions', ['https://discuss.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</p>
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_want_to_help')}</p>
-      <p class="${copyClass} mv0">${renderTranslatedLinks('page_landingWelcome_resources_want_to_help', ['https://github.com/ipfs/community/#community', 'https://github.com/ipfs/ipfs#project-links', 'https://github.com/ipfs/docs', 'https://www.transifex.com/ipfs/public', 'https://discuss.ipfs.io/c/help'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="${copyClass} mv0">${renderTranslatedLinks('page_landingWelcome_resources_want_to_help', ['https://github.com/ipfs/community/#community', 'https://github.com/ipfs/ipfs#project-links', 'https://github.com/ipfs/docs', 'https://github.com/ipfs/i18n#ipfs-translation-project--%EF%B8%8F', 'https://discuss.ipfs.io/c/help'], `target="_blank" class="${anchorClass}"`)}</p>
     </div>
   `
 }

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -95,16 +95,16 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
 
   return html`
     <div class="w-80 mt3 flex flex-column transition-all ${stateUnknown && 'state-unknown'}">
-      <p class="mt0 mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_title')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
-      <p class="${copyClass}">${i18n.getMessage('page_landingWelcome_installSteps_run')}</p>
+      <p class="mt0 mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="${copyClass}">${i18n.getMessage('page_landingWelcome_installSteps_cli_run')}</p>
       <div className='db w-100 mw6 mv3 pa3 bg-black-70 bt bw4 br2 snow f7'>
         <code className='db'>$ ipfs daemon</code>
         <code className='db'>Initializing daemon...</code>
         <code className='db'>API server listening on /ip4/127.0.0.1/tcp/5001</code>
       </div>
-      <p class="mt0 mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_title_desktop')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_install_desktop', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
     </div>
   `
 }

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -99,7 +99,6 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
-      <p class="${copyClass}">${i18n.getMessage('page_landingWelcome_installSteps_cli_run')}</p>
       <div className='db w-100 mw6 mv3 pa3 bg-black-70 bt bw4 br2 snow f7'>
         <code className='db'>$ ipfs daemon</code>
         <code className='db'>Initializing daemon...</code>


### PR DESCRIPTION
This PR adds info about IPFS Desktop to the welcome page introduced in #565.
The Welcome Screen appears once, after initial install from add-on store.
I also fixed/tweaked some links to give a better onboarding experience.

### Before

TERMINAL OR DIE

![2019-06-03--13-42-28](https://user-images.githubusercontent.com/157609/58801894-1fa2c000-860c-11e9-9e18-b3faaa7846c1.png)


### After

Terminal is life, but now there are options for everyone! :^)

![fixed-2019-06-03--14-06-27](https://user-images.githubusercontent.com/157609/58801662-76f46080-860b-11e9-81cb-2ae82ec45b9f.png)

@olizilla @ericronne  feel free to tweak copy if it can be worded in a  better way. 