### PR TITLE
fix: normalize URLs of subdomain gateway at cf-ipfs.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ os:
     - windows
 addons:
     homebrew:
-        packages: jq
+        packages:
+        - jq
 install:
     - npm run ci:install
 script:

--- a/test/functional/lib/ipfs-request-dnslink.test.js
+++ b/test/functional/lib/ipfs-request-dnslink.test.js
@@ -10,16 +10,7 @@ const { createRequestModifier } = require('../../../add-on/src/lib/ipfs-request'
 const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
 const { createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
-
-const url2request = (string) => {
-  return { url: string, type: 'main_frame' }
-}
-
-const fakeRequestId = () => {
-  return Math.floor(Math.random() * 100000).toString()
-}
-
-// const nodeTypes = ['external', 'embedded']
+const { url2request, fakeRequestId } = require('../lib/utils')
 
 describe('modifyRequest processing', function () {
   let state, dnslinkResolver, ipfsPathValidator, modifyRequest, runtime

--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -10,21 +10,7 @@ const { createRequestModifier, redirectOptOutHint } = require('../../../add-on/s
 const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
 const { createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
-
-const url2request = (string) => {
-  return { url: string, type: 'main_frame' }
-}
-
-const fakeRequestId = () => {
-  return Math.floor(Math.random() * 100000).toString()
-}
-
-const expectNoRedirect = (modifyRequest, request) => {
-  expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
-  expect(modifyRequest.onHeadersReceived(request)).to.equal(undefined)
-}
-
-const nodeTypes = ['external', 'embedded']
+const { url2request, expectNoRedirect, fakeRequestId, nodeTypes } = require('../lib/utils')
 
 describe('modifyRequest.onBeforeRequest:', function () {
   let state, dnslinkResolver, ipfsPathValidator, modifyRequest, runtime
@@ -39,7 +25,7 @@ describe('modifyRequest.onBeforeRequest:', function () {
       ipfsNodeType: 'external',
       peerCount: 1,
       redirect: true,
-      dnslinkPolicy: false, // dnslink testi suite is in ipfs-request-dnslink.test.js
+      dnslinkPolicy: false, // dnslink test suite is in ipfs-request-dnslink.test.js
       catchUnhandledProtocols: true,
       gwURLString: 'http://127.0.0.1:8080',
       gwURL: new URL('http://127.0.0.1:8080'),

--- a/test/functional/lib/ipfs-request-protocol-handlers.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.js
@@ -10,12 +10,7 @@ const { createRequestModifier } = require('../../../add-on/src/lib/ipfs-request'
 const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
 const { createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
-
-const url2request = (string) => {
-  return { url: string, type: 'main_frame' }
-}
-
-const nodeTypes = ['external', 'embedded']
+const { url2request, nodeTypes } = require('../lib/utils')
 
 describe('modifyRequest.onBeforeRequest:', function () {
   let state, dnslinkResolver, ipfsPathValidator, modifyRequest, runtime

--- a/test/functional/lib/utils.js
+++ b/test/functional/lib/utils.js
@@ -1,0 +1,17 @@
+'use strict'
+const { expect } = require('chai')
+
+exports.url2request = (string) => {
+  return { url: string, type: 'main_frame' }
+}
+
+exports.expectNoRedirect = (modifyRequest, request) => {
+  expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
+  expect(modifyRequest.onHeadersReceived(request)).to.equal(undefined)
+}
+
+exports.fakeRequestId = () => {
+  return Math.floor(Math.random() * 100000).toString()
+}
+
+exports.nodeTypes = ['external', 'embedded']


### PR DESCRIPTION
This PR aims to normalize URLs of subdomain gateway at cf-ipfs.com and cf-ipns.com for users of IPFS Companion browser extension. 

The goal is for user to always end up on FQDN following the convention with explicit namespace suffix:

```
{cid}.cf-ipfs.com        → {cid}.ipfs.cf-ipfs.com
{keyid}.cf-ipns.com      → {keyid}.ipns.cf-ipfs.com
{keyid}.ipns.cf-ipns.com → {keyid}.ipns.cf-ipfs.com
```

### Context

**Unified UX:** explicit `.ipfs.` and `.ipns.` provide clear hints to check for _subdomain gateway_ without hardcoding any gateway hostnames. This makes CID detection vendor-agnostic and enables browser to show  additional UI for it. 
   - See subdomain gateway detection in `is-ipfs` library: https://www.npmjs.com/package/is-ipfs#subdomains
   - A demo integration is already in ipfs-companion: it displays additional UI related to IPFS  on subdomain gateways ([example](https://user-images.githubusercontent.com/157609/59884432-9aaff880-93b8-11e9-8722-3921909475d8.png))


cc @Bren2010 
