### PR TITLE
fix(window.ipfs): stop injecting window.Buffer

### DIFF
--- a/add-on/src/contentScripts/ipfs-proxy/page.js
+++ b/add-on/src/contentScripts/ipfs-proxy/page.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const _Buffer = Buffer
 const { assign, freeze } = Object
 
 // TODO: (wip) this should not be injected by default into every page,
@@ -46,7 +45,4 @@ function createWindowIpfs () {
   return freeze(proxyClient)
 }
 
-// TODO: we should remove Buffer and add support for Uint8Array/ArrayBuffer natively
-// See: https://github.com/ipfs/interface-ipfs-core/issues/404
-window.Buffer = window.Buffer || _Buffer
 window.ipfs = window.ipfs || createWindowIpfs()

--- a/docs/examples/window.ipfs-fallback.html
+++ b/docs/examples/window.ipfs-fallback.html
@@ -1,4 +1,9 @@
 <!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+</head>
+<body>
 <div id="output"></div>
 <script>
   (() => {
@@ -39,3 +44,5 @@
       .catch(log)
   })()
 </script>
+</body>
+</html>

--- a/docs/window.ipfs.md
+++ b/docs/window.ipfs.md
@@ -68,7 +68,7 @@ if (window.ipfs && window.ipfs.enable) {
 }
 ```
 
-Note that IPFS Companion also adds `window.Buffer` if it doesn't already exist.
+Note that IPFS Companion does not add `Buffer` to the global scope, you need to [get it on your own](https://github.com/feross/buffer).
 
 See also: [How do I fallback if `window.ipfs` is not available?](#how-do-i-fallback-if-windowipfs-is-not-available)
 


### PR DESCRIPTION
This PR removes code responsible for injection of `window.Buffer` when `window.ipfs` is enabled. 
We did that as a convenience tweak to make it easier to write demos/pocs, but polluting global scope introduced some issues on websites (Closes #637). 


Question: should we 
- (A) ship it now..
- (B) park until we remove  old `window.ipfs` altogether in September:
  https://github.com/ipfs-shipyard/ipfs-companion/blob/4ca9a0ce1842a9cf5979623bbf416493a18c2b2f/add-on/src/contentScripts/ipfs-proxy/page.js#L37 
- (C) park until we add API support for String and Uint8Array/ArrayBuffer natively (https://github.com/ipfs/interface-ipfs-core/issues/404)
