### PR TITLE
Fix port collisions in Brave

### DIFF
--- a/add-on/src/lib/ipfs-client/embedded-chromesockets.js
+++ b/add-on/src/lib/ipfs-client/embedded-chromesockets.js
@@ -23,21 +23,7 @@ const { optionDefaults } = require('../options')
 let node = null
 let nodeHttpApi = null
 
-// additional servers for smoke-tests
-// let httpServer = null
-// let hapiServer = null
-
 exports.init = function init (opts) {
-  /*
-  // TEST RAW require('http') SERVER
-  if (!httpServer) {
-    httpServer = startRawHttpServer(9091)
-  }
-  // TEST require('@hapi/hapi') HTTP SERVER (same as in js-ipfs)
-  if (!hapiServer) {
-    hapiServer = startRawHapiServer(9092)
-  }
-  */
   log('init embedded:chromesockets')
 
   const defaultOpts = JSON.parse(optionDefaults.ipfsNodeConfig)
@@ -95,7 +81,6 @@ async function updateConfigWithHttpEndpoints (ipfs, opts) {
     const apiMa = await ipfs.config.get('Addresses.API')
     const httpGateway = multiaddr2httpUrl(gwMa)
     const httpApi = multiaddr2httpUrl(apiMa)
-    log(`updating extension configuration to Gateway=${httpGateway} and API=${httpApi}`)
     // update ports in JSON configuration for embedded js-ipfs
     const ipfsNodeConfig = JSON.parse(localConfig.ipfsNodeConfig)
     ipfsNodeConfig.config.Addresses.Gateway = gwMa
@@ -108,31 +93,13 @@ async function updateConfigWithHttpEndpoints (ipfs, opts) {
     // update current runtime config (in place, effective without restart)
     Object.assign(opts, configChanges)
     // update user config in storage (effective on next run)
+    log(`synchronizing ipfsNodeConfig with customGatewayUrl (${configChanges.customGatewayUrl}) and ipfsApiUrl (${configChanges.ipfsApiUrl})`)
     await browser.storage.local.set(configChanges)
   }
 }
 
 exports.destroy = async function () {
   log('destroy: embedded:chromesockets')
-
-  /*
-  if (httpServer) {
-    httpServer.close()
-    httpServer = null
-  }
-  if (hapiServer) {
-    try {
-      await hapiServer.stop({ timeout: 1000 })
-    } catch (err) {
-      if (err) {
-        console.error(`[ipfs-companion]  failed to stop hapi`, err)
-      } else {
-        console.log('[ipfs-companion] hapi server stopped')
-      }
-    }
-    hapiServer = null
-  }
-  */
 
   if (nodeHttpApi) {
     try {
@@ -164,45 +131,3 @@ exports.destroy = async function () {
     node = null
   }
 }
-
-/*
-// Quick smoke-test to confirm require('http') works for MVP
-function startRawHttpServer (port) {
-  const http = require('http') // courtesy of chrome-net
-  const httpServer = http.createServer(function (req, res) {
-    res.writeHead(200, { 'Content-Type': 'text/plain' })
-    res.end('Hello from ipfs-companion exposing HTTP via chrome.sockets in Brave :-)\n')
-  })
-  httpServer.listen(port, '127.0.0.1')
-  console.log(`[ipfs-companion] require('http') HTTP server on http://127.0.0.1:${port}`)
-  return httpServer
-}
-
-function startRawHapiServer (port) {
-  let options = {
-    host: '127.0.0.1',
-    port,
-    debug: {
-      log: ['*'],
-      request: ['*']
-    }
-  }
-  const initHapi = async () => {
-    // hapi v18 (js-ipfs >=v0.35.0-pre.0)
-    const Hapi = require('@hapi/hapi') // courtesy of js-ipfs
-    const hapiServer = new Hapi.Server(options)
-    await hapiServer.route({
-      method: 'GET',
-      path: '/',
-      handler: (request, h) => {
-        console.log('[ipfs-companion] hapiServer processing request', request)
-        return 'Hello from ipfs-companion+Hapi.js exposing HTTP via chrome.sockets in Brave :-)'
-      }
-    })
-    await hapiServer.start()
-    console.log(`[ipfs-companion] require('@hapi/hapi') HTTP server running at: ${hapiServer.info.uri}`)
-  }
-  initHapi()
-  return hapiServer
-}
-*/

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "drag-and-drop-files": "0.0.1",
     "file-type": "12.0.1",
     "filesize": "4.1.2",
+    "get-port": "5.0.0",
     "http-dns": "3.0.1",
     "http-node": "1.2.0",
     "ipfs": "https://github.com/ipfs/js-ipfs/tarball/2ae6b672c222555b1a068141f2acfe4b5f39b709/js-ipfs.tar.gz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5786,6 +5786,13 @@ get-iterator@^1.0.2:
   resolved "https://registry.yarnpkg.com/get-iterator/-/get-iterator-1.0.2.tgz#cd747c02b4c084461fac14f48f6b45a80ed25c82"
   integrity sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==
 
+get-port@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.0.0.tgz#aa22b6b86fd926dd7884de3e23332c9f70c031a6"
+  integrity sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==
+  dependencies:
+    type-fest "^0.3.0"
+
 get-port@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"


### PR DESCRIPTION
> Part of the effort to run embedded js-ipfs in Brave :lion: https://github.com/ipfs-shipyard/ipfs-companion/issues/716

fix(brave): no port collisions
    
    Before starting embedded js-ipfs we now check if API and Gateway ports are free.
    If not, we find available ones and update the config.
    
    This way user does not need to deal with "port taken" errors and
    embedded node provides seamless experience without surprises.

fix(brave): persist External node config
    
    Embedded node used same config keys as External one. 
    When switching between External and Embedded in Brave
    we now persist the old (External) config and restore it when user
    switched back to External node type.
