### PR TITLE
feat: preload webui root CID

### DIFF
--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -4,6 +4,10 @@
 const { safeURL } = require('./options')
 const offlinePeerCount = -1
 
+// CID of a 'blessed' Web UI release
+// which should work without setting CORS headers
+const webuiCid = 'QmYTRvKFGhxgBiUreiw7ihn8g95tfJTWDt7aXqDsvAcJse' // v2.4.7
+
 function initState (options) {
   // we store options and some pregenerated values to avoid async storage
   // reads and minimize performance impact on overall browsing experience
@@ -22,12 +26,11 @@ function initState (options) {
   state.gwURLString = state.gwURL.toString()
   delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
-  // store info about 'blessed' release of Web UI
-  // which should work without setting CORS headers
-  state.webuiCid = 'QmQNHd1suZTktPRhP7DD4nKWG46ZRSxkwHocycHVrK3dYW' // v2.4.6
+  state.webuiCid = webuiCid
   state.webuiRootUrl = `${state.gwURLString}ipfs/${state.webuiCid}/`
   return state
 }
 
 exports.initState = initState
 exports.offlinePeerCount = offlinePeerCount
+exports.webuiCid = webuiCid


### PR DESCRIPTION
This PR updated webui to [v2.4.7](https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.4.7) introduces a simple optimization: preloads the root CID after IPFS Client start to speed up the first time Web UI is opened. This is a best-effort version of #682 that respects user bandwidth and does not fetch entire Web UI when extension starts.

If embedded js-ipfs is used (eg. in Brave #716) it will trigger a remote (always recursive) preload of entire DAG to one of preload nodes. This way when embedded node wants to load resources related to webui it will get them fast from preload nodes.
