### PR TITLE
refactor: use Web UI provided by IPFS node

### DIFF
--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -4,10 +4,6 @@
 const { safeURL } = require('./options')
 const offlinePeerCount = -1
 
-// CID of a 'blessed' Web UI release
-// which should work without setting CORS headers
-const webuiCid = 'QmYTRvKFGhxgBiUreiw7ihn8g95tfJTWDt7aXqDsvAcJse' // v2.4.7
-
 function initState (options) {
   // we store options and some pregenerated values to avoid async storage
   // reads and minimize performance impact on overall browsing experience
@@ -26,11 +22,9 @@ function initState (options) {
   state.gwURLString = state.gwURL.toString()
   delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
-  state.webuiCid = webuiCid
-  state.webuiRootUrl = `${state.gwURLString}ipfs/${state.webuiCid}/`
+  state.webuiRootUrl = `${state.apiURLString}webui`
   return state
 }
 
 exports.initState = initState
 exports.offlinePeerCount = offlinePeerCount
-exports.webuiCid = webuiCid


### PR DESCRIPTION
This PR changes the way "Open Web UI" menu option works.

- Before: we kept CID of latest version and opened it from gateway port + executed a lot of magic to ensure it can talk to api port in secure way.

- After: we removed all the magic and just open the version provided on api port
  (default: `http://127.0.0.1:5001/webui/`)

Closes #736