### PR TITLE
feat: opt-in for loading webui from dnslink

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -351,6 +351,14 @@
     "message": "Turn plaintext /ipfs/ paths into clickable links",
     "description": "An option description on the Preferences screen (option_linkify_description)"
   },
+  "option_webuiFromDNSLink_title": {
+    "message": "Load the latest Web UI",
+    "description": "An option title on the Preferences screen (option_webuiFromDNSLink_title)"
+  },
+  "option_webuiFromDNSLink_description": {
+    "message": "Replaces stable version provided by your node with one at /ipns/webui.ipfs.io (requires working DNS and a compatible backend)",
+    "description": "An option description on the Preferences screen (option_webuiFromDNSLink_description)"
+  },
   "option_dnslinkPolicy_title": {
     "message": "DNSLink Support",
     "description": "An option title on the Preferences screen (option_dnslinkPolicy_title)"

--- a/add-on/src/lib/ipfs-client/index.js
+++ b/add-on/src/lib/ipfs-client/index.js
@@ -47,13 +47,13 @@ async function destroyIpfsClient () {
 
 function preloadWebui (instance, opts) {
   // run only when client still exists and async fetch is possible
-  if (!(client && instance && opts.webuiRootUrl && typeof fetch === 'function')) return
+  if (!(client && instance && opts.webuiURLString && typeof fetch === 'function')) return
   // Optimization: preload the root CID to speed up the first time
   // Web UI is opened. If embedded js-ipfs is used it will trigger
   // remote (always recursive) preload of entire DAG to one of preload nodes.
   // This way when embedded node wants to load resource related to webui
   // it will get it fast from preload nodes.
-  const webuiUrl = opts.webuiRootUrl
+  const webuiUrl = opts.webuiURLString
   log(`preloading webui root at ${webuiUrl}`)
   return fetch(webuiUrl, { redirect: 'follow' })
     .then(response => {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -7,7 +7,7 @@ log.error = debug('ipfs-companion:main:error')
 
 const browser = require('webextension-polyfill')
 const { optionDefaults, storeMissingOptions, migrateOptions } = require('./options')
-const { initState, offlinePeerCount } = require('./state')
+const { initState, offlinePeerCount, buildWebuiURLString } = require('./state')
 const { createIpfsPathValidator } = require('./ipfs-path')
 const createDnslinkResolver = require('./dnslink')
 const { createRequestModifier, redirectOptOutHint } = require('./ipfs-request')
@@ -223,7 +223,7 @@ module.exports = async function init () {
       peerCount: state.peerCount,
       gwURLString: dropSlash(state.gwURLString),
       pubGwURLString: dropSlash(state.pubGwURLString),
-      webuiRootUrl: state.webuiRootUrl,
+      webuiURLString: state.webuiURLString,
       apiURLString: dropSlash(state.apiURLString),
       redirect: state.redirect,
       noRedirectHostnames: state.noRedirectHostnames,
@@ -633,7 +633,7 @@ module.exports = async function init () {
         case 'ipfsApiUrl':
           state.apiURL = new URL(change.newValue)
           state.apiURLString = state.apiURL.toString()
-          state.webuiRootUrl = `${state.apiURLString}webui`
+          state.webuiURLString = buildWebuiURLString(state)
           shouldRestartIpfsClient = true
           break
         case 'ipfsApiPollMs':
@@ -663,6 +663,10 @@ module.exports = async function init () {
         case 'logNamespaces':
           shouldReloadExtension = true
           state[key] = localStorage.debug = change.newValue
+          break
+        case 'webuiFromDNSLink':
+          state[key] = change.newValue
+          state.webuiURLString = buildWebuiURLString(state)
           break
         case 'linkify':
         case 'catchUnhandledProtocols':

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -24,6 +24,7 @@ exports.optionDefaults = Object.freeze({
   ipfsApiUrl: buildIpfsApiUrl(),
   ipfsApiPollMs: 3000,
   ipfsProxy: true, // window.ipfs
+  webuiFromDNSLink: false,
   logNamespaces: 'jsipfs*,ipfs*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*'
 })
 

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -4,10 +4,6 @@
 const { safeURL } = require('./options')
 const offlinePeerCount = -1
 
-// CID of a 'blessed' Web UI release
-// which should work without setting CORS headers
-const webuiCid = 'QmYTRvKFGhxgBiUreiw7ihn8g95tfJTWDt7aXqDsvAcJse' // v2.4.7
-
 function initState (options) {
   // we store options and some pregenerated values to avoid async storage
   // reads and minimize performance impact on overall browsing experience
@@ -26,11 +22,9 @@ function initState (options) {
   state.gwURLString = state.gwURL.toString()
   delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
-  state.webuiCid = webuiCid
-  state.webuiRootUrl = `${state.gwURLString}ipfs/${state.webuiCid}/`
+  state.webuiRootUrl = `${state.apiURLString}webui`
   return state
 }
 
 exports.initState = initState
 exports.offlinePeerCount = offlinePeerCount
-exports.webuiCid = webuiCid

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -2,6 +2,7 @@
 /* eslint-env browser, webextensions */
 
 const { safeURL } = require('./options')
+
 const offlinePeerCount = -1
 
 function initState (options) {
@@ -22,9 +23,17 @@ function initState (options) {
   state.gwURLString = state.gwURL.toString()
   delete state.customGatewayUrl
   state.dnslinkPolicy = String(options.dnslinkPolicy) === 'false' ? false : options.dnslinkPolicy
-  state.webuiRootUrl = `${state.apiURLString}webui`
+  state.webuiURLString = buildWebuiURLString(state)
   return state
+}
+
+function buildWebuiURLString ({ apiURLString, webuiFromDNSLink }) {
+  if (!apiURLString) throw new Error('Missing apiURLString')
+  return webuiFromDNSLink
+    ? `${apiURLString}ipns/webui.ipfs.io/`
+    : `${apiURLString}webui/`
 }
 
 exports.initState = initState
 exports.offlinePeerCount = offlinePeerCount
+exports.buildWebuiURLString = buildWebuiURLString

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -10,6 +10,7 @@ function experimentsForm ({
   preloadAtPublicGateway,
   catchUnhandledProtocols,
   linkify,
+  webuiFromDNSLink,
   dnslinkPolicy,
   detectIpfsPathHeader,
   ipfsProxy,
@@ -24,6 +25,7 @@ function experimentsForm ({
   const onDnslinkPolicyChange = onOptionChange('dnslinkPolicy')
   const onDetectIpfsPathHeaderChange = onOptionChange('detectIpfsPathHeader')
   const onIpfsProxyChange = onOptionChange('ipfsProxy')
+  const onWebuiFromDNSLinkChange = onOptionChange('webuiFromDNSLink')
 
   return html`
     <form>
@@ -65,6 +67,15 @@ function experimentsForm ({
             </dl>
           </label>
           <div>${switchToggle({ id: 'linkify', checked: linkify, onchange: onLinkifyChange })}</div>
+        </div>
+        <div>
+          <label for="webuiFromDNSLink">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_webuiFromDNSLink_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_webuiFromDNSLink_description')}</dd>
+            </dl>
+          </label>
+          <div>${switchToggle({ id: 'webuiFromDNSLink', checked: webuiFromDNSLink, onchange: onWebuiFromDNSLinkChange })}</div>
         </div>
         <div>
           <label for="dnslinkPolicy">

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -74,6 +74,7 @@ module.exports = function optionsPage (state, emit) {
     preloadAtPublicGateway: state.options.preloadAtPublicGateway,
     catchUnhandledProtocols: state.options.catchUnhandledProtocols,
     linkify: state.options.linkify,
+    webuiFromDNSLink: state.options.webuiFromDNSLink,
     dnslinkPolicy: state.options.dnslinkPolicy,
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -129,7 +129,7 @@ module.exports = (state, emitter) => {
 
   emitter.on('openWebUi', async () => {
     try {
-      browser.tabs.create({ url: state.webuiRootUrl })
+      browser.tabs.create({ url: state.webuiURLString })
       window.close()
     } catch (error) {
       console.error(`Unable Open Web UI due to ${error}`)

--- a/test/functional/lib/state.test.js
+++ b/test/functional/lib/state.test.js
@@ -1,0 +1,80 @@
+'use strict'
+const { describe, it, beforeEach, before } = require('mocha')
+const { expect } = require('chai')
+const { initState, offlinePeerCount, buildWebuiURLString } = require('../../../add-on/src/lib/state')
+const { optionDefaults } = require('../../../add-on/src/lib/options')
+const { URL } = require('url')
+
+describe('state.js', function () {
+  describe('initState', function () {
+    before(function () {
+      global.URL = URL
+    })
+    it('should copy passed options as-is', () => {
+      const expectedProps = Object.assign({}, optionDefaults)
+      delete expectedProps.publicGatewayUrl
+      delete expectedProps.useCustomGateway
+      delete expectedProps.ipfsApiUrl
+      delete expectedProps.customGatewayUrl
+      const state = initState(optionDefaults)
+      for (const prop in expectedProps) {
+        expect(state).to.have.property(prop, optionDefaults[prop])
+      }
+    })
+    it('should generate pubGwURL*', () => {
+      const state = initState(optionDefaults)
+      expect(state).to.not.have.property('publicGatewayUrl')
+      expect(state).to.have.property('pubGwURL')
+      expect(state).to.have.property('pubGwURLString')
+    })
+    it('should generate redirect state', () => {
+      const state = initState(optionDefaults)
+      expect(state).to.not.have.property('useCustomGateway')
+      expect(state).to.have.property('redirect')
+    })
+    it('should generate apiURL*', () => {
+      const state = initState(optionDefaults)
+      expect(state).to.not.have.property('ipfsApiUrl')
+      expect(state).to.have.property('apiURL')
+      expect(state).to.have.property('apiURLString')
+    })
+    it('should generate gwURL*', () => {
+      const state = initState(optionDefaults)
+      expect(state).to.not.have.property('customGatewayUrl')
+      expect(state).to.have.property('gwURL')
+      expect(state).to.have.property('gwURLString')
+    })
+    it('should generate webuiURLString', () => {
+      const state = initState(optionDefaults)
+      expect(state).to.have.property('webuiURLString')
+    })
+  })
+
+  describe('offlinePeerCount', function () {
+    it('should be equal -1', () => {
+      expect(offlinePeerCount).to.be.equal(-1)
+    })
+  })
+
+  describe('buildWebuiURLString', function () {
+    let fakeState
+    beforeEach(() => {
+      fakeState = { apiURLString: 'http://127.0.0.1:5001/' }
+    })
+    it('should be throw error on missing apiURLString', () => {
+      expect(() => buildWebuiURLString({})).to.throw('Missing apiURLString')
+    })
+    it('should return /webui for optionDefaults', () => {
+      fakeState.webuiFromDNSLink = optionDefaults.webuiFromDNSLink
+      expect(buildWebuiURLString(fakeState)).to.be.equal(`${fakeState.apiURLString}webui/`)
+    })
+    it('should return /webui when webuiFromDNSLink is falsy', () => {
+      fakeState.webuiFromDNSLink = undefined
+      expect(buildWebuiURLString(fakeState)).to.be.equal(`${fakeState.apiURLString}webui/`)
+    })
+    it('should return /ipns/webui.ipfs.io when webuiFromDNSLink is true', () => {
+      fakeState.webuiFromDNSLink = true
+      expect(buildWebuiURLString(fakeState)).to.be.equal(`${fakeState.apiURLString}ipns/webui.ipfs.io/`)
+    })
+  })
+})


### PR DESCRIPTION
> Requires #737 to be merged first (changes specific to this PR are in https://github.com/ipfs-shipyard/ipfs-companion/commit/c2daf92395433744d33e0ae40a1db78181a108c4)
> Can be merged before https://github.com/ipfs/go-ipfs/pull/6530 lands 

This PR Adds an opt-in toggle (disabled by default) to _Preferences_ which changes the URL of Web UI opened via Browser Action menu from `{API}/webui` to `{API}/ipns/webui.ipfs.io`:

> ![2019-07-18--22-48-30](https://user-images.githubusercontent.com/157609/61490868-3465c800-a9ae-11e9-9108-9ed26593f43c.png)


This enables user to load the latest webui via DNSLink.

Note that go-ipfs and js-ipfs do not whitelist `/ipns/webui.ipfs.io` on the API port yet (https://github.com/ipfs/go-ipfs/pull/6530), so there is a fallback in place that detects HTTP 404  and redirects user to `{API}/webui`.

Closes: #736