### PR TITLE
[Moved to #937] feat: add permalink and IPFS path copy options

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -83,6 +83,10 @@
     "message": "Copy IPFS Path",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
+	"panelCopy_currentIpnsAddress": {
+		"message": "Copy IPNS Path",
+		"description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
+	},
   "panelCopy_copyRawCid": {
     "message": "Copy CID",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyRawCid)"
@@ -91,6 +95,10 @@
     "message": "Copy Public Gateway URL",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPublicGwUrl)"
   },
+	"panel_copyCurrentPermalink": {
+		"message": "Copy Permalink",
+		"description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPermalink)"
+	},
   "pageAction_titleIpfsAtPublicGateway": {
     "message": "IPFS resource loaded via Public Gateway",
     "description": "A tooltip displayed over Page Action in location bar (pageAction_titleIpfsAtPublicGateway)"

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -56,12 +56,16 @@ const contextMenuAddToIpfsKeepFilename = 'contextMenu_AddToIpfsKeepFilename'
 // Add X to IPFS
 const contextMenuAddToIpfsSelection = 'contextMenu_AddToIpfsSelection'
 // Copy X
-const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpfsAddress'
+const contextMenuCopyCidAddress = 'panelCopy_currentIpfsAddress'
+const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpnsAddress'
 const contextMenuCopyRawCid = 'panelCopy_copyRawCid'
 const contextMenuCopyAddressAtPublicGw = 'panel_copyCurrentPublicGwUrl'
+const contextMenuCopyPermalink = 'panel_copyCurrentPermalink'
+module.exports.contextMenuCopyCidAddress = contextMenuCopyCidAddress
 module.exports.contextMenuCopyCanonicalAddress = contextMenuCopyCanonicalAddress
 module.exports.contextMenuCopyRawCid = contextMenuCopyRawCid
 module.exports.contextMenuCopyAddressAtPublicGw = contextMenuCopyAddressAtPublicGw
+module.exports.contextMenuCopyPermalink = contextMenuCopyPermalink
 
 // menu items that are enabled only when API is online
 const apiMenuItems = new Set()

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -39,6 +39,12 @@ function createCopier (notify, ipfsPathValidator) {
       await copyTextToClipboard(ipfsPath, notify)
     },
 
+    async copyCidAddress (context, contextType) {
+      const url = await findValueForContext(context, contextType)
+      const ipfsPath = await ipfsPathValidator.resolveToImmutableIpfsPath(url)
+      await copyTextToClipboard(ipfsPath, notify)
+    },
+
     async copyRawCid (context, contextType) {
       const url = await findValueForContext(context, contextType)
       try {
@@ -64,6 +70,12 @@ function createCopier (notify, ipfsPathValidator) {
       const url = await findValueForContext(context, contextType)
       const publicUrl = ipfsPathValidator.resolveToPublicUrl(url)
       await copyTextToClipboard(publicUrl, notify)
+    },
+
+    async copyPermalink (context, contextType) {
+      const url = await findValueForContext(context, contextType)
+      const permalink = await ipfsPathValidator.resolveToPermalink(url)
+      await copyTextToClipboard(permalink, notify)
     }
   }
 }

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -17,7 +17,7 @@ const { createIpfsUrlProtocolHandler } = require('./ipfs-protocol')
 const createNotifier = require('./notifier')
 const createCopier = require('./copier')
 const { createRuntimeChecks } = require('./runtime-checks')
-const { createContextMenus, findValueForContext, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('./context-menus')
+const { createContextMenus, findValueForContext, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuCopyPermalink, contextMenuCopyCidAddress } = require('./context-menus')
 const createIpfsProxy = require('./ipfs-proxy')
 const { showPendingLandingPages } = require('./on-installed')
 
@@ -204,8 +204,10 @@ module.exports = async function init () {
   const BrowserActionMessageHandlers = {
     notification: (message) => notify(message.title, message.message),
     [contextMenuCopyCanonicalAddress]: copier.copyCanonicalAddress,
+    [contextMenuCopyCidAddress]: copier.copyCidAddress,
     [contextMenuCopyRawCid]: copier.copyRawCid,
-    [contextMenuCopyAddressAtPublicGw]: copier.copyAddressAtPublicGw
+    [contextMenuCopyAddressAtPublicGw]: copier.copyAddressAtPublicGw,
+    [contextMenuCopyPermalink]: copier.copyPermalink
   }
 
   function handleMessageFromBrowserAction (message) {

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -109,6 +109,20 @@ function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
       return input.startsWith('http') ? input : null
     },
 
+    // Resolve URL or path to HTTP URL with CID:
+    // - IPFS paths are attached to HTTP Gateway root
+    // - URL of DNSLinked websties are resolved to CIDs
+    // The purpose of this resolver is to always return a meaningful, publicly
+    // accessible URL that can be accessed without the need of an IPFS client
+    // and that never changes.
+    async resolveToPermalink (urlOrPath, optionalGatewayUrl) {
+      const input = urlOrPath
+      const ipfsPath = await this.resolveToImmutableIpfsPath(input)
+      const gateway = optionalGatewayUrl || getState().pubGwURLString
+      if (ipfsPath) return pathAtHttpGateway(ipfsPath, gateway)
+      return input.startsWith('http') ? input : null
+    },
+
     // Resolve URL or path to IPFS Path:
     // - The path can be /ipfs/ or /ipns/
     // - Keeps pathname + ?search + #hash from original URL

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -5,7 +5,7 @@ const browser = require('webextension-polyfill')
 const html = require('choo/html')
 const navItem = require('./nav-item')
 const navHeader = require('./nav-header')
-const { contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
+const { contextMenuCopyAddressAtPublicGw, contextMenuCopyPermalink, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuCopyCidAddress } = require('../../lib/context-menus')
 
 // Context Actions are displayed in Browser Action and Page Action (FF only)
 function contextActions ({
@@ -32,13 +32,21 @@ function contextActions ({
   const renderIpfsContextItems = () => {
     if (!isIpfsContext) return
     return html`<div>
-  ${navItem({
+  ${isRedirectContext ? navItem({
     text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
     onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
-  })}
+  }) : ''}
   ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyPermalink),
+    onClick: () => onCopy(contextMenuCopyPermalink)
+  })}
+  ${isRedirectContext ? navItem({
     text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
+  }) : ''}
+  ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyCidAddress),
+    onClick: () => onCopy(contextMenuCopyCidAddress)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 const IsIpfs = require('is-ipfs')
 const { trimHashAndSearch } = require('../../lib/ipfs-path')
-const { contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
+const { contextMenuCopyAddressAtPublicGw, contextMenuCopyPermalink, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuCopyCidAddress } = require('../../lib/context-menus')
 
 // The store contains and mutates the state for the app
 module.exports = (state, emitter) => {
@@ -67,11 +67,17 @@ module.exports = (state, emitter) => {
       case contextMenuCopyCanonicalAddress:
         port.postMessage({ event: contextMenuCopyCanonicalAddress })
         break
+      case contextMenuCopyCidAddress:
+        port.postMessage({ event: contextMenuCopyCidAddress })
+        break
       case contextMenuCopyRawCid:
         port.postMessage({ event: contextMenuCopyRawCid })
         break
       case contextMenuCopyAddressAtPublicGw:
         port.postMessage({ event: contextMenuCopyAddressAtPublicGw })
+        break
+      case contextMenuCopyPermalink:
+        port.postMessage({ event: contextMenuCopyPermalink })
         break
     }
     window.close()


### PR DESCRIPTION
Closes #740.

As this currently is, it introduces a UI bug in the pop-up in Firefox that's accessed by clicking the icon on the far-right, as opposed to the one in the URL bar. The contents of the pop-up are too large for it, and it's not scrollable, so the bottom of the menu becomes inaccessible. I'm not familiar enough with how extensions work to fix that without hunting through the codebase for stuff that looks like it might have to do with it, so if someone could let me know what I should take a look at for fixing that it would be quite helpful.