### PR TITLE
fix: disable window.ipfs until JS API is updated

### DIFF
--- a/add-on/manifest.chromium.json
+++ b/add-on/manifest.chromium.json
@@ -1,4 +1,16 @@
 {
   "minimum_chrome_version": "72",
+  "content_scripts": [
+    {
+      "all_frames": true,
+      "js": [
+        "dist/bundles/ipfsProxyContentScript.bundle.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "run_at": "document_start"
+    }
+  ],
   "incognito": "not_allowed"
 }

--- a/add-on/manifest.chromium.json
+++ b/add-on/manifest.chromium.json
@@ -1,16 +1,4 @@
 {
   "minimum_chrome_version": "72",
-  "content_scripts": [
-    {
-      "all_frames": true,
-      "js": [
-        "dist/bundles/ipfsProxyContentScript.bundle.js"
-      ],
-      "matches": [
-        "<all_urls>"
-      ],
-      "run_at": "document_start"
-    }
-  ],
   "incognito": "not_allowed"
 }

--- a/add-on/manifest.common.json
+++ b/add-on/manifest.common.json
@@ -43,18 +43,6 @@
     "icons/ipfs-logo-on.svg",
     "icons/ipfs-logo-off.svg"
   ],
-  "content_scripts": [
-    {
-      "all_frames": true,
-      "js": [
-        "dist/bundles/ipfsProxyContentScript.bundle.js"
-      ],
-      "matches": [
-        "<all_urls>"
-      ],
-      "run_at": "document_start"
-    }
-  ],
   "content_security_policy": "script-src 'self'; object-src 'self'; frame-src 'self';",
   "default_locale": "en"
 }

--- a/add-on/src/contentScripts/ipfs-proxy/page.js
+++ b/add-on/src/contentScripts/ipfs-proxy/page.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const _Buffer = Buffer
 const { assign, freeze } = Object
 
 // TODO: (wip) this should not be injected by default into every page,
@@ -46,7 +45,4 @@ function createWindowIpfs () {
   return freeze(proxyClient)
 }
 
-// TODO: we should remove Buffer and add support for Uint8Array/ArrayBuffer natively
-// See: https://github.com/ipfs/interface-ipfs-core/issues/404
-window.Buffer = window.Buffer || _Buffer
 window.ipfs = window.ipfs || createWindowIpfs()

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -141,7 +141,15 @@ module.exports = async function init () {
     if (previousHandle) {
       previousHandle.unregister()
     }
-    if (!state.active || !state.ipfsProxy || !browser.contentScripts) {
+    // TODO:
+    // No window.ipfs for now.
+    // We will restore when Migration to JS API with Async Await and Async Iterables
+    // is done:
+    // https://github.com/ipfs-shipyard/ipfs-companion/pull/777
+    // https://github.com/ipfs-shipyard/ipfs-companion/issues/843
+    // https://github.com/ipfs-shipyard/ipfs-companion/issues/852#issuecomment-594510819
+    const forceOff = true
+    if (forceOff || !state.active || !state.ipfsProxy || !browser.contentScripts) {
       // no-op if global toggle is off, window.ipfs is disabled in Preferences
       // or if runtime has no contentScript API
       // (Chrome loads content script via manifest)
@@ -749,8 +757,10 @@ module.exports = async function init () {
         ipfsProxyContentScript.unregister()
         ipfsProxyContentScript = null
       }
-      destroyTasks.push(ipfsProxy.destroy())
-      ipfsProxy = null
+      if (ipfsProxy) {
+        destroyTasks.push(ipfsProxy.destroy())
+        ipfsProxy = null
+      }
       destroyTasks.push(destroyIpfsClient())
       return Promise.all(destroyTasks)
     }

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -77,24 +77,27 @@ function experimentsForm ({
           </label>
           <div>${switchToggle({ id: 'detectIpfsPathHeader', checked: detectIpfsPathHeader, onchange: onDetectIpfsPathHeaderChange })}</div>
         </div>
-        <div>
+        <div class="o-50">
           <label for="ipfsProxy">
             <dl>
               <dt>${browser.i18n.getMessage('option_ipfsProxy_title')}</dt>
               <dd>
+                Disabled due to JS API migration
+                <!-- TODO: https://github.com/ipfs-shipyard/ipfs-companion/pull/777
                 ${browser.i18n.getMessage('option_ipfsProxy_description')}
                 <p>${ipfsProxy ? html`
                     <a href="${browser.extension.getURL('dist/pages/proxy-acl/index.html')}" target="_blank">
                       ${browser.i18n.getMessage('option_ipfsProxy_link_manage_permissions')}
                     </a>` : html`<del>${browser.i18n.getMessage('option_ipfsProxy_link_manage_permissions')}</del>`}
                 </p>
-                <p><a href="https://github.com/ipfs-shipyard/ipfs-companion/blob/master/docs/window.ipfs.md#notes-on-exposing-ipfs-api-as-windowipfs" target="_blank">
+                -->
+                <p><a href="https://github.com/ipfs-shipyard/ipfs-companion/blob/master/docs/window.ipfs.md#%EF%B8%8F-windowipfs-is-disabled-for-now" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>
             </dl>
           </label>
-          <div>${switchToggle({ id: 'ipfsProxy', checked: ipfsProxy, onchange: onIpfsProxyChange })}</div>
+          <div>${switchToggle({ id: 'ipfsProxy', checked: ipfsProxy, disabled: true, onchange: onIpfsProxyChange })}</div>
         </div>
         <div>
           <label for="logNamespaces">

--- a/docs/window.ipfs.md
+++ b/docs/window.ipfs.md
@@ -68,8 +68,6 @@ if (window.ipfs && window.ipfs.enable) {
 }
 ```
 
-Note that IPFS Companion also adds `window.Buffer` if it doesn't already exist.
-
 See also: [How do I fallback if `window.ipfs` is not available?](#how-do-i-fallback-if-windowipfs-is-not-available)
 
 ### Error Codes

--- a/docs/window.ipfs.md
+++ b/docs/window.ipfs.md
@@ -1,4 +1,17 @@
-# Notes on exposing IPFS API via `window.ipfs`
+# ⚠️ `window.ipfs` is disabled for now
+
+IPFS Companion 2.11 stopped injecting  `window.ipfs`.
+It will be restored in near future after [move to JS API with Async Await and Async Iterables](https://github.com/ipfs-shipyard/ipfs-companion/issues/843).
+ETA Q3 2020.
+
+Below are docs in case someone wants to implement support for when it will be
+restored.
+
+
+-----
+
+
+## Notes on exposing IPFS API via `window.ipfs`
 
 > ### Disclaimer:
 > - ### [🚧 ongoing work on v2 of this interface 🚧](https://github.com/ipfs-shipyard/ipfs-companion/issues/589)


### PR DESCRIPTION
> parent #589 

- [x] Firefox supports dynamic injection,  plus we recently added dedicated `manifest.chromium.json` so it makes sense to remove it from Firefox build.
- [x] stop injecting Buffer (Closes #637)
- [x] stop injecting window.ipfs until Migration to JS API with Async Await and Async Iterables (https://github.com/ipfs-shipyard/ipfs-companion/issues/843)
     - Mitigates #856
     - Mitigates #852