### PR TITLE
feat: default local gateway URLs to  'localhost'

### DIFF
--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -73,19 +73,22 @@ exports.storeMissingOptions = async (read, defaults, storage) => {
   return changes
 }
 
-function normalizeGatewayURL (url) {
+function normalizeGatewayURL (url, { localhost = true }) {
   if (typeof url === 'string') {
     url = new URL(url)
   }
-  // https://github.com/ipfs/ipfs-companion/issues/328
-  if (url.hostname.toLowerCase() === 'localhost') {
+  // localhost normalization (https://github.com/ipfs-shipyard/ipfs-companion/issues/328)
+  if (localhost && url.hostname === '127.0.0.1') {
+    url.hostname = 'localhost'
+  }
+  if (!localhost && url.hostname === 'localhost') {
     url.hostname = '127.0.0.1'
   }
   // Return string without trailing slash
   return url.toString().replace(/\/$/, '')
 }
 exports.normalizeGatewayURL = normalizeGatewayURL
-exports.safeURL = (url) => new URL(normalizeGatewayURL(url))
+exports.safeURL = (url, opts) => new URL(normalizeGatewayURL(url, opts || {}))
 
 // convert JS array to multiline textarea
 function hostArrayCleanup (array) {

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -19,7 +19,7 @@ function initState (options) {
   delete state.publicGatewayUrl
   state.redirect = options.useCustomGateway
   delete state.useCustomGateway
-  state.apiURL = safeURL(options.ipfsApiUrl)
+  state.apiURL = safeURL(options.ipfsApiUrl, { localhost: false }) // go-ipfs returns 403 if IP is beautified to 'localhost'
   state.apiURLString = state.apiURL.toString()
   delete state.ipfsApiUrl
   state.gwURL = safeURL(options.customGatewayUrl)

--- a/test/functional/lib/dnslink.test.js
+++ b/test/functional/lib/dnslink.test.js
@@ -8,7 +8,7 @@ const { initState } = require('../../../add-on/src/lib/state')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
 
 const testOptions = Object.assign({}, optionDefaults, {
-  customGatewayUrl: 'http://127.0.0.1:8080',
+  customGatewayUrl: 'http://localhost:8080',
   publicGatewayUrl: 'https://gateway.foobar.io'
 })
 
@@ -82,7 +82,7 @@ describe('dnslinkResolver (dnslinkPolicy=detectIpfsPathHeader)', function () {
       dnslinkResolver.setDnslink(url.hostname, '/ipfs/bafybeigxjv2o4jse2lajbd5c7xxl5rluhyqg5yupln42252e5tcao7hbge')
       expectNoDnsTxtRecordLookup(url.hostname, dnslinkResolver)
       expect(dnslinkResolver.dnslinkRedirect(url.toString()).redirectUrl)
-        .to.equal('http://127.0.0.1:8080/ipns/dnslinksite4.io/foo/barl?a=b#c=d')
+        .to.equal('http://localhost:8080/ipns/dnslinksite4.io/foo/barl?a=b#c=d')
     })
     it('[embedded node] should return redirect to public gateway if dnslink is present in cache', function () {
       const url = new URL('https://dnslinksite4.io/foo/barl?a=b#c=d')
@@ -164,7 +164,7 @@ describe('dnslinkResolver (dnslinkPolicy=enabled)', function () {
       const dnslinkResolver = createDnslinkResolver(getExternalNodeState)
       spoofDnsTxtRecord(url.hostname, dnslinkResolver, dnslinkValue)
       expect(dnslinkResolver.dnslinkRedirect(url.toString()).redirectUrl)
-        .to.equal('http://127.0.0.1:8080/ipns/dnslinksite4.io/foo/barl?a=b#c=d')
+        .to.equal('http://localhost:8080/ipns/dnslinksite4.io/foo/barl?a=b#c=d')
     })
     it('[embedded node] should return redirect to public gateway if DNS TXT record is present and path does not belong to a gateway', function () {
       const url = new URL('https://dnslinksite4.io/foo/barl?a=b#c=d')


### PR DESCRIPTION
Closes #328


## TODO

- [x] default local gateway to `localhost`
- [ ] remove warning on options page
- [ ] ensure webui loaded from gateway port works in a firefox/chromium/brave

## Known Issues

- webui loaded from gateway port is broken
  - go-ipfs returns 403 Forbidden if request is made to `localhost` API
  - normalizing API host to IP solves the issue under Firefox and Chromium
  - Brave [continues to show CORS error](https://user-images.githubusercontent.com/157609/66035880-46b2c500-e50c-11e9-8aa2-4d0e211ee497.png), needs additional work
