### PR TITLE
feat: recover from failed HTTP requests to third party gateways

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -375,13 +375,13 @@
     "message": "Check before HTTP request",
     "description": "A select field option description on the Preferences screen (option_dnslinkPolicy_enabled)"
   },
-  "option_recoverViaPublicGateway_title": {
+  "option_recoverFailedHttpRequests_title": {
     "message": "Recover links via public gateway",
-    "description": "An option title on the Preferences screen (option_recoverViaPublicGateway_title)"
+    "description": "An option title on the Preferences screen (option_recoverFailedHttpRequests_title)"
   },
-  "option_recoverViaPublicGateway_description": {
+  "option_recoverFailedHttpRequests_description": {
     "message": "Redirect broken public gateway requests to the default public gateway",
-    "description": "An option description on the Preferences screen (option_recoverViaPublicGateway_description)"
+    "description": "An option description on the Preferences screen (option_recoverFailedHttpRequests_description)"
   },
   "option_detectIpfsPathHeader_title": {
     "message": "Detect X-Ipfs-Path Header",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -376,11 +376,11 @@
     "description": "A select field option description on the Preferences screen (option_dnslinkPolicy_enabled)"
   },
   "option_recoverFailedHttpRequests_title": {
-    "message": "Recover links via public gateway",
+    "message": "Recover Failed HTTP Requests",
     "description": "An option title on the Preferences screen (option_recoverFailedHttpRequests_title)"
   },
   "option_recoverFailedHttpRequests_description": {
-    "message": "Redirect broken public gateway requests to the default public gateway",
+    "message": "Attempts to recover failed HTTP requests for IPFS resources by redirecting to the public gateway.",
     "description": "An option description on the Preferences screen (option_recoverFailedHttpRequests_description)"
   },
   "option_detectIpfsPathHeader_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -375,6 +375,14 @@
     "message": "Check before HTTP request",
     "description": "A select field option description on the Preferences screen (option_dnslinkPolicy_enabled)"
   },
+  "option_recoverViaPublicGateway_title": {
+    "message": "Recover links via public gateway",
+    "description": "An option title on the Preferences screen (option_recoverViaPublicGateway_title)"
+  },
+  "option_recoverViaPublicGateway_description": {
+    "message": "Redirect broken public gateway requests to the default public gateway",
+    "description": "An option description on the Preferences screen (option_recoverViaPublicGateway_description)"
+  },
   "option_detectIpfsPathHeader_title": {
     "message": "Detect X-Ipfs-Path Header",
     "description": "An option title on the Preferences screen (option_detectIpfsPathHeader_title)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -380,7 +380,7 @@
     "description": "An option title on the Preferences screen (option_recoverFailedHttpRequests_title)"
   },
   "option_recoverFailedHttpRequests_description": {
-    "message": "Attempts to recover failed HTTP requests for IPFS resources by redirecting to the public gateway.",
+    "message": "Recover failed HTTP requests for IPFS resources by redirecting to the public gateway.",
     "description": "An option description on the Preferences screen (option_recoverFailedHttpRequests_description)"
   },
   "option_detectIpfsPathHeader_title": {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -675,7 +675,7 @@ module.exports = async function init () {
             await browser.storage.local.set({ detectIpfsPathHeader: true })
           }
           break
-        case 'recoverViaPublicGateway':
+        case 'recoverFailedHttpRequests':
           state[key] = change.newValue
           break
         case 'logNamespaces':

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -675,6 +675,9 @@ module.exports = async function init () {
             await browser.storage.local.set({ detectIpfsPathHeader: true })
           }
           break
+        case 'recoverViaPublicGateway':
+          state[key] = change.newValue
+          break
         case 'logNamespaces':
           shouldReloadExtension = true
           state[key] = localStorage.debug = change.newValue

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -105,6 +105,7 @@ module.exports = async function init () {
     browser.webRequest.onBeforeRequest.addListener(onBeforeRequest, { urls: ['<all_urls>'] }, ['blocking'])
     browser.webRequest.onHeadersReceived.addListener(onHeadersReceived, { urls: ['<all_urls>'] }, ['blocking', 'responseHeaders'])
     browser.webRequest.onErrorOccurred.addListener(onErrorOccurred, { urls: ['<all_urls>'] })
+    browser.webRequest.onCompleted.addListener(onCompleted, { urls: ['<all_urls>'] })
     browser.storage.onChanged.addListener(onStorageChange)
     browser.webNavigation.onCommitted.addListener(onNavigationCommitted)
     browser.webNavigation.onDOMContentLoaded.addListener(onDOMContentLoaded)
@@ -167,6 +168,10 @@ module.exports = async function init () {
 
   function onErrorOccurred (request) {
     return modifyRequest.onErrorOccurred(request)
+  }
+
+  function onCompleted (request) {
+    return modifyRequest.onCompleted(request)
   }
 
   // RUNTIME MESSAGES (one-off messaging)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -417,7 +417,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
       if (!redirect && recoverable) {
         const redirectUrl = ipfsPathValidator.resolveToPublicUrl(request.url, state.pubGwURLString)
         redirect = { redirectUrl }
-        log(`onErrorOccurred: attempting to recover using public gateway for ${request.url}`, redirect)
+        log(`onErrorOccurred: attempting to recover failed request for ${request.url}`, redirect)
       }
       // We can't redirect in onErrorOccurred, so if DNSLink is present
       // recover by opening IPNS version in a new tab
@@ -437,7 +437,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         const redirectUrl = ipfsPathValidator.resolveToPublicUrl(request.url, state.pubGwURLString)
         const redirect = { redirectUrl }
         if (redirect) {
-          log(`onErrorOccurred: attempting to recover using public gateway for ${request.url}`, redirect)
+          log(`onCompleted: attempting to recover failed request for ${request.url}`, redirect)
           createTabWithURL(redirect, browser)
         }
       }

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -413,8 +413,8 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
       }
       // if error cannot be recovered via DNSLink
       // direct the request to the public gateway
-      const recoverableViaPubGw = isRecoverableViaPubGw(request, state, ipfsPathValidator)
-      if (!redirect && recoverableViaPubGw) {
+      const recoverable = isRecoverable(request, state, ipfsPathValidator)
+      if (!redirect && recoverable) {
         const redirectUrl = ipfsPathValidator.resolveToPublicUrl(request.url, state.pubGwURLString)
         redirect = { redirectUrl }
         log(`onErrorOccurred: attempting to recover using public gateway for ${request.url}`, redirect)
@@ -430,10 +430,10 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
     async onCompleted (request) {
       const state = getState()
 
-      const recoverableViaPubGw =
-        isRecoverableViaPubGw(request, state, ipfsPathValidator) &&
+      const recoverable =
+        isRecoverable(request, state, ipfsPathValidator) &&
         recoverableErrorCodes.has(request.statusCode)
-      if (recoverableViaPubGw) {
+      if (recoverable) {
         const redirectUrl = ipfsPathValidator.resolveToPublicUrl(request.url, state.pubGwURLString)
         const redirect = { redirectUrl }
         if (redirect) {
@@ -550,7 +550,7 @@ function findHeaderIndex (name, headers) {
 
 // utility functions for handling redirects
 // from onErrorOccurred and onCompleted
-function isRecoverableViaPubGw (request, state, ipfsPathValidator) {
+function isRecoverable (request, state, ipfsPathValidator) {
   return state.recoverFailedHttpRequests &&
     ipfsPathValidator.publicIpfsOrIpnsResource(request.url) &&
     !request.url.startsWith(state.pubGwURLString) &&

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -551,7 +551,7 @@ function findHeaderIndex (name, headers) {
 // utility functions for handling redirects
 // from onErrorOccurred and onCompleted
 function isRecoverableViaPubGw (request, state, ipfsPathValidator) {
-  return state.recoverViaPublicGateway &&
+  return state.recoverFailedHttpRequests &&
     ipfsPathValidator.publicIpfsOrIpnsResource(request.url) &&
     !request.url.startsWith(state.pubGwURLString) &&
     request.type === 'main_frame'

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -551,7 +551,8 @@ function findHeaderIndex (name, headers) {
 // utility functions for handling redirects
 // from onErrorOccurred and onCompleted
 function isRecoverableViaPubGw (request, state, ipfsPathValidator) {
-  return ipfsPathValidator.publicIpfsOrIpnsResource(request.url) &&
+  return state.recoverViaPublicGateway &&
+    ipfsPathValidator.publicIpfsOrIpnsResource(request.url) &&
     !request.url.startsWith(state.pubGwURLString) &&
     request.type === 'main_frame'
 }

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -16,6 +16,7 @@ exports.optionDefaults = Object.freeze({
   automaticMode: true,
   linkify: false,
   dnslinkPolicy: 'best-effort',
+  recoverViaPublicGateway: false,
   detectIpfsPathHeader: true,
   preloadAtPublicGateway: true,
   catchUnhandledProtocols: true,

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -16,7 +16,7 @@ exports.optionDefaults = Object.freeze({
   automaticMode: true,
   linkify: false,
   dnslinkPolicy: 'best-effort',
-  recoverViaPublicGateway: false,
+  recoverFailedHttpRequests: true,
   detectIpfsPathHeader: true,
   preloadAtPublicGateway: true,
   catchUnhandledProtocols: true,

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -11,6 +11,7 @@ function experimentsForm ({
   catchUnhandledProtocols,
   linkify,
   dnslinkPolicy,
+  recoverViaPublicGateway,
   detectIpfsPathHeader,
   ipfsProxy,
   logNamespaces,
@@ -22,6 +23,7 @@ function experimentsForm ({
   const onCatchUnhandledProtocolsChange = onOptionChange('catchUnhandledProtocols')
   const onLinkifyChange = onOptionChange('linkify')
   const onDnslinkPolicyChange = onOptionChange('dnslinkPolicy')
+  const onrecoverViaPublicGatewayChange = onOptionChange('recoverViaPublicGateway')
   const onDetectIpfsPathHeaderChange = onOptionChange('detectIpfsPathHeader')
   const onIpfsProxyChange = onOptionChange('ipfsProxy')
 
@@ -95,6 +97,15 @@ function experimentsForm ({
               ${browser.i18n.getMessage('option_dnslinkPolicy_enabled')}
             </option>
           </select>
+        </div>
+        <div>
+          <label for="recoverViaPublicGateway">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_recoverViaPublicGateway_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_recoverViaPublicGateway_description')}</dd>
+            </dl>
+          </label>
+          <div>${switchToggle({ id: 'recoverViaPublicGateway', checked: recoverViaPublicGateway, onchange: onrecoverViaPublicGatewayChange })}</div>
         </div>
         <div>
           <label for="detectIpfsPathHeader">

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -11,7 +11,7 @@ function experimentsForm ({
   catchUnhandledProtocols,
   linkify,
   dnslinkPolicy,
-  recoverViaPublicGateway,
+  recoverFailedHttpRequests,
   detectIpfsPathHeader,
   ipfsProxy,
   logNamespaces,
@@ -23,7 +23,7 @@ function experimentsForm ({
   const onCatchUnhandledProtocolsChange = onOptionChange('catchUnhandledProtocols')
   const onLinkifyChange = onOptionChange('linkify')
   const onDnslinkPolicyChange = onOptionChange('dnslinkPolicy')
-  const onrecoverViaPublicGatewayChange = onOptionChange('recoverViaPublicGateway')
+  const onrecoverFailedHttpRequestsChange = onOptionChange('recoverFailedHttpRequests')
   const onDetectIpfsPathHeaderChange = onOptionChange('detectIpfsPathHeader')
   const onIpfsProxyChange = onOptionChange('ipfsProxy')
 
@@ -99,13 +99,13 @@ function experimentsForm ({
           </select>
         </div>
         <div>
-          <label for="recoverViaPublicGateway">
+          <label for="recoverFailedHttpRequests">
             <dl>
-              <dt>${browser.i18n.getMessage('option_recoverViaPublicGateway_title')}</dt>
-              <dd>${browser.i18n.getMessage('option_recoverViaPublicGateway_description')}</dd>
+              <dt>${browser.i18n.getMessage('option_recoverFailedHttpRequests_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_recoverFailedHttpRequests_description')}</dd>
             </dl>
           </label>
-          <div>${switchToggle({ id: 'recoverViaPublicGateway', checked: recoverViaPublicGateway, onchange: onrecoverViaPublicGatewayChange })}</div>
+          <div>${switchToggle({ id: 'recoverFailedHttpRequests', checked: recoverFailedHttpRequests, onchange: onrecoverFailedHttpRequestsChange })}</div>
         </div>
         <div>
           <label for="detectIpfsPathHeader">

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -75,7 +75,7 @@ module.exports = function optionsPage (state, emit) {
     catchUnhandledProtocols: state.options.catchUnhandledProtocols,
     linkify: state.options.linkify,
     dnslinkPolicy: state.options.dnslinkPolicy,
-    recoverViaPublicGateway: state.options.recoverViaPublicGateway,
+    recoverFailedHttpRequests: state.options.recoverFailedHttpRequests,
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,
     logNamespaces: state.options.logNamespaces,

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -75,6 +75,7 @@ module.exports = function optionsPage (state, emit) {
     catchUnhandledProtocols: state.options.catchUnhandledProtocols,
     linkify: state.options.linkify,
     dnslinkPolicy: state.options.dnslinkPolicy,
+    recoverViaPublicGateway: state.options.recoverViaPublicGateway,
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,
     logNamespaces: state.options.logNamespaces,

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -42,7 +42,7 @@ describe('requestHandler.onCompleted:', function () {
       state.recoverFailedHttpRequests = true
     })
     it('should do nothing if broken request is a non-IPFS request', async function () {
-      const request = urlRequestWithStatus('https://ipfs.io', 500)
+      const request = urlRequestWithStatus('https://wikipedia.org', 500)
       await requestHandler.onCompleted(request)
       assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
     })
@@ -57,7 +57,7 @@ describe('requestHandler.onCompleted:', function () {
       assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
     })
     it('should do nothing if broken request is not a \'main_frame\' request', async function () {
-      const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500, 'non_main_frame')
+      const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500, 'stylesheet')
       await requestHandler.onCompleted(request)
       assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
     })
@@ -129,7 +129,7 @@ describe('requestHandler.onErrorOccurred:', function () {
       assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
     })
     it('should do nothing if failed request is not a \'main_frame\' request', async function () {
-      const request = url2request('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 'non_main_frame')
+      const request = url2request('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 'stylesheet')
       await requestHandler.onErrorOccurred(request)
       assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
     })

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -1,0 +1,163 @@
+'use strict'
+const { describe, it, before, beforeEach, after, afterEach } = require('mocha')
+const sinon = require('sinon')
+const { assert } = require('chai')
+const { URL } = require('url')
+const browser = require('sinon-chrome')
+const { initState } = require('../../../add-on/src/lib/state')
+const { createRuntimeChecks } = require('../../../add-on/src/lib/runtime-checks')
+const { createRequestModifier } = require('../../../add-on/src/lib/ipfs-request')
+const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
+const { createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
+const { optionDefaults } = require('../../../add-on/src/lib/options')
+
+const url2request = (url, type = 'main_frame') => {
+  return { url, type }
+}
+const urlRequestWithStatus = (url, statusCode = 200, type = 'main_frame') => {
+  return { ...url2request(url, type), statusCode }
+}
+
+describe('requestHandler.onCompleted:', function () {
+  let state, dnslinkResolver, ipfsPathValidator, requestHandler, runtime
+
+  before(function () {
+    global.URL = URL
+    browser.tabs = { ...browser.tabs, query: sinon.stub().resolves([{ id: 20 }]) }
+    global.browser = browser
+  })
+
+  beforeEach(async function () {
+    state = initState(optionDefaults)
+    const getState = () => state
+    const getIpfs = () => {}
+    dnslinkResolver = createDnslinkResolver(getState)
+    runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
+    ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
+    requestHandler = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
+  })
+
+  describe('with recoverViaPublicGateway=true', function () {
+    beforeEach(function () {
+      state.recoverViaPublicGateway = true
+    })
+    it('should do nothing if broken request is a non-IPFS request', async function () {
+      const request = urlRequestWithStatus('https://ipfs.io', 500)
+      await requestHandler.onCompleted(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should do nothing if broken request is a non-public IPFS request', async function () {
+      const request = urlRequestWithStatus('http://127.0.0.1:8080/ipfs/QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
+      await requestHandler.onCompleted(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should do nothing if broken request is to the default public gateway', async function () {
+      const request = urlRequestWithStatus('https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
+      await requestHandler.onCompleted(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should do nothing if broken request is not a \'main_frame\' request', async function () {
+      const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500, 'non_main_frame')
+      await requestHandler.onCompleted(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should redirect broken non-default public gateway IPFS request to public gateway', async function () {
+      const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
+      await requestHandler.onCompleted(request)
+      assert.ok(browser.tabs.create.withArgs({ url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with IPFS default public gateway URL')
+    })
+  })
+
+  describe('with recoverViaPublicGateway=false', function () {
+    beforeEach(function () {
+      state.recoverViaPublicGateway = false
+    })
+    it('should do nothing on broken non-default public gateway IPFS request', async function () {
+      const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
+      await requestHandler.onCompleted(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+  })
+
+  afterEach(function () {
+    browser.tabs.create.reset()
+  })
+
+  after(function () {
+    delete global.url
+    delete global.browser
+    browser.flush()
+  })
+})
+
+describe('requestHandler.onErrorOccurred:', function () {
+  let state, dnslinkResolver, ipfsPathValidator, requestHandler, runtime
+
+  before(function () {
+    global.URL = URL
+    browser.tabs = { ...browser.tabs, query: sinon.stub().resolves([{ id: 20 }]) }
+    global.browser = browser
+  })
+
+  beforeEach(async function () {
+    state = initState(optionDefaults)
+    const getState = () => state
+    const getIpfs = () => {}
+    dnslinkResolver = createDnslinkResolver(getState)
+    runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
+    ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
+    requestHandler = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
+  })
+
+  describe('with recoverViaPublicGateway=true', function () {
+    beforeEach(function () {
+      state.recoverViaPublicGateway = true
+    })
+    it('should do nothing if failed request is a non-IPFS request', async function () {
+      const request = url2request('https://wikipedia.org', 500)
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should do nothing if failed request is a non-public IPFS request', async function () {
+      const request = url2request('http://127.0.0.1:8080/ipfs/QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should do nothing if failed request is to the default public gateway', async function () {
+      const request = url2request('https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should do nothing if failed request is not a \'main_frame\' request', async function () {
+      const request = url2request('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 'non_main_frame')
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+    it('should redirect failed non-default public gateway IPFS request to public gateway', async function () {
+      const request = url2request('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.create.withArgs({ url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with IPFS default public gateway URL')
+    })
+  })
+
+  describe('with recoverViaPublicGateway=false', function () {
+    beforeEach(function () {
+      state.recoverViaPublicGateway = false
+    })
+    it('should do nothing on failed non-default public gateway IPFS request', async function () {
+      const request = url2request('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+    })
+  })
+
+  afterEach(function () {
+    browser.tabs.create.reset()
+  })
+
+  after(function () {
+    delete global.url
+    delete global.browser
+    browser.flush()
+  })
+})

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -37,9 +37,9 @@ describe('requestHandler.onCompleted:', function () {
     requestHandler = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
   })
 
-  describe('with recoverViaPublicGateway=true', function () {
+  describe('with recoverFailedHttpRequests=true', function () {
     beforeEach(function () {
-      state.recoverViaPublicGateway = true
+      state.recoverFailedHttpRequests = true
     })
     it('should do nothing if broken request is a non-IPFS request', async function () {
       const request = urlRequestWithStatus('https://ipfs.io', 500)
@@ -68,9 +68,9 @@ describe('requestHandler.onCompleted:', function () {
     })
   })
 
-  describe('with recoverViaPublicGateway=false', function () {
+  describe('with recoverFailedHttpRequests=false', function () {
     beforeEach(function () {
-      state.recoverViaPublicGateway = false
+      state.recoverFailedHttpRequests = false
     })
     it('should do nothing on broken non-default public gateway IPFS request', async function () {
       const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
@@ -109,9 +109,9 @@ describe('requestHandler.onErrorOccurred:', function () {
     requestHandler = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
   })
 
-  describe('with recoverViaPublicGateway=true', function () {
+  describe('with recoverFailedHttpRequests=true', function () {
     beforeEach(function () {
-      state.recoverViaPublicGateway = true
+      state.recoverFailedHttpRequests = true
     })
     it('should do nothing if failed request is a non-IPFS request', async function () {
       const request = url2request('https://wikipedia.org', 500)
@@ -140,9 +140,9 @@ describe('requestHandler.onErrorOccurred:', function () {
     })
   })
 
-  describe('with recoverViaPublicGateway=false', function () {
+  describe('with recoverFailedHttpRequests=false', function () {
     beforeEach(function () {
-      state.recoverViaPublicGateway = false
+      state.recoverFailedHttpRequests = false
     })
     it('should do nothing on failed non-default public gateway IPFS request', async function () {
       const request = url2request('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')


### PR DESCRIPTION
This PR closes #640, enabling dead public gateways to be redirected to the default public gateway. Added as an experimental option, defaulting to `false`.