### PR TITLE
fix: Improve extraHeaders feature detection

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -97,7 +97,7 @@ module.exports = async function init () {
 
   function registerListeners () {
     const onBeforeSendInfoSpec = ['blocking', 'requestHeaders']
-    if (!runtime.isFirefox) {
+    if (browser.webRequest.OnBeforeSendHeadersOptions && 'EXTRA_HEADERS' in browser.webRequest.OnBeforeSendHeadersOptions) {
       // Chrome 72+  requires 'extraHeaders' for access to Referer header (used in cors whitelisting of webui)
       onBeforeSendInfoSpec.push('extraHeaders')
     }


### PR DESCRIPTION
On Firefox forks the `runtime.isFirefox` detection will fail (because the browser name is not 'Firefox'). This leads to an error when registering webRequest listeners as the `extraHeaders` option is not needed, preventing the extension from loading.

There is actually an extension API that can be used to detect support for this option: [`OnBeforeSendHeadersOptions`](https://developer.chrome.com/extensions/webRequest#type-OnBeforeSendHeadersOptions).

This PR updates the feature detection check to explicitly look for this API. We have to also check to for the presence of `OnBeforeSendHeadersOptions` as it does not exist on Edge.