### PR TITLE
fix: avoid internal requests for action icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "mime-types": "2.1.24",
     "multiaddr": "7.1.0",
     "multiaddr-to-uri": "5.0.0",
+    "p-memoize": "3.1.0",
     "p-queue": "6.1.1",
     "path-browserify": "1.0.0",
     "piggybacker": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9643,7 +9643,7 @@ mem-storage-area@1.0.3:
   resolved "https://registry.yarnpkg.com/mem-storage-area/-/mem-storage-area-1.0.3.tgz#a8a9bc75eaf5ae69efe185fedd475fb731d14880"
   integrity sha512-UwDsIj6Fmml8NPiPp7QGJavwZVbXMFLvVDfshv3486KQHDcxOExr0od4YkUdJVWFlujZxtct59mEtsPvAQTOMQ==
 
-mem@^4.0.0:
+mem@^4.0.0, mem@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
   integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
@@ -11172,6 +11172,14 @@ p-map@^3.0.0:
   integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-memoize@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-memoize/-/p-memoize-3.1.0.tgz#ac7587983c9e530139f969ca7b41ef40e93659aa"
+  integrity sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==
+  dependencies:
+    mem "^4.3.0"
+    mimic-fn "^2.1.0"
 
 p-queue@6.1.1, p-queue@^6.0.0:
   version "6.1.1"


### PR DESCRIPTION
This PR:

- Checks if browser action icon really changed. We now set it only when it is really needed, removing the overhead of redraw and internal requests
- Chrome does not support SVG in browser action, so we have to compute the path of raster  version (PNG). This needs to be done only once, so the calculation is now memoized.
  - There is also a commented out version that creates rasters on the fly. For now we can't remove PNGs and switch to it: we need PNGs for use in manifest and Chrome Web Store. We may switch when CWS supports SVG at some point in the future.

## Motivation

Context: every time peer count was updated, the browser action icon got set,
which caused unnecessary  internal request for PNG assets every 3 seconds:

![internal-requests-2019-10-10--20-47-51](https://user-images.githubusercontent.com/157609/66597446-4915be80-eb9f-11e9-91ba-6d406b97a841.png)

This change mostly makes request logs in Network tab less noisy in Brave (#716), but is also related to addressing #721: next step will be to stop polling API status every 3 seconds.