### PR TITLE
feat: recover from DNS failures, support DNSLink for .eth

### DIFF
--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -180,8 +180,7 @@ module.exports = function createDnslinkResolver (getState) {
       if (typeof url === 'string') {
         url = new URL(url)
       }
-      const fqdn = url.hostname
-      return `/ipns/${fqdn}${url.pathname}${url.search}${url.hash}`
+      return `/ipns/${url.hostname}${url.pathname}${url.search}${url.hash}`
     },
 
     // Test if URL contains a valid DNSLink FQDN

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -60,6 +60,15 @@ function experimentsForm ({
           <div>${switchToggle({ id: 'catchUnhandledProtocols', checked: catchUnhandledProtocols, onchange: onCatchUnhandledProtocolsChange })}</div>
         </div>
         <div>
+          <label for="recoverFailedHttpRequests">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_recoverFailedHttpRequests_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_recoverFailedHttpRequests_description')}</dd>
+            </dl>
+          </label>
+          <div>${switchToggle({ id: 'recoverFailedHttpRequests', checked: recoverFailedHttpRequests, onchange: onrecoverFailedHttpRequestsChange })}</div>
+        </div>
+        <div>
           <label for="linkify">
             <dl>
               <dt>${browser.i18n.getMessage('option_linkify_title')}</dt>
@@ -97,15 +106,6 @@ function experimentsForm ({
               ${browser.i18n.getMessage('option_dnslinkPolicy_enabled')}
             </option>
           </select>
-        </div>
-        <div>
-          <label for="recoverFailedHttpRequests">
-            <dl>
-              <dt>${browser.i18n.getMessage('option_recoverFailedHttpRequests_title')}</dt>
-              <dd>${browser.i18n.getMessage('option_recoverFailedHttpRequests_description')}</dd>
-            </dl>
-          </label>
-          <div>${switchToggle({ id: 'recoverFailedHttpRequests', checked: recoverFailedHttpRequests, onchange: onrecoverFailedHttpRequestsChange })}</div>
         </div>
         <div>
           <label for="detectIpfsPathHeader">


### PR DESCRIPTION
This PR builds on top of #783 and:

-  adds support for recovery from DNS lookup failures
-  enables recovery for all HTTP Codes >= 400 
-  recovers `.eth` DNS failures bu reopening website on EthDNS gateway at `.eth.link`
-  simplifies some code paths and adds more tests

## Motivation 
    
When a third-party IPFS gateway is discontinued or censored at DNS level, the IPFS Companion should retry request using currently active gateway set by the user (public or local).

We also want to recover in situation when website with DNSLink has a valid DNS `TXT` record, but HTTP behind `A` record is down or unreachable.

*Note*: right now the only real use for DNS recovery is support .eth TLD via .eth.link gateway, however in the future this could provide means of working around DNS-based censorship (eg. by executing DNSLink lookups over libp2p as a fallback).

closes #678, closes #640, #783 needs to be merged first

### TODO

- [x] rebase on top of https://github.com/ipfs-shipyard/ipfs-companion/pull/783
- [x] check if `.eth` can be supported natively by go-ipfs, or do we need to point at `.eth.link` for now
	- not yet, we need go-ipfs v0.5.0 for `.eth`, using `.eth.link` for now
- [x] add `.eth` tests