### PR TITLE
fix: set minimum_chrome_version to 72

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,7 @@
       {
         "targets": {
           "firefox": 69,
-          "chrome": 70
+          "chrome": 72
         }
       }
     ]

--- a/add-on/manifest.chromium.json
+++ b/add-on/manifest.chromium.json
@@ -1,3 +1,4 @@
 {
+  "minimum_chrome_version": "72",
   "incognito": "not_allowed"
 }


### PR DESCRIPTION
This PR adds an explicit [`minimum_chrome_version`](https://chrome-apps-doc2.appspot.com/extensions/manifest.html#minimum_chrome_version) to the `manifest.json` in Chromium builds.

Closes #715