### PR TITLE
feat: display feedback form on extension uninstall

### DIFF
--- a/add-on/src/background/background.js
+++ b/add-on/src/background/background.js
@@ -3,10 +3,12 @@
 
 const browser = require('webextension-polyfill')
 const { onInstalled } = require('../lib/on-installed')
+const { getUninstallURL } = require('../lib/on-uninstalled')
 const { optionDefaults } = require('../lib/options')
 
-// register onInstalled hook early, otherwise we miss first install event
+// register lifecycle hooks early, otherwise we miss first install event
 browser.runtime.onInstalled.addListener(onInstalled)
+browser.runtime.setUninstallURL(getUninstallURL(browser))
 
 // init add-on after all libs are loaded
 document.addEventListener('DOMContentLoaded', async () => {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -755,6 +755,10 @@ module.exports = async function init () {
       return state
     },
 
+    get runtime () {
+      return runtime
+    },
+
     get dnslinkResolver () {
       return dnslinkResolver
     },

--- a/add-on/src/lib/on-uninstalled.js
+++ b/add-on/src/lib/on-uninstalled.js
@@ -1,0 +1,14 @@
+'use strict'
+/* eslint-env browser */
+
+const stableChannels = new Set([
+  'ipfs-firefox-addon@lidel.org', // firefox (for legacy reasons)
+  'nibjojkomfdiaoajekhjakgkdhaomnch' // chromium (chrome web store)
+])
+
+const stableChannelFormUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSfLF7uzaxRKiF4XpPL9_DvkdaQHoRnDihRTZ1uVL6ceQwIrtg/viewform'
+
+exports.getUninstallURL = (browser) => {
+  // on uninstall feedback form shown only on stable channel
+  return stableChannels.has(browser.runtime.id) ? stableChannelFormUrl : ''
+}


### PR DESCRIPTION
This PR displays a short feedback form  **on uninstall** of IPFS Companion browser extension.


This is a small experiment I made to get some insights about user expectations and biggest pain points. Note I have no experience in this, would appreciate honest feedback and thoughts on feasibility of such "on uninstall" feedback forms, and types of questions we should ask.

cc @ipfs-shipyard/gui, @autonome  @terichadbourne, @meiqimichelle

## How does this work?

- when user removed IPFS Companion, the form is opened in a new tab
- we use anonymous form that does not require login
  - all fields are optional
  - user can provide contact information (email) if they choose to do so
- uninstall feedback form is displayed only on stable channel
  - this ensures we get feedback about the official stable channel

## How does it look like?

### v2 (simplified Google Forms)

- picked Google Form to keep everything visible at a single glance
- simplified text by @ericronne   https://hackmd.io/D3AcXZptQyme4utzSEaXjw
- details in https://github.com/ipfs-shipyard/ipfs-companion/pull/799#issuecomment-545408467
  > ![](https://user-images.githubusercontent.com/157609/67390103-3ab2a400-f59c-11e9-8e0f-d5f9c85624f5.png)

### v1 (prototype in Google Forms & Typeform)

-  brainstorming questions: https://hackmd.io/D3AcXZptQyme4utzSEaXjw

- screenshots in https://github.com/ipfs-shipyard/ipfs-companion/pull/799#issuecomment-544524590

### v0 (Google Forms)

- [screenshot](https://user-images.githubusercontent.com/157609/67014745-a35dd480-f0f5-11e9-8020-b616f5d5190b.png)



closes #468