### PR TITLE
feat: import files to MFS

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -39,10 +39,6 @@
     "message": "Share files via IPFS",
     "description": "A menu item in Browser Action pop-up (panel_quickUpload)"
   },
-  "quickUpload_options_openViaWebUI": {
-    "message": "Open imported files in Web UI",
-    "description": "Checkbox label on the share files page (quickUpload_options_openViaWebUI)"
-  },
   "panel_openWebui": {
     "message": "Open Web UI",
     "description": "A menu item in Browser Action pop-up (panel_openWebui)"
@@ -435,10 +431,6 @@
     "message": "MFS Import Directory",
     "description": "An option title on the Preferences screen (option_uploadDir_title)"
   },
-  "quickUpload_options_wrapWithDirectory": {
-    "message": "Wrap single files in a directory to preserve their filenames.",
-    "description": "Checkbox label on the share files page (quickUpload_options_wrapWithDirectory)"
-  },
   "option_uploadDir_description": {
     "message": "Customize the directory used for uploading files to MFS.",
     "description": "An option description on the Preferences screen (option_uploadDir_description)"
@@ -493,7 +485,15 @@
   },
   "quickUpload_options_uploadDir": {
     "message": "MFS directory to store imported files",
-    "description": "Textbox label on the share files page (quickUpload_options_wrapWithDirectory)"
+    "description": "Textbox label on the share files page (quickUpload_options_uploadDir)"
+  },
+  "quickUpload_options_wrapWithDirectory": {
+    "message": "Wrap single files in a directory to preserve their filenames.",
+    "description": "Checkbox label on the share files page (quickUpload_options_wrapWithDirectory)"
+  },
+  "quickUpload_options_openViaWebUI": {
+    "message": "Open imported files in Web UI",
+    "description": "Checkbox label on the share files page (quickUpload_options_openViaWebUI)"
   },
   "page_proxyAcl_title": {
     "message": "Manage Permissions",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -215,6 +215,10 @@
     "message": "IPFS Node",
     "description": "A section header on the Preferences screen (option_header_nodeType)"
   },
+  "option_header_fileImport": {
+    "message": "File Import",
+    "description": "A section header on the Preferences screen (option_header_fileImport)"
+  },
   "option_ipfsNodeType_title": {
     "message": "IPFS Node Type",
     "description": "An option title on the Preferences screen (option_ipfsNodeType_title)"
@@ -432,7 +436,7 @@
     "description": "An option title on the Preferences screen (option_importDir_title)"
   },
   "option_importDir_description": {
-    "message": "Customize the directory used for uploading files to MFS.",
+    "message": "Customize the directory used for imported files.",
     "description": "An option description on the Preferences screen (option_importDir_description)"
   },
   "option_resetAllOptions_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -127,17 +127,13 @@
     "message": "This Page",
     "description": "An item in right-click context menu (contextMenu_parentPage)"
   },
-  "contextMenu_AddToIpfsKeepFilename": {
-    "message": "Add to IPFS (Keep Filename)",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsKeepFilename)"
+  "contextMenu_importToIpfs": {
+    "message": "Import to IPFS",
+    "description": "An item in right-click context menu (contextMenu_importToIpfs)"
   },
-  "contextMenu_AddToIpfsRawCid": {
-    "message": "Add to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsRawCid)"
-  },
-  "contextMenu_AddToIpfsSelection": {
-    "message": "Add Selected Text to IPFS",
-    "description": "An item in right-click context menu (contextMenu_AddToIpfsSelection)"
+  "contextMenu_importToIpfsSelection": {
+    "message": "Import Selected Text to IPFS",
+    "description": "An item in right-click context menu (contextMenu_importToIpfsSelection)"
   },
   "notify_addonIssueTitle": {
     "message": "IPFS Add-on Issue",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -476,7 +476,7 @@
     "description": "Button on the share files page (quickUpload_options_show)"
   },
   "quickUpload_options_uploadDir": {
-    "message": "MFS directory to store uploaded files",
+    "message": "MFS directory to store imported files",
     "description": "Textbox label on the share files page (quickUpload_options_wrapWithDirectory)"
   },
   "page_proxyAcl_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -416,11 +416,11 @@
     "description": "Link text for managing permissions"
   },
   "option_preloadAtPublicGateway_title": {
-    "message": "Preload Uploads",
+    "message": "Preload Imports",
     "description": "An option title on the Preferences screen (option_preloadAtPublicGateway_title)"
   },
   "option_preloadAtPublicGateway_description": {
-    "message": "Enables automatic preload of uploaded assets via asynchronous HTTP HEAD request to a Public Gateway",
+    "message": "Enables automatic preload of imported assets via asynchronous HTTP HEAD request to a Public Gateway",
     "description": "An option description on the Preferences screen (option_preloadAtPublicGateway_description)"
   },
   "option_logNamespaces_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -475,9 +475,9 @@
     "message": "upload options",
     "description": "Button on the share files page (quickUpload_options_show)"
   },
-  "quickUpload_options_wrapWithDirectory": {
-    "message": "Wrap single files in a directory to preserve their filenames.",
-    "description": "Checkbox label on the share files page (quickUpload_options_wrapWithDirectory)"
+  "quickUpload_options_uploadDir": {
+    "message": "MFS directory to store uploaded files",
+    "description": "Textbox label on the share files page (quickUpload_options_wrapWithDirectory)"
   },
   "quickUpload_options_pinUpload": {
     "message": "Pin files so they are retained when performing garbage collection on your IPFS repo.",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -39,6 +39,10 @@
     "message": "Share files via IPFS",
     "description": "A menu item in Browser Action pop-up (panel_quickUpload)"
   },
+  "quickUpload_options_openViaWebUI": {
+    "message": "Open imported files in Web UI",
+    "description": "Checkbox label on the share files page (quickUpload_options_openViaWebUI)"
+  },
   "panel_openWebui": {
     "message": "Open Web UI",
     "description": "A menu item in Browser Action pop-up (panel_openWebui)"
@@ -480,7 +484,7 @@
     "description": "Status label on the share files page (quickUpload_state_buffering)"
   },
   "quickUpload_options_show": {
-    "message": "upload options",
+    "message": "import options",
     "description": "Button on the share files page (quickUpload_options_show)"
   },
   "quickUpload_options_uploadDir": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -427,13 +427,13 @@
     "message": "Customize which namespaces are logged to Browser Console. Changing this value will trigger extension restart.",
     "description": "An option description for the log level (option_logNamespaces_description)"
   },
-  "option_uploadDir_title": {
+  "option_importDir_title": {
     "message": "File Import Directory",
-    "description": "An option title on the Preferences screen (option_uploadDir_title)"
+    "description": "An option title on the Preferences screen (option_importDir_title)"
   },
-  "option_uploadDir_description": {
+  "option_importDir_description": {
     "message": "Customize the directory used for uploading files to MFS.",
-    "description": "An option description on the Preferences screen (option_uploadDir_description)"
+    "description": "An option description on the Preferences screen (option_importDir_description)"
   },
   "option_resetAllOptions_title": {
     "message": "Reset Everything",
@@ -483,9 +483,9 @@
     "message": "import options",
     "description": "Button on the share files page (quickUpload_options_show)"
   },
-  "quickUpload_options_uploadDir": {
+  "quickUpload_options_importDir": {
     "message": "Path to store imported files",
-    "description": "Textbox label on the share files page (quickUpload_options_uploadDir)"
+    "description": "Textbox label on the share files page (quickUpload_options_importDir)"
   },
   "quickUpload_options_openViaWebUI": {
     "message": "Open in Web UI",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -435,6 +435,10 @@
     "message": "MFS Import Directory",
     "description": "An option title on the Preferences screen (option_uploadDir_title)"
   },
+  "quickUpload_options_wrapWithDirectory": {
+    "message": "Wrap single files in a directory to preserve their filenames.",
+    "description": "Checkbox label on the share files page (quickUpload_options_wrapWithDirectory)"
+  },
   "option_uploadDir_description": {
     "message": "Customize the directory used for uploading files to MFS.",
     "description": "An option description on the Preferences screen (option_uploadDir_description)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -415,6 +415,14 @@
     "message": "Manage permissions",
     "description": "Link text for managing permissions"
   },
+  "option_openViaWebUI_title": {
+    "message": "Open imported files in Web UI",
+    "description": "An option title on the Preferences screen (option_openViaWebUI_title)"
+  },
+  "option_openViaWebUI_description": {
+    "message": "Display files in Web UI rather than opening file or parent directory at gateway.",
+    "description": "An option description on the Preferences screen (option_openViaWebUI_description)"
+  },
   "option_preloadAtPublicGateway_title": {
     "message": "Preload Imports",
     "description": "An option title on the Preferences screen (option_preloadAtPublicGateway_title)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -428,7 +428,7 @@
     "description": "An option description for the log level (option_logNamespaces_description)"
   },
   "option_uploadDir_title": {
-    "message": "MFS Import Directory",
+    "message": "File Import Directory",
     "description": "An option title on the Preferences screen (option_uploadDir_title)"
   },
   "option_uploadDir_description": {
@@ -484,7 +484,7 @@
     "description": "Button on the share files page (quickUpload_options_show)"
   },
   "quickUpload_options_uploadDir": {
-    "message": "MFS directory to store imported files",
+    "message": "Path to store imported files",
     "description": "Textbox label on the share files page (quickUpload_options_uploadDir)"
   },
   "quickUpload_options_wrapWithDirectory": {
@@ -492,7 +492,7 @@
     "description": "Checkbox label on the share files page (quickUpload_options_wrapWithDirectory)"
   },
   "quickUpload_options_openViaWebUI": {
-    "message": "Open imported files in Web UI",
+    "message": "Open in Web UI",
     "description": "Checkbox label on the share files page (quickUpload_options_openViaWebUI)"
   },
   "page_proxyAcl_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -479,10 +479,6 @@
     "message": "MFS directory to store uploaded files",
     "description": "Textbox label on the share files page (quickUpload_options_wrapWithDirectory)"
   },
-  "quickUpload_options_pinUpload": {
-    "message": "Pin files so they are retained when performing garbage collection on your IPFS repo.",
-    "description": "Checkbox label on the share files page (quickUpload_options_pinUpload)"
-  },
   "page_proxyAcl_title": {
     "message": "Manage Permissions",
     "description": "Page title for the IPFS proxy ACL page (page_proxyAcl_title)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -427,6 +427,14 @@
     "message": "Customize which namespaces are logged to Browser Console. Changing this value will trigger extension restart.",
     "description": "An option description for the log level (option_logNamespaces_description)"
   },
+  "option_uploadDir_title": {
+    "message": "MFS Import Directory",
+    "description": "An option title on the Preferences screen (option_uploadDir_title)"
+  },
+  "option_uploadDir_description": {
+    "message": "Customize the directory used for uploading files to MFS.",
+    "description": "An option description on the Preferences screen (option_uploadDir_description)"
+  },
   "option_resetAllOptions_title": {
     "message": "Reset Everything",
     "description": "An option title and button label on the Preferences screen (option_resetAllOptions_title)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -487,10 +487,6 @@
     "message": "Path to store imported files",
     "description": "Textbox label on the share files page (quickUpload_options_uploadDir)"
   },
-  "quickUpload_options_wrapWithDirectory": {
-    "message": "Wrap single files in a directory to preserve their filenames.",
-    "description": "Checkbox label on the share files page (quickUpload_options_wrapWithDirectory)"
-  },
   "quickUpload_options_openViaWebUI": {
     "message": "Open in Web UI",
     "description": "Checkbox label on the share files page (quickUpload_options_openViaWebUI)"

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -51,10 +51,9 @@ const menuParentLink = 'contextMenu_parentLink'
 const menuParentPage = 'contextMenu_parentPage'
 // const menuParentText = 'contextMenu_parentText'
 // Generic Add to IPFS
-const contextMenuAddToIpfsRawCid = 'contextMenu_AddToIpfsRawCid'
-const contextMenuAddToIpfsKeepFilename = 'contextMenu_AddToIpfsKeepFilename'
+const contextMenuImportToIpfs = 'contextMenu_importToIpfs'
 // Add X to IPFS
-const contextMenuAddToIpfsSelection = 'contextMenu_AddToIpfsSelection'
+const contextMenuImportToIpfsSelection = 'contextMenu_importToIpfsSelection'
 // Copy X
 const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpfsAddress'
 const contextMenuCopyRawCid = 'panelCopy_copyRawCid'
@@ -78,15 +77,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
         contexts: [contextType]
       })
     }
-    const createSeparator = (parentId, id, contextType) => {
-      return browser.contextMenus.create({
-        id: `${parentId}_${id}`,
-        parentId,
-        type: 'separator',
-        contexts: ['all']
-      })
-    }
-    const createAddToIpfsMenuItem = (parentId, id, contextType, ipfsAddOptions) => {
+    const createImportToIpfsMenuItem = (parentId, id, contextType, ipfsAddOptions) => {
       const itemId = `${parentId}_${id}`
       apiMenuItems.add(itemId)
       return browser.contextMenus.create({
@@ -125,9 +116,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
     }
     const buildSubmenu = (parentId, contextType) => {
       createSubmenu(parentId, contextType)
-      createAddToIpfsMenuItem(parentId, contextMenuAddToIpfsKeepFilename, contextType, { wrapWithDirectory: true })
-      createAddToIpfsMenuItem(parentId, contextMenuAddToIpfsRawCid, contextType, { wrapWithDirectory: false })
-      createSeparator(parentId, 'separator-1', contextType)
+      createImportToIpfsMenuItem(parentId, contextMenuImportToIpfs, contextType, { wrapWithDirectory: true, pin: false })
       createCopierMenuItem(parentId, contextMenuCopyAddressAtPublicGw, contextType, onCopyAddressAtPublicGw)
       createCopierMenuItem(parentId, contextMenuCopyCanonicalAddress, contextType, onCopyCanonicalAddress)
       createCopierMenuItem(parentId, contextMenuCopyRawCid, contextType, onCopyRawCid)
@@ -135,9 +124,9 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
 
     /*
     createSubmenu(menuParentText, 'selection')
-    createAddToIpfsMenuItem(menuParentText, contextMenuAddToIpfsSelection, 'selection')
+    createImportToIpfsMenuItem(menuParentText, contextMenuImportToIpfsSelection, 'selection')
     */
-    createAddToIpfsMenuItem(null, contextMenuAddToIpfsSelection, 'selection')
+    createImportToIpfsMenuItem(null, contextMenuImportToIpfsSelection, 'selection', { pin: false })
     buildSubmenu(menuParentImage, 'image')
     buildSubmenu(menuParentVideo, 'video')
     buildSubmenu(menuParentAudio, 'audio')

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -231,6 +231,7 @@ module.exports = async function init () {
       pubGwURLString: dropSlash(state.pubGwURLString),
       webuiRootUrl: state.webuiRootUrl,
       importDir: state.importDir,
+      openViaWebUI: state.openViaWebUI,
       apiURLString: dropSlash(state.apiURLString),
       redirect: state.redirect,
       noRedirectHostnames: state.noRedirectHostnames,
@@ -734,6 +735,7 @@ module.exports = async function init () {
         case 'automaticMode':
         case 'detectIpfsPathHeader':
         case 'preloadAtPublicGateway':
+        case 'openViaWebUI':
         case 'noRedirectHostnames':
           state[key] = change.newValue
           break

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -367,6 +367,12 @@ module.exports = async function init () {
     return result
   }
 
+  async function openWebUiAtDirectory (dir) {
+    await browser.tabs.create({
+      url: `${state.webuiRootUrl}#/files${dir}`
+    })
+  }
+
   // Page-specific Actions
   // -------------------------------------------------------------------
 
@@ -785,6 +791,10 @@ module.exports = async function init () {
 
     get uploadResultHandler () {
       return uploadResultHandler
+    },
+
+    get openWebUiAtDirectory () {
+      return openWebUiAtDirectory
     },
 
     destroy () {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -230,7 +230,7 @@ module.exports = async function init () {
       gwURLString: dropSlash(state.gwURLString),
       pubGwURLString: dropSlash(state.pubGwURLString),
       webuiRootUrl: state.webuiRootUrl,
-      uploadDir: state.uploadDir,
+      importDir: state.importDir,
       apiURLString: dropSlash(state.apiURLString),
       redirect: state.redirect,
       noRedirectHostnames: state.noRedirectHostnames,
@@ -716,7 +716,7 @@ module.exports = async function init () {
           shouldReloadExtension = true
           state[key] = localStorage.debug = change.newValue
           break
-        case 'uploadDir':
+        case 'importDir':
           state[key] = change.newValue
           break
         case 'linkify':

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -230,6 +230,7 @@ module.exports = async function init () {
       gwURLString: dropSlash(state.gwURLString),
       pubGwURLString: dropSlash(state.pubGwURLString),
       webuiRootUrl: state.webuiRootUrl,
+      uploadDir: state.uploadDir,
       apiURLString: dropSlash(state.apiURLString),
       redirect: state.redirect,
       noRedirectHostnames: state.noRedirectHostnames,
@@ -714,6 +715,9 @@ module.exports = async function init () {
         case 'logNamespaces':
           shouldReloadExtension = true
           state[key] = localStorage.debug = change.newValue
+          break
+        case 'uploadDir':
+          state[key] = change.newValue
           break
         case 'linkify':
         case 'catchUnhandledProtocols':

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -283,6 +283,16 @@ module.exports = async function init () {
     })
   }
 
+  function preloadFilesAtPublicGateway (files) {
+    for (const file in files) {
+      if (file && file.hash) {
+        const { path } = getIpfsPathAndNativeAddress(file.hash)
+        preloadAtPublicGateway(path)
+        console.info('[ipfs-companion] successfully stored', file)
+      }
+    }
+  }
+
   // Context Menu Uploader
   // -------------------------------------------------------------------
 
@@ -352,12 +362,10 @@ module.exports = async function init () {
   }
 
   async function uploadResultHandler ({ result, openRootInNewTab = false }) {
+    preloadFilesAtPublicGateway(result)
     for (const file of result) {
       if (file && file.hash) {
-        const { path, url } = getIpfsPathAndNativeAddress(file.hash)
-        preloadAtPublicGateway(path)
-        console.info('[ipfs-companion] successfully stored', file)
-        // open the wrapping directory (or the CID if wrapping was disabled)
+        const { url } = getIpfsPathAndNativeAddress(file.hash)
         if (openRootInNewTab && (result.length === 1 || file.path === '' || file.path === file.hash)) {
           await browser.tabs.create({
             url: url
@@ -368,7 +376,8 @@ module.exports = async function init () {
     return result
   }
 
-  async function openWebUiAtDirectory (dir) {
+  async function openWebUiAtDirectory (result, dir) {
+    preloadFilesAtPublicGateway(result)
     await browser.tabs.create({
       url: `${state.webuiRootUrl}#/files${dir}`
     })

--- a/add-on/src/lib/ipfs-import.js
+++ b/add-on/src/lib/ipfs-import.js
@@ -1,0 +1,103 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+const browser = require('webextension-polyfill')
+
+const { redirectOptOutHint } = require('./ipfs-request')
+
+function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, runtime) {
+  const ipfsImportHandler = {
+    formatImportDirectory (path) {
+      path = path.replace(/\/$|$/, '/')
+      path = path.replace(/(\/)\/+/g, '$1')
+
+      // needed to handle date symbols in the import directory
+      const now = new Date()
+      const dateSymbols = [/%Y/g, /%M/g, /%D/g, /%h/g, /%m/g, /%s/g]
+      const symbolReplacements = [now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()].map(n => String(n).padStart(2, '0'))
+      dateSymbols.forEach((symbol, i) => { path = path.replace(symbol, symbolReplacements[i]) })
+      return path
+    },
+    // TODO: feature detect and push to client type specific modules.
+    getIpfsPathAndNativeAddress (hash) {
+      const state = getState()
+      const path = `/ipfs/${hash}`
+      if (runtime.hasNativeProtocolHandler) {
+        return { path, url: `ipfs://${hash}` }
+      } else {
+        // open at public GW (will be redirected to local elsewhere, if enabled)
+        const url = new URL(path, state.pubGwURLString).toString()
+        return { path, url: url }
+      }
+    },
+    async openFilesAtGateway ({ result, openRootInNewTab = false }) {
+      for (const file of result) {
+        if (file && file.hash) {
+          const { url } = this.getIpfsPathAndNativeAddress(file.hash)
+          if (openRootInNewTab && (result.length === 1 || file.path === '' || file.path === file.hash)) {
+            await browser.tabs.create({
+              url: url
+            })
+          }
+        }
+      }
+      return result
+    },
+    async openFilesAtWebUI (dir) {
+      const state = getState()
+      await browser.tabs.create({
+        url: `${state.webuiRootUrl}#/files${dir}`
+      })
+    },
+    async importFiles (data, options, importDir) {
+      const ipfs = getIpfs()
+      // files are first `add`ed to IPFS
+      // and then copied to an MFS directory
+      // to ensure that CIDs for any created file
+      // remain the same for ipfs-companion and Web UI
+      const result = await ipfs.add(data, options)
+      // cp will fail if directory does not exist
+      await ipfs.files.mkdir(`${importDir}`, { parents: true })
+      // remove directory from files API import files
+      let files = result.filter(file => (file.path !== ''))
+      files = files.map(file => (ipfs.files.cp(`/ipfs/${file.hash}`, `${importDir}${file.path}`)))
+      await Promise.all(files)
+
+      return result
+    },
+    preloadAtPublicGateway (path) {
+      const state = getState()
+      if (!state.preloadAtPublicGateway) return
+      // asynchronous HTTP HEAD request preloads triggers content without downloading it
+      return new Promise((resolve, reject) => {
+        const http = new XMLHttpRequest()
+        // Make sure preload request is excluded from global redirect
+        const preloadUrl = ipfsPathValidator.resolveToPublicUrl(`${path}#${redirectOptOutHint}`, state.pubGwURLString)
+        http.open('HEAD', preloadUrl)
+        http.onreadystatechange = function () {
+          if (this.readyState === this.DONE) {
+            console.info(`[ipfs-companion] preloadAtPublicGateway(${path}):`, this.statusText)
+            if (this.status === 200) {
+              resolve(this.statusText)
+            } else {
+              reject(new Error(this.statusText))
+            }
+          }
+        }
+        http.send()
+      })
+    },
+    preloadFilesAtPublicGateway (files) {
+      files.forEach(file => {
+        if (file && file.hash) {
+          const { path } = this.getIpfsPathAndNativeAddress(file.hash)
+          this.preloadAtPublicGateway(path)
+          console.info('[ipfs-companion] successfully stored', file)
+        }
+      })
+    }
+  }
+  return ipfsImportHandler
+}
+
+module.exports = createIpfsImportHandler

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -26,7 +26,8 @@ exports.optionDefaults = Object.freeze({
   ipfsApiUrl: buildIpfsApiUrl(),
   ipfsApiPollMs: 3000,
   ipfsProxy: true, // window.ipfs
-  logNamespaces: 'jsipfs*,ipfs*,libp2p:mdns*,libp2p-delegated*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*,-ipfs:http-api*'
+  logNamespaces: 'jsipfs*,ipfs*,libp2p:mdns*,libp2p-delegated*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*,-ipfs:http-api*',
+  uploadDir: '/ipfs-companion-imports/'
 })
 
 function buildCustomGatewayUrl () {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -27,7 +27,8 @@ exports.optionDefaults = Object.freeze({
   ipfsApiPollMs: 3000,
   ipfsProxy: true, // window.ipfs
   logNamespaces: 'jsipfs*,ipfs*,libp2p:mdns*,libp2p-delegated*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*,-ipfs:http-api*',
-  importDir: '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/'
+  importDir: '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/',
+  openViaWebUI: true
 })
 
 function buildCustomGatewayUrl () {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -27,7 +27,7 @@ exports.optionDefaults = Object.freeze({
   ipfsApiPollMs: 3000,
   ipfsProxy: true, // window.ipfs
   logNamespaces: 'jsipfs*,ipfs*,libp2p:mdns*,libp2p-delegated*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*,-ipfs:http-api*',
-  uploadDir: '/ipfs-companion-imports/'
+  uploadDir: '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/'
 })
 
 function buildCustomGatewayUrl () {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -27,7 +27,7 @@ exports.optionDefaults = Object.freeze({
   ipfsApiPollMs: 3000,
   ipfsProxy: true, // window.ipfs
   logNamespaces: 'jsipfs*,ipfs*,libp2p:mdns*,libp2p-delegated*,-*:ipns*,-ipfs:preload*,-ipfs-http-client:request*,-ipfs:http-api*',
-  uploadDir: '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/'
+  importDir: '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/'
 })
 
 function buildCustomGatewayUrl () {

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -7,7 +7,6 @@ const switchToggle = require('../../pages/components/switch-toggle')
 
 function experimentsForm ({
   displayNotifications,
-  preloadAtPublicGateway,
   catchUnhandledProtocols,
   linkify,
   dnslinkPolicy,
@@ -19,7 +18,6 @@ function experimentsForm ({
   onOptionsReset
 }) {
   const onDisplayNotificationsChange = onOptionChange('displayNotifications')
-  const onPreloadAtPublicGatewayChange = onOptionChange('preloadAtPublicGateway')
   const onCatchUnhandledProtocolsChange = onOptionChange('catchUnhandledProtocols')
   const onLinkifyChange = onOptionChange('linkify')
   const onDnslinkPolicyChange = onOptionChange('dnslinkPolicy')
@@ -40,15 +38,6 @@ function experimentsForm ({
             </dl>
           </label>
           <div>${switchToggle({ id: 'displayNotifications', checked: displayNotifications, onchange: onDisplayNotificationsChange })}</div>
-        </div>
-        <div>
-          <label for="preloadAtPublicGateway">
-            <dl>
-              <dt>${browser.i18n.getMessage('option_preloadAtPublicGateway_title')}</dt>
-              <dd>${browser.i18n.getMessage('option_preloadAtPublicGateway_description')}</dd>
-            </dl>
-          </label>
-          <div>${switchToggle({ id: 'preloadAtPublicGateway', checked: preloadAtPublicGateway, onchange: onPreloadAtPublicGatewayChange })}</div>
         </div>
         <div>
           <label for="catchUnhandledProtocols">

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -15,7 +15,7 @@ function experimentsForm ({
   detectIpfsPathHeader,
   ipfsProxy,
   logNamespaces,
-  uploadDir,
+  importDir,
   onOptionChange,
   onOptionsReset
 }) {
@@ -155,11 +155,11 @@ function experimentsForm ({
             value=${logNamespaces} />
         </div>
         <div>
-          <label for="uploadDir">
+          <label for="importDir">
             <dl>
-              <dt>${browser.i18n.getMessage('option_uploadDir_title')}</dt>
+              <dt>${browser.i18n.getMessage('option_importDir_title')}</dt>
               <dd>
-                ${browser.i18n.getMessage('option_uploadDir_description')}
+                ${browser.i18n.getMessage('option_importDir_description')}
                 <p><a href="https://docs.ipfs.io/guides/concepts/mfs/" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
@@ -167,12 +167,12 @@ function experimentsForm ({
             </dl>
           </label>
           <input
-            id="uploadDir"
+            id="importDir"
             type="text"
             pattern="^\/(.*)"
             required
-            onchange=${onOptionChange('uploadDir')}
-            value=${uploadDir} />
+            onchange=${onOptionChange('importDir')}
+            value=${importDir} />
         </div>
         <div>
           <label for="resetAllOptions">

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -15,6 +15,7 @@ function experimentsForm ({
   detectIpfsPathHeader,
   ipfsProxy,
   logNamespaces,
+  uploadDir,
   onOptionChange,
   onOptionsReset
 }) {
@@ -152,6 +153,26 @@ function experimentsForm ({
             required
             onchange=${onOptionChange('logNamespaces')}
             value=${logNamespaces} />
+        </div>
+        <div>
+          <label for="uploadDir">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_uploadDir_title')}</dt>
+              <dd>
+                ${browser.i18n.getMessage('option_uploadDir_description')}
+                <p><a href="https://docs.ipfs.io/guides/concepts/mfs/" target="_blank">
+                  ${browser.i18n.getMessage('option_legend_readMore')}
+                </a></p>
+              </dd>
+            </dl>
+          </label>
+          <input
+            id="uploadDir"
+            type="text"
+            pattern="^\/(.*)"
+            required
+            onchange=${onOptionChange('uploadDir')}
+            value=${uploadDir} />
         </div>
         <div>
           <label for="resetAllOptions">

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -15,7 +15,6 @@ function experimentsForm ({
   detectIpfsPathHeader,
   ipfsProxy,
   logNamespaces,
-  importDir,
   onOptionChange,
   onOptionsReset
 }) {
@@ -153,26 +152,6 @@ function experimentsForm ({
             required
             onchange=${onOptionChange('logNamespaces')}
             value=${logNamespaces} />
-        </div>
-        <div>
-          <label for="importDir">
-            <dl>
-              <dt>${browser.i18n.getMessage('option_importDir_title')}</dt>
-              <dd>
-                ${browser.i18n.getMessage('option_importDir_description')}
-                <p><a href="https://docs.ipfs.io/guides/concepts/mfs/" target="_blank">
-                  ${browser.i18n.getMessage('option_legend_readMore')}
-                </a></p>
-              </dd>
-            </dl>
-          </label>
-          <input
-            id="importDir"
-            type="text"
-            pattern="^\/(.*)"
-            required
-            onchange=${onOptionChange('importDir')}
-            value=${importDir} />
         </div>
         <div>
           <label for="resetAllOptions">

--- a/add-on/src/options/forms/file-import-form.js
+++ b/add-on/src/options/forms/file-import-form.js
@@ -1,0 +1,38 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+const browser = require('webextension-polyfill')
+const html = require('choo/html')
+
+function fileImportForm ({ importDir, onOptionChange }) {
+  const onImportDirChange = onOptionChange('importDir')
+  return html`
+    <form>
+      <fieldset>
+        <legend>${browser.i18n.getMessage('option_header_fileImport')}</legend>
+        <div>
+          <label for="importDir">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_importDir_title')}</dt>
+              <dd>
+                ${browser.i18n.getMessage('option_importDir_description')}
+                <p><a href="https://docs.ipfs.io/guides/concepts/mfs/" target="_blank">
+                  ${browser.i18n.getMessage('option_legend_readMore')}
+                </a></p>
+              </dd>
+            </dl>
+          </label>
+          <input
+            id="importDir"
+            type="text"
+            pattern="^\/(.*)"
+            required
+            onchange=${onImportDirChange}
+            value=${importDir} />
+        </div>
+      </fieldset>
+    </form>
+  `
+}
+
+module.exports = fileImportForm

--- a/add-on/src/options/forms/file-import-form.js
+++ b/add-on/src/options/forms/file-import-form.js
@@ -5,8 +5,9 @@ const browser = require('webextension-polyfill')
 const html = require('choo/html')
 const switchToggle = require('../../pages/components/switch-toggle')
 
-function fileImportForm ({ importDir, preloadAtPublicGateway, onOptionChange }) {
+function fileImportForm ({ importDir, openViaWebUI, preloadAtPublicGateway, onOptionChange }) {
   const onImportDirChange = onOptionChange('importDir')
+  const onOpenViaWebUIChange = onOptionChange('openViaWebUI')
   const onPreloadAtPublicGatewayChange = onOptionChange('preloadAtPublicGateway')
   return html`
     <form>
@@ -31,6 +32,15 @@ function fileImportForm ({ importDir, preloadAtPublicGateway, onOptionChange }) 
             required
             onchange=${onImportDirChange}
             value=${importDir} />
+        </div>
+        <div>
+          <label for="openViaWebUI">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_openViaWebUI_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_openViaWebUI_description')}</dd>
+            </dl>
+          </label>
+          <div>${switchToggle({ id: 'openViaWebUI', checked: openViaWebUI, onchange: onOpenViaWebUIChange })}</div>
         </div>
         <div>
           <label for="preloadAtPublicGateway">

--- a/add-on/src/options/forms/file-import-form.js
+++ b/add-on/src/options/forms/file-import-form.js
@@ -3,9 +3,11 @@
 
 const browser = require('webextension-polyfill')
 const html = require('choo/html')
+const switchToggle = require('../../pages/components/switch-toggle')
 
-function fileImportForm ({ importDir, onOptionChange }) {
+function fileImportForm ({ importDir, preloadAtPublicGateway, onOptionChange }) {
   const onImportDirChange = onOptionChange('importDir')
+  const onPreloadAtPublicGatewayChange = onOptionChange('preloadAtPublicGateway')
   return html`
     <form>
       <fieldset>
@@ -29,6 +31,15 @@ function fileImportForm ({ importDir, onOptionChange }) {
             required
             onchange=${onImportDirChange}
             value=${importDir} />
+        </div>
+        <div>
+          <label for="preloadAtPublicGateway">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_preloadAtPublicGateway_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_preloadAtPublicGateway_description')}</dd>
+            </dl>
+          </label>
+          <div>${switchToggle({ id: 'preloadAtPublicGateway', checked: preloadAtPublicGateway, onchange: onPreloadAtPublicGatewayChange })}</div>
         </div>
       </fieldset>
     </form>

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -80,7 +80,7 @@ module.exports = function optionsPage (state, emit) {
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,
     logNamespaces: state.options.logNamespaces,
-    uploadDir: state.options.uploadDir,
+    importDir: state.options.importDir,
     onOptionChange,
     onOptionsReset
   })}

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -4,6 +4,7 @@
 const html = require('choo/html')
 const globalToggleForm = require('./forms/global-toggle-form')
 const ipfsNodeForm = require('./forms/ipfs-node-form')
+const fileImportForm = require('./forms/file-import-form')
 const gatewaysForm = require('./forms/gateways-form')
 const apiForm = require('./forms/api-form')
 const experimentsForm = require('./forms/experiments-form')
@@ -70,6 +71,10 @@ module.exports = function optionsPage (state, emit) {
     noRedirectHostnames: state.options.noRedirectHostnames,
     onOptionChange
   })}
+  ${fileImportForm({
+    importDir: state.options.importDir,
+    onOptionChange
+  })}
   ${experimentsForm({
     displayNotifications: state.options.displayNotifications,
     preloadAtPublicGateway: state.options.preloadAtPublicGateway,
@@ -80,7 +85,6 @@ module.exports = function optionsPage (state, emit) {
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,
     logNamespaces: state.options.logNamespaces,
-    importDir: state.options.importDir,
     onOptionChange,
     onOptionsReset
   })}

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -73,11 +73,11 @@ module.exports = function optionsPage (state, emit) {
   })}
   ${fileImportForm({
     importDir: state.options.importDir,
+    preloadAtPublicGateway: state.options.preloadAtPublicGateway,
     onOptionChange
   })}
   ${experimentsForm({
     displayNotifications: state.options.displayNotifications,
-    preloadAtPublicGateway: state.options.preloadAtPublicGateway,
     catchUnhandledProtocols: state.options.catchUnhandledProtocols,
     linkify: state.options.linkify,
     dnslinkPolicy: state.options.dnslinkPolicy,

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -73,6 +73,7 @@ module.exports = function optionsPage (state, emit) {
   })}
   ${fileImportForm({
     importDir: state.options.importDir,
+    openViaWebUI: state.options.openViaWebUI,
     preloadAtPublicGateway: state.options.preloadAtPublicGateway,
     onOptionChange
   })}

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -80,6 +80,7 @@ module.exports = function optionsPage (state, emit) {
     detectIpfsPathHeader: state.options.detectIpfsPathHeader,
     ipfsProxy: state.options.ipfsProxy,
     logNamespaces: state.options.logNamespaces,
+    uploadDir: state.options.uploadDir,
     onOptionChange,
     onOptionsReset
   })}

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -144,6 +144,8 @@ function formatImportDirectory (path) {
   return path
 }
 
+exports.formatImportDirectory = formatImportDirectory
+
 function files2streams (files) {
   const streams = []
   for (const file of files) {

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -184,7 +184,7 @@ function quickUploadOptions (state, emit) {
         <label for='uploadDir' class='flex items-center db relative mt1 pointer'>
           ${browser.i18n.getMessage('quickUpload_options_uploadDir')}
           <span class='mark db flex items-center relative mr2 br2'></span>
-          <input id='uploadDir' class='w-40' type='text' oninput=${onDirectoryChange} value=${state.uploadDir} />
+          <input id='uploadDir' class='w-40 bg-transparent aqua monospace br1 ba b--aqua pa2' type='text' oninput=${onDirectoryChange} value=${state.uploadDir} />
         </label>
       </div>
     `

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -22,14 +22,21 @@ function quickUploadStore (state, emitter) {
   state.ipfsNodeType = 'external'
   state.expandOptions = false
   state.openViaWebUI = true
+  state.userChangedOpenViaWebUI = false
   state.importDir = ''
   state.userChangedImportDir = false
 
-  function updateState ({ ipfsNodeType, peerCount, importDir }) {
+  function updateState ({ ipfsNodeType, peerCount, importDir, openViaWebUI }) {
     state.ipfsNodeType = ipfsNodeType
     state.peerCount = peerCount
+    // This event will fire repeatedly,
+    // we need to ensure we don't unset the user's preferences
+    // when they change the options on this page
     if (!state.userChangedImportDir) {
       state.importDir = importDir
+    }
+    if (!state.userChangedOpenViaWebUI) {
+      state.openViaWebUI = openViaWebUI
     }
   }
 
@@ -167,7 +174,7 @@ function files2streams (files) {
 function quickUploadOptions (state, emit) {
   const onExpandOptions = (e) => { state.expandOptions = true; emit('render') }
   const onDirectoryChange = (e) => { state.userChangedImportDir = true; state.importDir = e.target.value }
-  const onOpenViaWebUIChange = (e) => { state.openViaWebUI = e.target.checked }
+  const onOpenViaWebUIChange = (e) => { state.userChangedOpenViaWebUI = true; state.openViaWebUI = e.target.checked }
   const displayOpenWebUI = state.ipfsNodeType !== 'embedded'
 
   if (state.expandOptions) {

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -79,8 +79,6 @@ async function processFiles (state, emitter, files) {
     state.progress = 'Completed'
     emitter.emit('render')
     console.log(`Successfully uploaded ${streams.length} files`)
-    // function to open web UI at state.uploadDir
-    // await ipfsCompanion.uploadHandler(state.uploadDir)
     // close upload tab as it will be replaced with a new tab with uploaded content
     await browser.tabs.remove(uploadTab.id)
   } catch (err) {

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -109,7 +109,7 @@ async function processFiles (state, emitter, files) {
     if (state.ipfsNodeType === 'embedded' || !state.openViaWebUI) {
       await ipfsCompanion.uploadResultHandler({ result, openRootInNewTab: true })
     } else {
-      await ipfsCompanion.openWebUiAtDirectory(importDir)
+      await ipfsCompanion.openWebUiAtDirectory(result, importDir)
     }
     // close upload tab as it will be replaced with a new tab with uploaded content
     await browser.tabs.remove(uploadTab.id)

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -66,10 +66,11 @@ async function processFiles (state, emitter, files) {
       parents: true
     }
     state.progress = `Uploading ${streams.length} files...`
+    const uploadDir = state.uploadDir.replace(/\/$|$/, '/')
     try {
-      const files = streams.map(stream => (ipfsCompanion.ipfs.files.write(`${state.uploadDir}${stream.path}`, stream.content, options)))
+      const files = streams.map(stream => (ipfsCompanion.ipfs.files.write(`${uploadDir}${stream.path}`, stream.content, options)))
       await Promise.all(files)
-      await ipfsCompanion.openWebUiAtDirectory(state.uploadDir)
+      await ipfsCompanion.openWebUiAtDirectory(uploadDir)
     } catch (err) {
       console.error('Failed to upload files to IPFS', err)
       ipfsCompanion.notify('notify_uploadErrorTitle', 'notify_inlineErrorMsg', `${err.message}`)

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -21,7 +21,7 @@ function quickUploadStore (state, emitter) {
   state.peerCount = ''
   state.ipfsNodeType = 'external'
   state.expandOptions = false
-  state.uploadDir = '/ipfs-companion-uploads/'
+  state.uploadDir = '/ipfs-companion-imports/'
 
   function updateState ({ ipfsNodeType, peerCount }) {
     state.ipfsNodeType = ipfsNodeType
@@ -65,28 +65,28 @@ async function processFiles (state, emitter, files) {
       create: true,
       parents: true
     }
-    state.progress = `Uploading ${streams.length} files...`
+    state.progress = `Importing ${streams.length} files...`
     const uploadDir = state.uploadDir.replace(/\/$|$/, '/')
     try {
       const files = streams.map(stream => (ipfsCompanion.ipfs.files.write(`${uploadDir}${stream.path}`, stream.content, options)))
       await Promise.all(files)
     } catch (err) {
-      console.error('Failed to upload files to IPFS', err)
+      console.error('Failed to import files to IPFS', err)
       ipfsCompanion.notify('notify_uploadErrorTitle', 'notify_inlineErrorMsg', `${err.message}`)
       throw err
     }
     state.progress = 'Completed'
     emitter.emit('render')
-    console.log(`Successfully uploaded ${streams.length} files`)
+    console.log(`Successfully imported ${streams.length} files`)
 
     // open web UI at proper directory
     await ipfsCompanion.openWebUiAtDirectory(uploadDir)
     // close upload tab as it will be replaced with a new tab with uploaded content
     await browser.tabs.remove(uploadTab.id)
   } catch (err) {
-    console.error('Unable to perform quick upload', err)
+    console.error('Unable to perform import', err)
     // keep upload tab and display error message in it
-    state.message = 'Unable to upload to IPFS API:'
+    state.message = 'Unable to import to IPFS:'
     state.progress = `${err}`
     emitter.emit('render')
   }

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -21,7 +21,6 @@ function quickUploadStore (state, emitter) {
   state.peerCount = ''
   state.ipfsNodeType = 'external'
   state.expandOptions = false
-  state.wrapWithDirectory = true
   state.openViaWebUI = true
   state.uploadDir = ''
   state.userChangedUploadDir = false
@@ -67,7 +66,7 @@ async function processFiles (state, emitter, files) {
     const uploadTab = await browser.tabs.getCurrent()
     const streams = files2streams(files)
     emitter.emit('render')
-    const wrapFlag = (state.wrapWithDirectory || streams.length > 1)
+    const wrapFlag = streams.length > 1
     const options = {
       wrapWithDirectory: wrapFlag
     }
@@ -138,7 +137,7 @@ function formatUploadDirectory (path) {
   // needed to handle date symbols in the import directory
   const now = new Date()
   const dateSymbols = [/%Y/g, /%M/g, /%D/g, /%h/g, /%m/g, /%s/g]
-  const symbolReplacements = [now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()].map(n => String(n).padStart(2, "0"))
+  const symbolReplacements = [now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()].map(n => String(n).padStart(2, '0'))
   dateSymbols.forEach((symbol, i) => { path = path.replace(symbol, symbolReplacements[i]) })
   return path
 }
@@ -163,7 +162,6 @@ function files2streams (files) {
 
 function quickUploadOptions (state, emit) {
   const onExpandOptions = (e) => { state.expandOptions = true; emit('render') }
-  const onWrapWithDirectoryChange = (e) => { state.wrapWithDirectory = e.target.checked }
   const onDirectoryChange = (e) => { state.userChangedUploadDir = true; state.uploadDir = e.target.value }
   const onOpenViaWebUIChange = (e) => { state.openViaWebUI = e.target.checked }
   const displayOpenWebUI = state.ipfsNodeType !== 'embedded'
@@ -171,11 +169,6 @@ function quickUploadOptions (state, emit) {
   if (state.expandOptions) {
     return html`
       <div id='quickUploadOptions' class='sans-serif mt3 f6 lh-copy light-gray no-user-select'>
-        <label for='wrapWithDirectory' class='flex items-center db relative mt1 pointer'>
-          <input id='wrapWithDirectory' type='checkbox' onchange=${onWrapWithDirectoryChange} checked=${state.wrapWithDirectory} />
-          <span class='mark db flex items-center relative mr2 br2'></span>
-          ${browser.i18n.getMessage('quickUpload_options_wrapWithDirectory')}
-        </label>
         ${displayOpenWebUI ? html`<label for='openViaWebUI' class='flex items-center db relative mt1 pointer'>
           <input id='openViaWebUI' type='checkbox' onchange=${onOpenViaWebUIChange} checked=${state.openViaWebUI} />
           <span class='mark db flex items-center relative mr2 br2'></span>

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -21,11 +21,12 @@ function quickUploadStore (state, emitter) {
   state.peerCount = ''
   state.ipfsNodeType = 'external'
   state.expandOptions = false
-  state.uploadDir = '/ipfs-companion-imports/'
+  state.uploadDir = ''
 
-  function updateState ({ ipfsNodeType, peerCount }) {
+  function updateState ({ ipfsNodeType, peerCount, uploadDir }) {
     state.ipfsNodeType = ipfsNodeType
     state.peerCount = peerCount
+    state.uploadDir = uploadDir
   }
 
   let port
@@ -120,27 +121,6 @@ function files2streams (files) {
   return streams
 }
 
-function quickUploadOptions (state, emit) {
-  const onExpandOptions = (e) => { state.expandOptions = true; emit('render') }
-  const onDirectoryChange = (e) => { state.uploadDir = e.target.value }
-  if (state.expandOptions) {
-    return html`
-      <div id='quickUploadOptions' class='sans-serif mt3 f6 lh-copy light-gray no-user-select'>
-        <label for='uploadDir' class='flex items-center db relative mt1 pointer'>
-          ${browser.i18n.getMessage('quickUpload_options_uploadDir')}
-          <span class='mark db flex items-center relative mr2 br2'></span>
-          <input id='uploadDir' type='text' oninput=${onDirectoryChange} value=${state.uploadDir} />
-        </label>
-      </div>
-    `
-  }
-  return html`
-    <button class='mt3 f6 lh-copy link bn bg-transparent moon-gray dib pa0 pointer' style='color: #6ACAD1' onclick=${onExpandOptions}>
-      ${browser.i18n.getMessage('quickUpload_options_show')} »
-    </button>
-  `
-}
-
 function quickUploadPage (state, emit) {
   const onFileInputChange = (e) => emit('fileInputChange', e)
   const { peerCount } = state
@@ -180,7 +160,6 @@ function quickUploadPage (state, emit) {
             </div>
           </div>
         </label>
-        ${quickUploadOptions(state, emit)}
       </div>
     </div>
   `

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -70,7 +70,6 @@ async function processFiles (state, emitter, files) {
     try {
       const files = streams.map(stream => (ipfsCompanion.ipfs.files.write(`${uploadDir}${stream.path}`, stream.content, options)))
       await Promise.all(files)
-      await ipfsCompanion.openWebUiAtDirectory(uploadDir)
     } catch (err) {
       console.error('Failed to upload files to IPFS', err)
       ipfsCompanion.notify('notify_uploadErrorTitle', 'notify_inlineErrorMsg', `${err.message}`)
@@ -79,6 +78,9 @@ async function processFiles (state, emitter, files) {
     state.progress = 'Completed'
     emitter.emit('render')
     console.log(`Successfully uploaded ${streams.length} files`)
+
+    // open web UI at proper directory
+    await ipfsCompanion.openWebUiAtDirectory(uploadDir)
     // close upload tab as it will be replaced with a new tab with uploaded content
     await browser.tabs.remove(uploadTab.id)
   } catch (err) {

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -134,6 +134,8 @@ function file2buffer (file) {
 
 function formatImportDirectory (path) {
   path = path.replace(/\/$|$/, '/')
+  path = path.replace(/(\/)\/+/g, '$1')
+
   // needed to handle date symbols in the import directory
   const now = new Date()
   const dateSymbols = [/%Y/g, /%M/g, /%D/g, /%h/g, /%m/g, /%s/g]

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -159,14 +159,16 @@ function quickUploadOptions (state, emit) {
   const onExpandOptions = (e) => { state.expandOptions = true; emit('render') }
   const onDirectoryChange = (e) => { state.userChangedUploadDir = true; state.uploadDir = e.target.value }
   const onOpenViaWebUIChange = (e) => { state.openViaWebUI = e.target.checked }
+  const displayOpenWebUI = state.ipfsNodeType !== 'embedded'
+
   if (state.expandOptions) {
     return html`
       <div id='quickUploadOptions' class='sans-serif mt3 f6 lh-copy light-gray no-user-select'>
-        <label for='openViaWebUI' class='flex items-center db relative mt1 pointer'>
+        ${displayOpenWebUI ? html`<label for='openViaWebUI' class='flex items-center db relative mt1 pointer'>
           <input id='openViaWebUI' type='checkbox' onchange=${onOpenViaWebUIChange} checked=${state.openViaWebUI} />
           <span class='mark db flex items-center relative mr2 br2'></span>
           ${browser.i18n.getMessage('quickUpload_options_openViaWebUI')}
-        </label>
+        </label>` : null}
         <label for='uploadDir' class='flex items-center db relative mt1 pointer'>
           ${browser.i18n.getMessage('quickUpload_options_uploadDir')}
           <span class='mark db flex items-center relative mr2 br2'></span>

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -91,8 +91,9 @@ async function processFiles (state, emitter, files) {
 
       // cp will fail if directory does not exist
       await ipfsCompanion.ipfs.files.mkdir(`${uploadDir}`, { parents: true })
-
-      const files = result.map(result => (ipfsCompanion.ipfs.files.cp(`/ipfs/${result.hash}`, `${uploadDir}${result.path}`)))
+      // remove directory from files API import files
+      let files = result.filter(file => (file.path !== ''))
+      files = files.map(file => (ipfsCompanion.ipfs.files.cp(`/ipfs/${file.hash}`, `${uploadDir}${file.path}`)))
       await Promise.all(files)
     } catch (err) {
       console.error('Failed to import files to IPFS', err)

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -75,7 +75,8 @@ async function processFiles (state, emitter, files) {
     emitter.emit('render')
     const wrapFlag = streams.length > 1
     const options = {
-      wrapWithDirectory: wrapFlag
+      wrapWithDirectory: wrapFlag,
+      pin: false // we use MFS for implicit pinning instead
     }
     state.progress = `Importing ${streams.length} files...`
     const importDir = formatImportDirectory(state.importDir)

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -138,7 +138,7 @@ function formatUploadDirectory (path) {
   // needed to handle date symbols in the import directory
   const now = new Date()
   const dateSymbols = [/%Y/g, /%M/g, /%D/g, /%h/g, /%m/g, /%s/g]
-  const symbolReplacements = [now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()]
+  const symbolReplacements = [now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()].map(n => String(n).padStart(2, "0"))
   dateSymbols.forEach((symbol, i) => { path = path.replace(symbol, symbolReplacements[i]) })
   return path
 }

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -22,14 +22,14 @@ function quickUploadStore (state, emitter) {
   state.ipfsNodeType = 'external'
   state.expandOptions = false
   state.openViaWebUI = true
-  state.uploadDir = ''
-  state.userChangedUploadDir = false
+  state.importDir = ''
+  state.userChangedImportDir = false
 
-  function updateState ({ ipfsNodeType, peerCount, uploadDir }) {
+  function updateState ({ ipfsNodeType, peerCount, importDir }) {
     state.ipfsNodeType = ipfsNodeType
     state.peerCount = peerCount
-    if (!state.userChangedUploadDir) {
-      state.uploadDir = uploadDir
+    if (!state.userChangedImportDir) {
+      state.importDir = importDir
     }
   }
 
@@ -71,7 +71,7 @@ async function processFiles (state, emitter, files) {
       wrapWithDirectory: wrapFlag
     }
     state.progress = `Importing ${streams.length} files...`
-    const uploadDir = formatUploadDirectory(state.uploadDir)
+    const importDir = formatImportDirectory(state.importDir)
     let result
     try {
       // files are first `add`ed to IPFS
@@ -89,10 +89,10 @@ async function processFiles (state, emitter, files) {
       }
 
       // cp will fail if directory does not exist
-      await ipfsCompanion.ipfs.files.mkdir(`${uploadDir}`, { parents: true })
+      await ipfsCompanion.ipfs.files.mkdir(`${importDir}`, { parents: true })
       // remove directory from files API import files
       let files = result.filter(file => (file.path !== ''))
-      files = files.map(file => (ipfsCompanion.ipfs.files.cp(`/ipfs/${file.hash}`, `${uploadDir}${file.path}`)))
+      files = files.map(file => (ipfsCompanion.ipfs.files.cp(`/ipfs/${file.hash}`, `${importDir}${file.path}`)))
       await Promise.all(files)
     } catch (err) {
       console.error('Failed to import files to IPFS', err)
@@ -109,7 +109,7 @@ async function processFiles (state, emitter, files) {
     if (state.ipfsNodeType === 'embedded' || !state.openViaWebUI) {
       await ipfsCompanion.uploadResultHandler({ result, openRootInNewTab: true })
     } else {
-      await ipfsCompanion.openWebUiAtDirectory(uploadDir)
+      await ipfsCompanion.openWebUiAtDirectory(importDir)
     }
     // close upload tab as it will be replaced with a new tab with uploaded content
     await browser.tabs.remove(uploadTab.id)
@@ -132,7 +132,7 @@ function file2buffer (file) {
   })
 } */
 
-function formatUploadDirectory (path) {
+function formatImportDirectory (path) {
   path = path.replace(/\/$|$/, '/')
   // needed to handle date symbols in the import directory
   const now = new Date()
@@ -162,7 +162,7 @@ function files2streams (files) {
 
 function quickUploadOptions (state, emit) {
   const onExpandOptions = (e) => { state.expandOptions = true; emit('render') }
-  const onDirectoryChange = (e) => { state.userChangedUploadDir = true; state.uploadDir = e.target.value }
+  const onDirectoryChange = (e) => { state.userChangedImportDir = true; state.importDir = e.target.value }
   const onOpenViaWebUIChange = (e) => { state.openViaWebUI = e.target.checked }
   const displayOpenWebUI = state.ipfsNodeType !== 'embedded'
 
@@ -174,10 +174,10 @@ function quickUploadOptions (state, emit) {
           <span class='mark db flex items-center relative mr2 br2'></span>
           ${browser.i18n.getMessage('quickUpload_options_openViaWebUI')}
         </label>` : null}
-        <label for='uploadDir' class='flex items-center db relative mt1 pointer'>
-          ${browser.i18n.getMessage('quickUpload_options_uploadDir')}
+        <label for='importDir' class='flex items-center db relative mt1 pointer'>
+          ${browser.i18n.getMessage('quickUpload_options_importDir')}
           <span class='mark db flex items-center relative mr2 br2'></span>
-          <input id='uploadDir' class='w-40 bg-transparent aqua monospace br1 ba b--aqua pa2' type='text' oninput=${onDirectoryChange} value=${state.uploadDir} />
+          <input id='importDir' class='w-40 bg-transparent aqua monospace br1 ba b--aqua pa2' type='text' oninput=${onDirectoryChange} value=${state.importDir} />
         </label>
       </div>
     `

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -63,7 +63,7 @@ async function processFiles (state, emitter, files) {
     const streams = files2streams(files)
     emitter.emit('render')
     state.progress = `Importing ${streams.length} files...`
-    const uploadDir = state.uploadDir.replace(/\/$|$/, '/')
+    const uploadDir = formatUploadDirectory(state.uploadDir)
     let result
     try {
       // files are first `add`ed to IPFS
@@ -122,6 +122,16 @@ function file2buffer (file) {
     reader.readAsArrayBuffer(file)
   })
 } */
+
+function formatUploadDirectory (path) {
+  path = path.replace(/\/$|$/, '/')
+  // needed to handle date symbols in the import directory
+  const now = new Date()
+  const dateSymbols = [/%Y/g, /%M/g, /%D/g, /%h/g, /%m/g, /%s/g]
+  const symbolReplacements = [now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()]
+  dateSymbols.forEach((symbol, i) => { path = path.replace(symbol, symbolReplacements[i]) })
+  return path
+}
 
 function files2streams (files) {
   const streams = []

--- a/test/functional/lib/ipfs-import.test.js
+++ b/test/functional/lib/ipfs-import.test.js
@@ -5,21 +5,31 @@ const { useFakeTimers } = require('sinon')
 const browser = require('sinon-chrome')
 
 describe('quick-upload.js', function () {
-  let formatImportDirectory
+  let createIpfsImportHandler
+  let ipfsImportHandler
   let clock
+
   before(function () {
     global.document = {}
     global.browser = browser
-    // quick-upload depends on webextension/polyfill which can't be imported
+    // ipfs-import depends on webextension/polyfill which can't be imported
     // in a non-browser environment unless global.browser is stubbed
-    formatImportDirectory = require('../../../add-on/src/popup/quick-upload').formatImportDirectory
     // need to force Date to return a particular date
+    createIpfsImportHandler = require('../../../add-on/src/lib/ipfs-import')
+
     clock = useFakeTimers({
       now: new Date(2017, 10, 5, 12, 1, 1)
     })
   })
 
   describe('formatImportDirectory', function () {
+    let formatImportDirectory
+
+    before(function () {
+      ipfsImportHandler = createIpfsImportHandler(() => {}, {}, {}, {})
+      formatImportDirectory = ipfsImportHandler.formatImportDirectory
+    })
+
     it('should change nothing if path is properly formatted and date wildcards are not provided', function () {
       const path = '/ipfs-companion-imports/my-directory/'
       expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/my-directory/')
@@ -45,6 +55,15 @@ describe('quick-upload.js', function () {
       expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/2017-11-05_120101/')
     })
   })
+  // TODO: complete tests
+  // describe('openFilesAtWebUI', function () {
+  // })
+  //
+  // describe('openFilesAtGateway', function () {
+  // })
+  //
+  // describe('importFiles', function () {
+  // })
 
   after(function () {
     clock.restore()

--- a/test/functional/lib/quick-upload.test.js
+++ b/test/functional/lib/quick-upload.test.js
@@ -1,0 +1,55 @@
+'use strict'
+const { describe, it, before, after } = require('mocha')
+const { expect } = require('chai')
+const { useFakeTimers } = require('sinon')
+const browser = require('sinon-chrome')
+
+describe('quick-upload.js', function () {
+  let formatImportDirectory
+  let clock
+  before(function () {
+    global.document = {}
+    global.browser = browser
+    // quick-upload depends on webextension/polyfill which can't be imported
+    // in a non-browser environment unless global.browser is stubbed
+    formatImportDirectory = require('../../../add-on/src/popup/quick-upload').formatImportDirectory
+    // need to force Date to return a particular date
+    clock = useFakeTimers({
+      now: new Date(2017, 10, 5, 12, 1, 1)
+    })
+  })
+
+  describe('formatImportDirectory', function () {
+    it('should change nothing if path is properly formatted and date wildcards are not provided', function () {
+      const path = '/ipfs-companion-imports/my-directory/'
+      expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/my-directory/')
+    })
+
+    it('should replace two successive slashes with a single slash', function () {
+      const path = '/ipfs-companion-imports//my-directory/'
+      expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/my-directory/')
+    })
+
+    it('should replace multiple slashes with a single slash', function () {
+      const path = '/ipfs-companion-imports/////////my-directory/'
+      expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/my-directory/')
+    })
+
+    it('should add trailing slash if not present', function () {
+      const path = '/ipfs-companion-imports/my-directory'
+      expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/my-directory/')
+    })
+
+    it('should replace date wildcards with padded dates', function () {
+      const path = '/ipfs-companion-imports/%Y-%M-%D_%h%m%s/'
+      expect(formatImportDirectory(path)).to.equal('/ipfs-companion-imports/2017-11-05_120101/')
+    })
+  })
+
+  after(function () {
+    clock.restore()
+    delete global.document
+    delete global.browser
+    browser.flush()
+  })
+})


### PR DESCRIPTION
This PR changes the upload target from `ipfs add` to MFS. Currently, it uses the default directory `ipfs-companion-uploads` with the user option to change this on the upload page. On successful upload, it will open the Web UI, at the directory used for the upload. 

closes #415 and closes #635