### PR TITLE
fix: restore ESR compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "firefox": 69,
+          "firefox": 68,
           "chrome": 72
         }
       }

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "ipfs-firefox-addon@lidel.org",
-      "strict_min_version": "69.0"
+      "strict_min_version": "68.0"
     }
   },
   "page_action": {

--- a/add-on/src/lib/runtime-checks.js
+++ b/add-on/src/lib/runtime-checks.js
@@ -6,7 +6,7 @@ function getBrowserInfo (browser) {
   if (browser && browser.runtime && browser.runtime.getBrowserInfo) {
     return browser.runtime.getBrowserInfo()
   }
-  return Promise.resolve()
+  return Promise.resolve({})
 }
 
 function getPlatformInfo (browser) {
@@ -28,21 +28,20 @@ function hasChromeSocketsForTcp () {
 
 async function createRuntimeChecks (browser) {
   // browser
-  const browserInfo = await getBrowserInfo(browser)
-  const runtimeBrowserName = browserInfo ? browserInfo.name : 'unknown'
-  const runtimeIsFirefox = !!(runtimeBrowserName.includes('Firefox') || runtimeBrowserName.includes('Fennec'))
-  const runtimeHasNativeProtocol = !!(browser && browser.protocol && browser.protocol.registerStringProtocol)
+  const { name, version } = await getBrowserInfo(browser)
+  const isFirefox = name && (name.includes('Firefox') || name.includes('Fennec'))
+  const hasNativeProtocolHandler = !!(browser && browser.protocol && browser.protocol.registerStringProtocol)
   // platform
   const platformInfo = await getPlatformInfo(browser)
-  const runtimeIsAndroid = platformInfo ? platformInfo.os === 'android' : false
-  const runtimeHasSocketsForTcp = hasChromeSocketsForTcp()
+  const isAndroid = platformInfo ? platformInfo.os === 'android' : false
   return Object.freeze({
     browser,
-    isFirefox: runtimeIsFirefox,
-    isAndroid: runtimeIsAndroid,
-    isBrave: runtimeHasSocketsForTcp, // TODO: make it more robust
-    hasChromeSocketsForTcp: runtimeHasSocketsForTcp,
-    hasNativeProtocolHandler: runtimeHasNativeProtocol
+    isFirefox,
+    isAndroid,
+    isBrave: hasChromeSocketsForTcp(), // TODO: make it more robust
+    requiresXHRCORSfix: !!(isFirefox && version && version.startsWith('68')),
+    hasChromeSocketsForTcp: hasChromeSocketsForTcp(),
+    hasNativeProtocolHandler
   })
 }
 

--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -160,6 +160,36 @@ describe('modifyRequest.onBeforeRequest:', function () {
         expect(modifyRequest.onBeforeRequest(xhrRequest).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
       })
     })
+    describe('with external node when runtime.requiresXHRCORSfix', function () {
+      beforeEach(function () {
+        state.ipfsNodeType = 'external'
+        browser.runtime.getBrowserInfo = () => Promise.resolve({ name: 'Firefox', version: '68.0.0' })
+      })
+      it('should be served from custom gateway if fetched from the same origin and redirect is enabled in Firefox', function () {
+        runtime.isFirefox = true
+        const xhrRequest = { url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', originUrl: 'https://google.com/' }
+        expect(modifyRequest.onBeforeRequest(xhrRequest).redirectUrl).to.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+      it('should be served from custom gateway if fetched from the same origin and redirect is enabled in non-Firefox', function () {
+        runtime.isFirefox = false
+        const xhrRequest = { url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', initiator: 'https://google.com/' }
+        expect(modifyRequest.onBeforeRequest(xhrRequest).redirectUrl).to.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+      it('should be served from custom gateway if XHR is cross-origin and redirect is enabled in non-Firefox', function () {
+        runtime.isFirefox = false
+        const xhrRequest = { url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', initiator: 'https://www.nasa.gov/foo.html', requestId: fakeRequestId() }
+        expect(modifyRequest.onBeforeRequest(xhrRequest).redirectUrl).to.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+      it('should be served from custom gateway via late redirect in onHeadersReceived if XHR is cross-origin and redirect is enabled in Firefox', function () {
+        // Context for CORS XHR problems in Firefox: https://github.com/ipfs-shipyard/ipfs-companion/issues/436
+        runtime.isFirefox = true
+        const xhrRequest = { url: 'https://google.com/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest', type: 'xmlhttprequest', originUrl: 'https://www.nasa.gov/foo.html', requestId: fakeRequestId() }
+        // onBeforeRequest should not change anything, as it will trigger false-positive CORS error
+        expect(modifyRequest.onBeforeRequest(xhrRequest)).to.equal(undefined)
+        // onHeadersReceived is after CORS validation happens, so its ok to cancel and redirect late
+        expect(modifyRequest.onHeadersReceived(xhrRequest).redirectUrl).to.equal('http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      })
+    })
   })
 
   describe('request for a path matching /ipns/{path}', function () {


### PR DESCRIPTION
This PR:

- changes minimal Firefox version to 68 (current [ESR](https://support.mozilla.org/en-US/kb/choosing-firefox-update-channel))
- restores CORS workaround when runtime is Firefox <69 (removed in https://github.com/ipfs-shipyard/ipfs-companion/pull/771)

### Motivation

This makes Companion once again compatible with Firefox ESR and Fennec-based Firefox for Android.

### How to test :notes: 

A way to test this is to open Firefox 68 (ESR) and go to https://audius.co using Firefox ESR and start listening to music. XHR requests sent to public gateways should get cancelled before receiving first byte of payload, and a late redirect to local gateway replaces them. (Firefox >69 redirects immediately, without the need to cancel original requet mid-flight)

Closes #784
Closes #779
CC https://github.com/ipfs-shipyard/ipfs-companion/issues/436