### PR TITLE
fix: no dnslink lookup when turned off

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -243,7 +243,7 @@ module.exports = async function init () {
     } catch (error) {
       info.gatewayVersion = null
     }
-    if (info.currentTab) {
+    if (state.active && info.currentTab) {
       const url = info.currentTab.url
       info.isIpfsContext = ipfsPathValidator.isIpfsPageActionsContext(url)
       info.currentDnslinkFqdn = dnslinkResolver.findDNSLinkHostname(url)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -111,6 +111,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
     // This is a good place to listen if you want to cancel or redirect the request.
     onBeforeRequest (request) {
       const state = getState()
+      if (!state.active) return
       // early sanity checks
       if (preNormalizationSkip(state, request)) {
         return
@@ -131,7 +132,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         }
       }
       // handle redirects to custom gateway
-      if (state.active && state.redirect) {
+      if (state.redirect) {
         // late sanity checks
         if (postNormalizationSkip(state, request)) {
           return


### PR DESCRIPTION
This PR disables all integrations (including protocol handlers)
when global integrations toggle is in "off" state.

It includes opening the browser action menu (it no longer triggers dnslink lookup for current tab).

Closes #821