### PR TITLE
fix: update error page for ipfs://CIDv0 in Firefox 70+

### DIFF
--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -23,32 +23,32 @@
     {
       "protocol": "web+dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#%s"
     },
     {
       "protocol": "web+ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#%s"
     },
     {
       "protocol": "web+ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#%s"
     },
     {
       "protocol": "dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#%s"
     },
     {
       "protocol": "ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#%s"
     },
     {
       "protocol": "ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#%s"
     }
   ]
 }

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -509,7 +509,7 @@ function isSafeToRedirect (request, runtime) {
 
 // This is just a placeholder that we had to provide -- removed in normalizedRedirectingProtocolRequest()
 // It has to match URL from manifest.json/protocol_handlers
-const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#'
+const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#'
 
 function redirectingProtocolRequest (request) {
   return request.url.startsWith(redirectingProtocolEndpoint)

--- a/test/functional/lib/ipfs-request-protocol-handlers.test.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.test.js
@@ -59,81 +59,81 @@ describe('modifyRequest.onBeforeRequest:', function () {
 
         // without web+ prefix (Firefox > 59: https://github.com/ipfs-shipyard/ipfs-companion/issues/164#issuecomment-356301174)
         it('should not be normalized if ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if ipns:/{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipns://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if ipfs://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
 
         // web+ prefixed versions (Firefox < 59 and Chrome)
         it('should not be normalized if web+ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+ipns:/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipns://{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if web+dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}:/bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}://bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmXQY7mKr28B964Uj4ouq3fPgkNLqzaKiajTA7surAiQuD#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiegmsbyyxqe3otwyymguym5sflugdf2bnfh75sk3rqcfgvnyatgry#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
       })


### PR DESCRIPTION
We are unable to fix this (URI is lowercased before passed to extension), nor we are able to reconstruct the original CIDv0, but we can inform user about manual fix and link to https://cid.ipfs.io:

> ![2019-12-03--16-16-47](https://user-images.githubusercontent.com/157609/70064013-1a3d2700-15e9-11ea-85b4-9861f7461895.png)


This PR also adds SRI for CSS assets.

Closes #815, cc #527