### PR TITLE
feat: preload visited DNSLink URLs to local node

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -287,6 +287,14 @@
     "message": "If global redirect is enabled, this will include DNSLink websites and redirect them to respective /ipns/{fqdn} paths at Custom Gateway",
     "description": "An option description on the Preferences screen (option_dnslinkRedirect_description)"
   },
+  "option_dnslinkDataPreload_title": {
+    "message": "Preload visited pages",
+    "description": "An option title on the Preferences screen (option_dnslinkDataPreload_title)"
+  },
+  "option_dnslinkDataPreload_description": {
+    "message": "DNSLink websites will be preloaded to the local IPFS node to enable offline access and improve resiliency against network failures",
+    "description": "An option description on the Preferences screen (option_dnslinkDataPreload_description)"
+  },
   "option_dnslinkRedirect_warning": {
     "message": "Redirecting to a path-based gateway breaks Origin-based security isolation of DNSLink website! Please leave this disabled unless you are aware of (and ok with) related risks.",
     "description": "A warning on the Preferences screen, displayed when URL does not belong to Secure Context (option_customGatewayUrl_warning)"

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -17,6 +17,7 @@ exports.optionDefaults = Object.freeze({
   automaticMode: true,
   linkify: false,
   dnslinkPolicy: 'best-effort',
+  dnslinkDataPreload: true,
   dnslinkRedirect: false,
   recoverFailedHttpRequests: true,
   detectIpfsPathHeader: true,

--- a/add-on/src/options/forms/dnslink-form.js
+++ b/add-on/src/options/forms/dnslink-form.js
@@ -7,11 +7,13 @@ const switchToggle = require('../../pages/components/switch-toggle')
 
 function dnslinkForm ({
   dnslinkPolicy,
+  dnslinkDataPreload,
   dnslinkRedirect,
   onOptionChange
 }) {
   const onDnslinkPolicyChange = onOptionChange('dnslinkPolicy')
   const onDnslinkRedirectChange = onOptionChange('dnslinkRedirect')
+  const onDnslinkDataPreloadChange = onOptionChange('dnslinkDataPreload')
 
   return html`
     <form>
@@ -46,6 +48,15 @@ function dnslinkForm ({
               ${browser.i18n.getMessage('option_dnslinkPolicy_enabled')}
             </option>
           </select>
+        </div>
+        <div>
+          <label for="dnslinkDataPreload">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_dnslinkDataPreload_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_dnslinkDataPreload_description')}</dd>
+            </dl>
+          </label>
+          <div>${switchToggle({ id: 'dnslinkDataPreload', checked: dnslinkDataPreload, disabled: dnslinkRedirect, onchange: onDnslinkDataPreloadChange })}</div>
         </div>
         <div>
           <label for="dnslinkRedirect">

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -80,6 +80,7 @@ module.exports = function optionsPage (state, emit) {
   })}
   ${dnslinkForm({
     dnslinkPolicy: state.options.dnslinkPolicy,
+    dnslinkDataPreload: state.options.dnslinkDataPreload,
     dnslinkRedirect: state.options.dnslinkRedirect,
     onOptionChange
   })}


### PR DESCRIPTION
> For the context see #826 and discussion in https://github.com/ipfs/docs/issues/405

With https://github.com/ipfs-shipyard/ipfs-companion/pull/826 the data of visited DNSLink websites was no longer getting into the cache of local IPFS node by default.

This PR fixes the data distribution problem with a background task queue that ensures every visited DNSLink asset is preloaded to the cache of local IPFS node, contributing to the swarm. If original HTTP server is down, IPFS Companion will recover (#640) in a new tab.

This preload of DNSLink data is enabled by default, but can be disabled with a toggle on Preferences screen:

> ![2019-12-09--16-05-19](https://user-images.githubusercontent.com/157609/70446654-ba89c480-1a9d-11ea-8186-cae8468579eb.png)
