### PR TITLE
refactor: restore DNSLink redirect to local gateway

### DIFF
--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -18,7 +18,7 @@ exports.optionDefaults = Object.freeze({
   linkify: false,
   dnslinkPolicy: 'best-effort',
   dnslinkDataPreload: true,
-  dnslinkRedirect: false,
+  dnslinkRedirect: true,
   recoverFailedHttpRequests: true,
   detectIpfsPathHeader: true,
   preloadAtPublicGateway: true,

--- a/test/functional/lib/ipfs-request-dnslink.test.js
+++ b/test/functional/lib/ipfs-request-dnslink.test.js
@@ -34,7 +34,6 @@ describe('modifyRequest processing of DNSLinks', function () {
       ipfsNodeType: 'external',
       peerCount: 1,
       redirect: true,
-      dnslinkRedirect: true, // NOTE: this is opt-in now
       catchUnhandledProtocols: true,
       gwURLString: 'http://127.0.0.1:8080',
       pubGwURLString: 'https://ipfs.io'


### PR DESCRIPTION
This PR restores DNSLink redirect to local gateway as the default setting:

https://docs.ipfs.io → http://127.0.0.1:8080/ipns/docs.ipfs.io/


### Motivation

During the Design Review Call for https://github.com/ipfs/docs/issues/405 we've decided to keep the default user experience of loading DNSLink websites from local gateway by default.

References:
- Meeting Notes: https://github.com/ipfs/team-mgmt/pull/1081
- Decisions: https://github.com/ipfs/docs/issues/405#issuecomment-564310469

cc https://github.com/ipfs-shipyard/ipfs-companion/pull/826 @momack2