### PR TITLE
feat: copy shareable link during file import

### DIFF
--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -33,6 +33,10 @@ async function copyTextToClipboard (text, notify) {
 
 function createCopier (notify, ipfsPathValidator) {
   return {
+    async copyTextToClipboard (text) {
+      await copyTextToClipboard(text, notify)
+    },
+
     async copyCanonicalAddress (context, contextType) {
       const url = await findValueForContext(context, contextType)
       const ipfsPath = ipfsPathValidator.resolveToIpfsPath(url)

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -69,8 +69,8 @@ module.exports = async function init () {
 
     dnslinkResolver = createDnslinkResolver(getState)
     ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
-    ipfsImportHandler = createIpfsImportHandler(getState, getIpfs, ipfsPathValidator, runtime)
     copier = createCopier(notify, ipfsPathValidator)
+    ipfsImportHandler = createIpfsImportHandler(getState, getIpfs, ipfsPathValidator, runtime, copier)
     inspector = createInspector(notify, ipfsPathValidator, getState)
     contextMenus = createContextMenus(getState, runtime, ipfsPathValidator, {
       onAddFromContext,
@@ -319,6 +319,7 @@ module.exports = async function init () {
       }
       return
     }
+    ipfsImportHandler.copyShareLink(result)
     ipfsImportHandler.preloadFilesAtPublicGateway(result)
     if (state.ipfsNodeType === 'embedded' || !state.openViaWebUI) {
       return ipfsImportHandler.openFilesAtGateway({ result, openRootInNewTab: true })

--- a/add-on/src/popup/quick-import.js
+++ b/add-on/src/popup/quick-import.js
@@ -91,6 +91,7 @@ async function processFiles (state, emitter, files) {
     state.progress = 'Completed'
     emitter.emit('render')
     console.log(`Successfully imported ${streams.length} files`)
+    ipfsImportHandler.copyShareLink(result)
     ipfsImportHandler.preloadFilesAtPublicGateway(result)
     // open web UI at proper directory
     // unless and embedded node is in use (no access to web UI)


### PR DESCRIPTION
> @ericronne suggested that best interface is no interface, so..

This PR adds automatic copying of shareable link to clipboard when user imports a file via IPFS Companion UI. Closes #833.


## Details

Import file via context menu or "Share files via IPFS" from the main menu.
A system notification in system-native look will be shown at the same time imported file is being opened in Web UI:

> ![2019-12-12--13-32-56](https://user-images.githubusercontent.com/157609/70712384-f4e4a300-1ce3-11ea-9761-195d267a8cd3.png)

This notification is the same as one when user manually copies via:

> ![2019-12-12--13-34-46](https://user-images.githubusercontent.com/157609/70712502-35442100-1ce4-11ea-8ea9-dd8e9a0fb55b.png)

