### PR TITLE
fix: broken dnslink at /ipns/ipfs.io/blog/foo

### DIFF
--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -455,7 +455,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
       /// https://github.com/ipfs/blog/issues/360
       if (request.type === 'main_frame' &&
           request.statusCode === 404 &&
-          request.url.includes('/ipns/ipfs.io/blog')) {
+          request.url.match(/\/\/[^/]+\/ipns\/ipfs\.io\/blog\//)) {
         log('onCompleted: fixing /ipns/ipfs.io/blog → /ipns/blog.ipfs.io')
         return browser.tabs.update({ url: request.url.replace('/ipns/ipfs.io/blog', '/ipns/blog.ipfs.io') })
       }

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -450,6 +450,16 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
       const state = getState()
       if (!state.active) return
       if (request.statusCode === 200) return // finish if no error to recover from
+
+      // Seamlessly fix canonical link when DNSLink breaks ipfs.io/blog/*
+      /// https://github.com/ipfs/blog/issues/360
+      if (request.type === 'main_frame' &&
+          request.statusCode === 404 &&
+          request.url.includes('/ipns/ipfs.io/blog')) {
+        log('onCompleted: fixing /ipns/ipfs.io/blog → /ipns/blog.ipfs.io')
+        return browser.tabs.update({ url: request.url.replace('/ipns/ipfs.io/blog', '/ipns/blog.ipfs.io') })
+      }
+
       let redirectUrl
       if (isRecoverable(request, state, ipfsPathValidator)) {
         // if subdomain request redirect to default public subdomain url

--- a/test/functional/lib/ipfs-request-workarounds.test.js
+++ b/test/functional/lib/ipfs-request-workarounds.test.js
@@ -6,7 +6,7 @@ const browser = require('sinon-chrome')
 const { initState } = require('../../../add-on/src/lib/state')
 const { createRuntimeChecks } = require('../../../add-on/src/lib/runtime-checks')
 const { createRequestModifier } = require('../../../add-on/src/lib/ipfs-request')
-const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
+const createDNSLinkResolver = require('../../../add-on/src/lib/dnslink')
 const { createIpfsPathValidator } = require('../../../add-on/src/lib/ipfs-path')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
 
@@ -33,7 +33,7 @@ describe('modifyRequest processing', function () {
     state = initState(optionDefaults)
     getState = () => state
     const getIpfs = () => {}
-    dnslinkResolver = createDnslinkResolver(getState)
+    dnslinkResolver = createDNSLinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
     ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
     modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
@@ -159,13 +159,13 @@ describe('modifyRequest processing', function () {
     })
   })
 
-  // We've moved blog to blog.ipfs.io and fixe but links to ipfs.io/blog/*
+  // We've moved blog to blog.ipfs.io but links to ipfs.io/blog/*
   // are still around due to the way Discourse integration was done for comments.
   // https://github.com/ipfs/blog/issues/360
   describe('a failed main_frame request to /ipns/ipfs.io/blog', function () {
     it('should be updated to /ipns/blog.ipfs.io', async function () {
-      const brokenDnslinkUrl = 'http://example.com/ipns/ipfs.io/blog/some-post'
-      const fixedDnslinkUrl = 'http://example.com/ipns/blog.ipfs.io/some-post'
+      const brokenDNSLinkUrl = 'http://example.com/ipns/ipfs.io/blog/some-post'
+      const fixedDNSLinkUrl = 'http://example.com/ipns/blog.ipfs.io/some-post'
       // ensure clean modifyRequest
       runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
       modifyRequest = createRequestModifier(getState, dnslinkResolver, ipfsPathValidator, runtime)
@@ -173,12 +173,12 @@ describe('modifyRequest processing', function () {
       const request = {
         statusCode: 404,
         type: 'main_frame',
-        url: brokenDnslinkUrl
+        url: brokenDNSLinkUrl
       }
       browser.tabs.update.flush()
       assert.ok(browser.tabs.update.notCalled)
       modifyRequest.onCompleted(request)
-      assert.ok(browser.tabs.update.withArgs({ url: fixedDnslinkUrl }).calledOnce)
+      assert.ok(browser.tabs.update.withArgs({ url: fixedDNSLinkUrl }).calledOnce)
       browser.tabs.update.flush()
     })
   })


### PR DESCRIPTION
This PR fixes broken DNSLink loads for `/ipns/ipfs.io/blog/*` from local or public gateways.

Without this, user stumbling upon https://ipfs.io/blog/2020-02-10-our-focus-for-2020/ will get redirected to  http://127.0.0.1:8080/ipns/ipfs.io/blog/2020-02-10-our-focus-for-2020/ and get HTTP 404 error without any indication how to fix it, which is pretty bad experience:

```console
ipfs resolve -r /ipns/ipfs.io/blog/2020-02-10-our-focus-for-2020/: no link named "2020-02-10-our-focus-for-2020" under bafybeics2j3x4qcn3365docj4f5xfe7gwlbakds7x3it63okc572imyb4e
```

Wider context: https://github.com/ipfs/blog/issues/360
cc @autonome  (as I am not sure who is responsible for ipfs.io atm)