### PR TITLE
fix: remove redundant/unused permissions

### DIFF
--- a/add-on/manifest.common.json
+++ b/add-on/manifest.common.json
@@ -14,10 +14,8 @@
   "permissions": [
     "<all_urls>",
     "idle",
-    "activeTab",
     "tabs",
     "notifications",
-    "alarms",
     "storage",
     "unlimitedStorage",
     "contextMenus",


### PR DESCRIPTION
This PR is addressing Chrome Web Store review (https://github.com/ipfs-shipyard/ipfs-companion/issues/808#issuecomment-590313139)

We no longer use `alarms` API (Chrome behaved differently than Firefox)
and `activeTab` is superseded by  `<all_urls>` (old Firefox bug is no longer a problem).

