### PR TITLE
fix: normalize API calls from 0.0.0.0 to 127.0.0.1

### DIFF
--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -93,6 +93,13 @@ function sameGateway (url, gwUrl) {
     // match as path-based gateway, and not subdomains.
     return url.hostname === gwUrl.hostname
   }
+  if (url.hostname === '0.0.0.0') {
+    // normalize 0.0.0.0 (used by go-ipfs in the console)
+    // to 127.0.0.1 to minimize the number of edge cases we need to handle later
+    // https://github.com/ipfs-shipyard/ipfs-companion/issues/867
+    url = new URL(url.toString())
+    url.hostname = '127.0.0.1'
+  }
 
   const gws = [gwUrl.host]
 

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -130,6 +130,11 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         const redirectUrl = safeURL(request.url, { useLocalhostName: state.useSubdomains }).toString()
         if (redirectUrl !== request.url) return { redirectUrl }
       }
+      // For now normalize API to the IP to comply with go-ipfs checks
+      if (state.redirect && request.type === 'main_frame' && sameGateway(request.url, state.apiURL)) {
+        const redirectUrl = safeURL(request.url, { useLocalhostName: false }).toString()
+        if (redirectUrl !== request.url) return { redirectUrl }
+      }
 
       // early sanity checks
       if (preNormalizationSkip(state, request)) {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -86,6 +86,13 @@ function safeURL (url, opts) {
   if (typeof url === 'string') {
     url = new URL(url)
   }
+  if (url.hostname === '0.0.0.0') {
+    // normalize 0.0.0.0 (used by go-ipfs in the console)
+    // to 127.0.0.1 to minimize the number of edge cases we need to handle later
+    // https://github.com/ipfs-shipyard/ipfs-companion/issues/867
+    url = new URL(url.toString())
+    url.hostname = '127.0.0.1'
+  }
   // "localhost" gateway normalization matters because:
   // - 127.0.0.1 is a path gateway
   // - localhost is a subdomain gateway

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -118,6 +118,11 @@ describe('ipfs-path.js', function () {
       const gw = 'http://localhost:8080'
       expect(sameGateway(url, gw)).to.equal(true)
     })
+    it('should return true on 127.0.0.1/0.0.0.0 host match', function () {
+      const url = 'http://0.0.0.0:5001/webui'
+      const api = 'http://127.0.0.1:5001'
+      expect(sameGateway(url, api)).to.equal(true)
+    })
     it('should return false on hostname match but different port', function () {
       const url = 'https://localhost:8081/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
       const gw = 'http://localhost:8080'

--- a/test/functional/lib/ipfs-request-gateway-redirect.test.js
+++ b/test/functional/lib/ipfs-request-gateway-redirect.test.js
@@ -342,19 +342,39 @@ describe('modifyRequest.onBeforeRequest:', function () {
       describe('request for IPFS path at the localhost', function () {
         // we do not touch local requests, as it may interfere with other nodes running at the same machine
         // or could produce false-positives such as redirection from localhost:5001/ipfs/path to localhost:8080/ipfs/path
-        it('should be left untouched if localhost is used', function () {
+        it('should fix localhost API hostname to IP', function () {
           const request = url2request('http://localhost:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+          // expectNoRedirect(modifyRequest, request)
+          expect(modifyRequest.onBeforeRequest(request).redirectUrl)
+            .to.equal('http://127.0.0.1:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+        })
+        it('should be left untouched if localhost Gateway is used', function () {
+          const request = url2request('http://localhost:8080/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
           expectNoRedirect(modifyRequest, request)
         })
-        it('should be left untouched if localhost is used', function () {
+        it('should fix 127.0.0.1 Gateway to localhost', function () {
+          const request = url2request('http://127.0.0.1:8080/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+          // expectNoRedirect(modifyRequest, request)
+          expect(modifyRequest.onBeforeRequest(request).redirectUrl)
+            .to.equal('http://localhost:8080/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+        })
+        it('should fix 0.0.0.0 to localhost IP API', function () {
+          // https://github.com/ipfs-shipyard/ipfs-companion/issues/867
+          const request = url2request('http://0.0.0.0:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+          expect(modifyRequest.onBeforeRequest(request).redirectUrl)
+            .to.equal('http://127.0.0.1:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+        })
+        it('should fix localhost API to IP', function () {
           // https://github.com/ipfs/ipfs-companion/issues/291
-          const request = url2request('http://localhost:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
-          expectNoRedirect(modifyRequest, request)
+          const request = url2request('http://localhost:5001/webui')
+          // expectNoRedirect(modifyRequest, request)
+          expect(modifyRequest.onBeforeRequest(request).redirectUrl)
+            .to.equal('http://127.0.0.1:5001/webui')
         })
-        it('should be left untouched if localhost is used, even when x-ipfs-path is present', function () {
+        it('should be left untouched if localhost API IP is used, even when x-ipfs-path is present', function () {
           // https://github.com/ipfs-shipyard/ipfs-companion/issues/604
-          const request = url2request('http://localhost:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
-          request.responseHeaders = [{ name: 'X-Ipfs-Path', value: '/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ' }]
+          const request = url2request('http://127.0.0.1:5001/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ/')
+          request.responseHeaders = [{ name: 'X-Ipfs-Path', value: '/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DDIFF' }]
           expectNoRedirect(modifyRequest, request)
         })
         it('should be left untouched if [::1] is used', function () {


### PR DESCRIPTION
This normalizes `http://0.0.0.0:5001/webui/` to `http://127.0.0.1:5001/webui/` 

Closes #867