### PR TITLE
fix: HTTP recovery in the same tab

### DIFF
--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -368,7 +368,6 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         url.hostname = `${url.hostname}.link`
         const redirectUrl = url.toString()
         log(`onErrorOccurred: attempting to recover from DNS error (${request.error}) using EthDNS for ${request.url} → ${redirectUrl}`, request)
-        // TODO: update existing tab
         return updateTabWithURL(request, redirectUrl, browser)
       }
 

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -379,7 +379,6 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         if (dnslink) {
           const redirectUrl = dnslinkResolver.dnslinkAtGateway(request.url, dnslink)
           log(`onErrorOccurred: attempting to recover from network error (${request.error}) using dnslink for ${request.url} → ${redirectUrl}`, request)
-          browser.tabs.update({ url: redirectUrl })
           return updateTabWithURL(request, redirectUrl, browser)
         }
       }

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -369,8 +369,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
         const redirectUrl = url.toString()
         log(`onErrorOccurred: attempting to recover from DNS error (${request.error}) using EthDNS for ${request.url} → ${redirectUrl}`, request)
         // TODO: update existing tab
-        browser.tabs.update({ url: redirectUrl })
-        return
+        return updateTabWithURL(request, redirectUrl, browser)
       }
 
       // Check if error can be recovered via DNSLink
@@ -381,7 +380,7 @@ function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, ru
           const redirectUrl = dnslinkResolver.dnslinkAtGateway(request.url, dnslink)
           log(`onErrorOccurred: attempting to recover from network error (${request.error}) using dnslink for ${request.url} → ${redirectUrl}`, request)
           browser.tabs.update({ url: redirectUrl })
-          return
+          return updateTabWithURL(request, redirectUrl, browser)
         }
       }
 
@@ -613,7 +612,7 @@ async function updateTabWithURL (request, redirectUrl, browser) {
   // Do nothing if the URL remains the same
   if (request.url === redirectUrl) return
 
-  browser.tabs.update({
+  return browser.tabs.update({
     active: true,
     url: redirectUrl
   })

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -49,47 +49,47 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
     it('should do nothing if broken request is for the default subdomain gateway', async function () {
       const request = urlRequestWithStatus('https://QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h.ipfs.dweb.link/wiki/', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should redirect to default subdomain gateway on broken subdomain gateway request', async function () {
       const request = urlRequestWithStatus('http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.brokenexample.com/wiki/', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.withArgs({ url: 'https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/', active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with default subdomain gateway URL')
+      assert.ok(browser.tabs.update.withArgs({ url: 'https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/', active: true }).calledOnce, 'tabs.update should be called with default subdomain gateway URL')
     })
     it('should do nothing if broken request is a non-IPFS request', async function () {
       const request = urlRequestWithStatus('https://wikipedia.org', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if broken request is a local request to 127.0.0.1/ipfs', async function () {
       const request = urlRequestWithStatus('http://127.0.0.1:8080/ipfs/QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if broken request is a local request to localhost/ipfs', async function () {
       const request = urlRequestWithStatus('http://localhost:8080/ipfs/QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if broken request is a local request to *.ipfs.localhost', async function () {
       const request = urlRequestWithStatus('http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhw.ipfs.localhost:8080/', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if broken request is to the default public gateway', async function () {
       const request = urlRequestWithStatus('https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if broken request is not a \'main_frame\' request', async function () {
       const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500, 'stylesheet')
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should recover from unreachable third party public gateway by reopening on the public gateway', async function () {
       const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.withArgs({ url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with IPFS default public gateway URL')
+      assert.ok(browser.tabs.update.withArgs({ url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should be called with IPFS default public gateway URL')
     })
   })
 
@@ -101,17 +101,17 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
     it('should do nothing on failed subdomain gateway request', async function () {
       const request = urlRequestWithStatus('https://QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h.ipfs.brokendomain.com/wiki/', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing on broken non-default public gateway IPFS request', async function () {
       const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
   })
 
   afterEach(function () {
-    browser.tabs.create.reset()
+    browser.tabs.update.reset()
   })
 
   after(function () {
@@ -148,38 +148,38 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
     it('should do nothing if failed request is for the default subdomain gateway', async function () {
       const request = urlRequestWithStatus('https://QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h.ipfs.dweb.link/wiki/', 500)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should redirect to default subdomain gateway on failed subdomain gateway request', async function () {
       const request = urlRequestWithStatus('http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.brokenexample.com/wiki/', 500)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.withArgs({ url: 'https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/', active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with default subdomain gateway URL')
+      assert.ok(browser.tabs.update.withArgs({ url: 'https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/', active: true }).calledOnce, 'tabs.update should be called with default subdomain gateway URL')
     })
     it('should do nothing if failed request is a non-IPFS request', async function () {
       const request = urlRequestWithNetworkError('https://wikipedia.org')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if failed request is a non-public IPFS request', async function () {
       const request = urlRequestWithNetworkError('http://127.0.0.1:8080/ipfs/QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if failed request is to the default public gateway', async function () {
       const request = urlRequestWithNetworkError('https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing if failed request is not a \'main_frame\' request', async function () {
       const requestType = 'stylesheet'
       const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 'net::ERR_NAME_NOT_RESOLVED', requestType)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should recover from unreachable third party public gateway by reopening on the public gateway', async function () {
       const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.withArgs({ url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with IPFS default public gateway URL')
+      assert.ok(browser.tabs.update.withArgs({ url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should be called with IPFS default public gateway URL')
     })
     it('should recover from unreachable HTTP server by reopening DNSLink on the active gateway', async function () {
       state.dnslinkPolicy = 'best-effort'
@@ -188,7 +188,7 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       const expectedUrl = 'http://localhost:8080/ipns/en.wikipedia-on-ipfs.org/'
       const request = urlRequestWithNetworkError('https://en.wikipedia-on-ipfs.org/')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.withArgs({ url: expectedUrl, active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with DNSLink on local gateway URL')
+      assert.ok(browser.tabs.update.withArgs({ url: expectedUrl, active: true }).calledOnce, 'tabs.update should be called with DNSLink on local gateway URL')
       dnslinkResolver.clearCache()
     })
     it('should recover from failed DNS for .eth opening it on EthDNS gateway at .eth.link', async function () {
@@ -199,7 +199,7 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       const expectedUrl = 'https://almonit.eth.link/'
       const request = urlRequestWithNetworkError('https://almonit.eth', dnsFailure)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.withArgs({ url: expectedUrl, active: true, openerTabId: 20 }).calledOnce, 'tabs.create should be called with ENS resource on local gateway URL')
+      assert.ok(browser.tabs.update.withArgs({ url: expectedUrl, active: true }).calledOnce, 'tabs.update should be called with ENS resource on local gateway URL')
       dnslinkResolver.clearCache()
     })
   })
@@ -212,19 +212,19 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
     it('should do nothing on unreachable third party public gateway', async function () {
       const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing on failed subdomain gateway request', async function () {
       const request = urlRequestWithStatus('https://QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h.ipfs.brokendomain.com/wiki/', 500)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
     it('should do nothing on unreachable HTTP server with DNSLink', async function () {
       state.dnslinkPolicy = 'best-effort'
       dnslinkResolver.setDnslink('en.wikipedia-on-ipfs.org', '/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco')
       const request = urlRequestWithNetworkError('https://en.wikipedia-on-ipfs.org')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
       dnslinkResolver.clearCache()
     })
     it('should do nothing on failed non-default public gateway IPFS request', async function () {
@@ -234,13 +234,13 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       const dnsFailure = 'net::ERR_NAME_NOT_RESOLVED' // chrome code
       const request = urlRequestWithNetworkError('https://almonit.eth', dnsFailure)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.create.notCalled, 'tabs.create should not be called')
+      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
       dnslinkResolver.clearCache()
     })
   })
 
   afterEach(function () {
-    browser.tabs.create.reset()
+    browser.tabs.update.reset()
   })
 
   after(function () {


### PR DESCRIPTION
> Fixes #873 

The changes caused some tests to fail, and I'm not sure my javascript skills are good enough to figure out how to fix them properly without just deleting them.
```
  419 passing (2s)
  1 pending
  7 failing

  1) requestHandler.onCompleted:
       with recoverFailedHttpRequests=true
         should redirect to default subdomain gateway on broken subdomain gateway request:
     AssertionError: tabs.create should be called with default subdomain gateway URL: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-gateway-recover.test.js:57:14)

  2) requestHandler.onCompleted:
       with recoverFailedHttpRequests=true
         should recover from unreachable third party public gateway by reopening on the public gateway:
     AssertionError: tabs.create should be called with IPFS default public gateway URL: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-gateway-recover.test.js:92:14)

  3) requestHandler.onErrorOccurred:
       with recoverFailedHttpRequests=true
         should redirect to default subdomain gateway on failed subdomain gateway request:
     AssertionError: tabs.create should be called with default subdomain gateway URL: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-gateway-recover.test.js:156:14)

  4) requestHandler.onErrorOccurred:
       with recoverFailedHttpRequests=true
         should recover from unreachable third party public gateway by reopening on the public gateway:
     AssertionError: tabs.create should be called with IPFS default public gateway URL: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-gateway-recover.test.js:182:14)

  5) requestHandler.onErrorOccurred:
       with recoverFailedHttpRequests=true
         should recover from unreachable HTTP server by reopening DNSLink on the active gateway:
     AssertionError: tabs.create should be called with DNSLink on local gateway URL: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-gateway-recover.test.js:191:14)

  6) requestHandler.onErrorOccurred:
       with recoverFailedHttpRequests=true
         should recover from failed DNS for .eth opening it on EthDNS gateway at .eth.link:
     AssertionError: tabs.create should be called with ENS resource on local gateway URL: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-gateway-recover.test.js:202:14)

  7) modifyRequest processing
       a failed main_frame request to /ipns/ipfs.io/blog
         should be updated to /ipns/blog.ipfs.io:
     AssertionError: expected false to be truthy
      at Context.<anonymous> (test/functional/lib/ipfs-request-workarounds.test.js:194:14)



----------------------------------------|----------|----------|----------|----------|-------------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------------------------|----------|----------|----------|----------|-------------------|
All files                               |    61.29 |    57.17 |       59 |    62.74 |                   |
 lib                                    |    59.53 |    55.52 |    56.94 |    61.06 |                   |
  context-menus.js                      |    58.24 |     7.69 |    42.86 |    60.47 |... 71,173,174,177 |
  copier.js                             |     9.38 |        0 |    14.29 |     9.38 |... 59,61,68,69,70 |
  dir-view.js                           |      100 |       50 |      100 |      100 |             10,33 |
  dnslink.js                            |    68.81 |    66.67 |    81.25 |    73.27 |... 56,159,161,167 |
  http-proxy.js                         |    25.81 |     6.25 |    33.33 |    24.14 |... 8,92,96,97,101 |
  inspector.js                          |       50 |      100 |       50 |       50 |    10,11,12,13,14 |
  ipfs-companion.js                     |    27.88 |     8.05 |    15.38 |    29.38 |... 55,759,776,777 |
  ipfs-import.js                        |    21.43 |        0 |    22.22 |    21.31 |... 09,110,111,112 |
  ipfs-path.js                          |     92.5 |    80.67 |      100 |    94.41 |... 25,250,310,359 |
  ipfs-protocol.js                      |    86.67 |     62.5 |      100 |    86.21 |       20,21,37,49 |
  ipfs-request.js                       |    87.88 |    84.41 |     93.1 |    90.95 |... 15,416,420,422 |
  mime-sniff.js                         |       80 |       60 |      100 |    92.31 |                33 |
  notifier.js                           |    27.27 |        0 |    33.33 |    27.27 |... 12,14,15,20,22 |
  on-installed.js                       |    55.56 |        0 |       50 |    55.56 |         8,9,17,18 |
  options.js                            |    91.43 |    77.55 |      100 |    91.18 |... 63,172,173,182 |
  precache.js                           |       30 |     8.33 |    30.77 |    32.14 |... 03,104,105,109 |
  runtime-checks.js                     |    93.33 |    96.43 |      100 |    93.33 |                16 |
  state.js                              |    94.74 |     62.5 |       80 |    94.29 |             50,53 |
 lib/ipfs-client                        |     61.7 |    52.63 |    43.75 |    63.04 |                   |
  embedded.js                           |    29.03 |        0 |        0 |       30 |... 37,44,45,47,48 |
  external.js                           |      100 |      100 |      100 |      100 |                   |
  index.js                              |       72 |    55.56 |    71.43 |    73.47 |... 62,64,65,66,89 |
 lib/ipfs-client/embedded-chromesockets |    29.61 |        0 |        0 |    30.41 |                   |
  config.js                             |    20.75 |        0 |        0 |    21.57 |... 56,159,161,162 |
  index.js                              |    21.57 |        0 |        0 |       22 |... 85,86,87,89,92 |
  libp2p-bundle.js                      |    34.48 |        0 |        0 |    34.48 |... 01,102,104,106 |
  libp2p.js                             |    68.42 |      100 |        0 |    72.22 |    24,25,26,32,87 |
 lib/ipfs-proxy                         |     76.7 |    74.85 |    74.12 |    78.48 |                   |
  access-control.js                     |    98.08 |    96.08 |      100 |      100 |            62,173 |
  enable-command.js                     |      100 |    90.91 |      100 |      100 |             24,48 |
  index.js                              |    43.18 |        0 |    15.38 |     47.5 |... 57,58,61,64,68 |
  pre-acl.js                            |       96 |    88.89 |      100 |      100 |             27,49 |
  pre-command.js                        |     91.3 |       75 |      100 |    95.24 |                21 |
  pre-mfs-scope.js                      |    97.01 |    92.59 |      100 |    96.72 |            72,121 |
  request-access.js                     |    12.28 |        0 |     8.33 |    13.73 |... 06,108,111,113 |
 pages/proxy-access-dialog              |    71.43 |       50 |       50 |    90.91 |                   |
  page.js                               |    71.43 |       50 |       50 |    90.91 |                54 |
 pages/proxy-acl                        |    93.48 |       90 |    88.89 |      100 |                   |
  page.js                               |     87.5 |    93.33 |    81.82 |      100 |                38 |
  store.js                              |      100 |       80 |      100 |      100 |                 3 |
 popup                                  |      100 |    57.14 |      100 |      100 |                   |
  logo.js                               |      100 |    57.14 |      100 |      100 |          6,7,8,13 |
----------------------------------------|----------|----------|----------|----------|-------------------|
```