### PR TITLE
feat: update welcome page content

### DIFF
--- a/add-on/_locales/ca/messages.json
+++ b/add-on/_locales/ca/messages.json
@@ -611,9 +611,9 @@
     "message": "Ara mateix el teu node està connectat a __TX_TAG__2e7a3d8709699e8f9b6925fc476cc112__$1</0>peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Descobreix què <0>pots fer amb l'Acompanyant</0> i endinsat la web distribuïda amb IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "Sembla que l'IPFS no funciona",
@@ -635,33 +635,33 @@
     "message": "Ets nou a IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Llegeix la <0>documentació</0> per aprendre els <1>conceptes</1> bàsics per treballar amb IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Descobreix!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Troba <0>recursos útils</0> per fer servir IPFS i <1>construir-hi</1>al damunt.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Tens preguntes?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visita el <0>Fòrum de Suport i Debat</0>. ",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Vols ajudar?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Uneix-te a la <0>Comunitat IPFS</0>!  Contribueix amb <1>codi</1>, <2>documentació</2>,<3> traduccions</3> o ajuda bo i donant suport a <4>altres usuaris</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Demo Alfa",

--- a/add-on/_locales/ca/messages.json
+++ b/add-on/_locales/ca/messages.json
@@ -663,13 +663,13 @@
     "message": "Uneix-te a la <0>Comunitat IPFS</0>!  Contribueix amb <1>codi</1>, <2>documentació</2>,<3> traduccions</3> o ajuda bo i donant suport a <4>altres usuaris</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Demo Alfa",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "La Web Permanent",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Projectes Relacionats",

--- a/add-on/_locales/cs/messages.json
+++ b/add-on/_locales/cs/messages.json
@@ -663,13 +663,13 @@
     "message": "Přidejte se k <0>IPFS komunitě</0>! Přispějte <1>kódem</1>, <2>dokumentací</2>, <3>překlady</3> nebo pomocí <4>ostatním uživatelům</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Permanentní Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Související projekty",

--- a/add-on/_locales/cs/messages.json
+++ b/add-on/_locales/cs/messages.json
@@ -611,9 +611,9 @@
     "message": "V současné době je váš uzel připojen k dalším <0>$1</0> uzlům.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Vyzkoušejte co <0>můžete dělat s IPFS Companion</0> a ponořte se do distribuovaného webu s IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "Zdá se, že IPFS není spuštěn",
@@ -635,33 +635,33 @@
     "message": "IPFS nováček?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Přečtěte si <0>dokumentaci</0> aby jste se dozvěděli o základních <1>pojmech</1> IPFS a o tom jak funguje.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Objevujte!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Naleznete <0>zajímavé zdroje</0> pro používaní a <1>tvoření nových věcí</1> založených na IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Máte otázky?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Navštivte <0>fórum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Chcete pomoct?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Přidejte se k <0>IPFS komunitě</0>! Přispějte <1>kódem</1>, <2>dokumentací</2>, <3>překlady</3> nebo pomocí <4>ostatním uživatelům</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/da/messages.json
+++ b/add-on/_locales/da/messages.json
@@ -611,9 +611,9 @@
     "message": "Lige nu er din klient forbundet til <0>$1</0> andre klienter.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Udforsk hvad du <0> kan gøre med Følgesvend</0> og dyk ned i det distribuerede net med IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS ser ikke ud til at være kørende",
@@ -635,33 +635,33 @@
     "message": "Er du nybegynder til IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Læs <0>dokumentationen</0> for at lære omkring basis <1>koncepter</1> og arbejdet med IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Udforsk!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>nyttige ressourcer</0>om brugen af IPFS og opbygning af ting</1>oven på.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Har du spørgsmål?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Besøg <0>Diskussions og Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Lyst til at hjælpe?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Tilslut dig <0>IPFS Fællesskabet</0>! Bidrag med <1>kode</1>, <2>dokumentation</2>, <3>oversættelser</3> eller hjælp vedat <4>supportere andre brugere</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alfa Demo",

--- a/add-on/_locales/da/messages.json
+++ b/add-on/_locales/da/messages.json
@@ -663,13 +663,13 @@
     "message": "Tilslut dig <0>IPFS Fællesskabet</0>! Bidrag med <1>kode</1>, <2>dokumentation</2>, <3>oversættelser</3> eller hjælp vedat <4>supportere andre brugere</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alfa Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Det Permanente Net",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Relaterede Projekter",

--- a/add-on/_locales/de/messages.json
+++ b/add-on/_locales/de/messages.json
@@ -663,13 +663,13 @@
     "message": "Werde Teil der <0>IPFS-Gemeinschaft</0>! Trage bei mit <1>Programmierung</1>, <2>Dokumentation</2>, <3>Übersetzungen</3>, oder der <4>Unterstützung anderer Nutzer</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS-Alpha-Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Das permanente Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Verwandte Projekte",

--- a/add-on/_locales/de/messages.json
+++ b/add-on/_locales/de/messages.json
@@ -611,9 +611,9 @@
     "message": "Momentan ist Dein Node mit <0>$1</0> Peers verbunden.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "<0>Entdecke den Companion</0> und tauche mit dem IPFS in das verteilte Web ein!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "Neu im IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Lies die <0>Dokumentation</0>, um mehr über die grundlegenden <1>Konzepte</1> und die Arbeit mit dem IPFS zu erfahren.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Entdecke!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Entdecke <0>praktische Ressourcen</0>, um das IPFS zu nutzen und darauf <1>Anwendungen zu entwickeln</1>.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Hast Du Fragen?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Besuche das <0>Diskussions- und Support-Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Möchtest Du helfen?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Werde Teil der <0>IPFS-Gemeinschaft</0>! Trage bei mit <1>Programmierung</1>, <2>Dokumentation</2>, <3>Übersetzungen</3>, oder der <4>Unterstützung anderer Nutzer</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS-Alpha-Demo",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -624,15 +624,15 @@
     "description": "Install steps title (page_landingWelcome_installSteps_notRunning_title)"
   },
   "page_landingWelcome_installSteps_desktop_install": {
-    "message": "Get <0>IPFS Desktop</0> and you will be all set!",
+    "message": "Make sure IPFS Desktop is running. Don't have it installed? <0>Download IPFS Desktop now.</0>",
     "description": "Install steps copy (page_landingWelcome_installSteps_desktop_install)"
   },
   "page_landingWelcome_installSteps_cli_title": {
-    "message": "Prefer to use the command line?",
+    "message": "Command-line users",
     "description": "Install steps title (page_landingWelcome_installSteps_cli_title)"
   },
   "page_landingWelcome_installSteps_cli_install": {
-    "message": "Follow <0>these instructions</0>, then start an IPFS daemon in your terminal:",
+    "message": "Start IPFS by entering <code class=\"yellow\">ipfs daemon</code> in your terminal. If you don't have IPFS installed yet, follow the <0>CLI quick-start guide</0> first.",
     "description": "Install steps copy (page_landingWelcome_installSteps_cli_install)"
   },
   "page_landingWelcome_resources_title_new_ipfs": {
@@ -667,13 +667,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
-    "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+  "page_landingWelcome_videos_why_ipfs": {
+    "message": "Why IPFS?",
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
-    "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+  "page_landingWelcome_videos_how_ipfs_works": {
+    "message": "How IPFS Works",
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Related Projects",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -620,7 +620,7 @@
     "description": "Ready message copy (page_landingWelcome_welcome_discover)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
-    "message": "IPFS does not seem to be running",
+    "message": "IPFS is not running",
     "description": "Install steps title (page_landingWelcome_installSteps_notRunning_title)"
   },
   "page_landingWelcome_installSteps_desktop_install": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -612,7 +612,7 @@
     "description": "Ready message title (page_landingWelcome_welcome_title)"
   },
   "page_landingWelcome_welcome_peers": {
-    "message": "Right now your node is connected to <0>$1</0> peers.",
+    "message": "Your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
   "page_landingWelcome_welcome_discover": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -611,17 +611,17 @@
     "message": "Your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_status": {
+  "page_landingWelcome_welcome_statusButton_text": {
     "message": "Status",
-    "description": "Ready message button text for opening Web UI status page (page_landingWelcome_welcome_status)"
+    "description": "Ready message button text for opening Web UI status page (page_landingWelcome_welcome_statusButton_text)"
   },
-  "page_landingWelcome_welcome_files": {
+  "page_landingWelcome_welcome_filesButton_text": {
     "message": "Files",
-    "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_files)"
+    "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_filesButton_text)"
   },
-  "page_landingWelcome_welcome_peers": {
+  "page_landingWelcome_welcome_peersButton_text": {
     "message": "Peers",
-    "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_peers)"
+    "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_peersButton_text)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS is not running",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -29,7 +29,7 @@
   },
   "panel_statusSwarmPeers": {
     "message": "Peers",
-    "description": "A label in Node status section of Browser Action pop-upi (panel_statusSwarmPeers)"
+    "description": "A label in Node status section of Browser Action pop-up, also used as Welcome ready message button text for opening Web UI peers page (panel_statusSwarmPeers)"
   },
   "panel_statusSwarmPeersTitle": {
     "message": "The number of other IPFS nodes you can connect to",
@@ -607,13 +607,17 @@
     "message": "IPFS Companion",
     "description": "Extension name after the IPFS logo (page_landingWelcome_logo_title)"
   },
-  "page_landingWelcome_welcome_title": {
-    "message": "You are all set!",
-    "description": "Ready message title (page_landingWelcome_welcome_title)"
-  },
   "page_landingWelcome_welcome_peers": {
     "message": "Your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
+  },
+  "page_landingWelcome_welcome_status": {
+    "message": "Status",
+    "description": "Ready message button text for opening Web UI status page (page_landingWelcome_welcome_status)"
+  },
+  "page_landingWelcome_welcome_files": {
+    "message": "Files",
+    "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_files)"
   },
   "page_landingWelcome_welcome_discover": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -623,6 +623,10 @@
     "message": "IPFS is not running",
     "description": "Install steps title (page_landingWelcome_installSteps_notRunning_title)"
   },
+  "page_landingWelcome_installSteps_desktop_title": {
+    "message": "IPFS Desktop users",
+    "description": "Install steps title (page_landingWelcome_installSteps_desktop_title)"
+  },
   "page_landingWelcome_installSteps_desktop_install": {
     "message": "Make sure IPFS Desktop is running. Don't have it installed? <0>Download IPFS Desktop now.</0>",
     "description": "Install steps copy (page_landingWelcome_installSteps_desktop_install)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -29,7 +29,7 @@
   },
   "panel_statusSwarmPeers": {
     "message": "Peers",
-    "description": "A label in Node status section of Browser Action pop-up, also used as Welcome ready message button text for opening Web UI peers page (panel_statusSwarmPeers)"
+    "description": "A label in Node status section of Browser Action pop-up (panel_statusSwarmPeers)"
   },
   "panel_statusSwarmPeersTitle": {
     "message": "The number of other IPFS nodes you can connect to",
@@ -618,6 +618,10 @@
   "page_landingWelcome_welcome_files": {
     "message": "Files",
     "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_files)"
+  },
+  "page_landingWelcome_welcome_peers": {
+    "message": "Peers",
+    "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_peers)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS is not running",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -40,7 +40,7 @@
     "description": "A menu item in Browser Action pop-up (panel_quickImport)"
   },
   "panel_openWebui": {
-    "message": "Open Web UI",
+    "message": "View Node Status",
     "description": "A menu item in Browser Action pop-up (panel_openWebui)"
   },
   "panel_redirectToggle": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -40,7 +40,7 @@
     "description": "A menu item in Browser Action pop-up (panel_quickImport)"
   },
   "panel_openWebui": {
-    "message": "View Node Status",
+    "message": "Open Web UI",
     "description": "A menu item in Browser Action pop-up (panel_openWebui)"
   },
   "panel_redirectToggle": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -619,10 +619,6 @@
     "message": "Files",
     "description": "Ready message button text for opening Web UI files page (page_landingWelcome_welcome_files)"
   },
-  "page_landingWelcome_welcome_discover": {
-    "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
-  },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS is not running",
     "description": "Install steps title (page_landingWelcome_installSteps_notRunning_title)"
@@ -644,36 +640,56 @@
     "description": "Install steps copy (page_landingWelcome_installSteps_cli_install)"
   },
   "page_landingWelcome_resources_title_new_ipfs": {
-    "message": "New to IPFS?",
+    "message": "Learn about IPFS",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
-    "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
+    "message": "Read about <0>IPFS Companion's features</0>",
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
-  "page_landingWelcome_resources_title_discover": {
-    "message": "Discover!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+  "page_landingWelcome_resources_new_ipfs_concepts": {
+    "message": "Learn basic concepts in the <0>How IPFS Works</0> guide",
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_concepts)"
   },
-  "page_landingWelcome_resources_discover": {
-    "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+  "page_landingWelcome_resources_new_ipfs_docs": {
+    "message": "Visit the <0>IPFS documentation site</0> to dig deeper",
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
-    "message": "Got questions?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+  "page_landingWelcome_resources_title_build": {
+    "message": "Build on IPFS",
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_got_questions": {
-    "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+  "page_landingWelcome_resources_build_tutorials": {
+    "message": "Find <0>how-tos and tutorials</0> to help get you started",
+    "description": "Resources copy (page_landingWelcome_resources_build_tutorials)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
-    "message": "Want to help?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+  "page_landingWelcome_resources_build_examples": {
+    "message": "See what <0>awesome things</0> others are building with IPFS",
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_want_to_help": {
-    "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+  "page_landingWelcome_resources_title_get_help": {
+    "message": "Get help",
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
+  },
+  "page_landingWelcome_resources_get_help": {
+    "message": "Ask questions and discuss IPFS in the <0>official forums</0>",
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
+  },
+  "page_landingWelcome_resources_title_community": {
+    "message": "Join the community",
+    "description": "Community title (page_landingWelcome_resources_title_community)"
+  },
+  "page_landingWelcome_resources_community_contribute": {
+    "message": "<0>Contribute</0> with code, documentation, and more",
+    "description": "Community copy (page_landingWelcome_resources_community_contribute)"
+  },
+  "page_landingWelcome_resources_community_translate": {
+    "message": "<0>Translate</0> IPFS into your favorite language",
+    "description": "Community copy (page_landingWelcome_resources_community_translate)"
+  },
+  "page_landingWelcome_resources_community_resources": {
+    "message": "Explore all <0>IPFS community resources</0>",
+    "description": "Community copy (page_landingWelcome_resources_community_resources)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "Why IPFS?",

--- a/add-on/_locales/es/messages.json
+++ b/add-on/_locales/es/messages.json
@@ -663,13 +663,13 @@
     "message": "Únete a la <0>Comunidad de IPFS</0>! Contribuye con <1>código</1>, <2>documentación</2>, <3>traducciones</3> o ayuda <4>apoyando a otros usuarios</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "Demo Alfa de IPFS",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "La Web Permanente",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Proyectos Relacionados",

--- a/add-on/_locales/es/messages.json
+++ b/add-on/_locales/es/messages.json
@@ -611,9 +611,9 @@
     "message": "En este momento su nodo está conectado a <0>$1</0> pares.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Descubra lo que puede <0>hacer con Companion</0> y sumérjase en la red distribuida con IPFS",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "¿Nuevo en IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Lea la <0>documentación</0> para conocer los <1>conceptos</1> básicos y trabajar con IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Descubrir!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Encuentra <0>recursos útiles</0> para usar IPFS y <1>construir cosas</1> sobre él.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "¿Tienes preguntas?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visita el <0>foro de discusión y soporte</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "¿Quieres ayudar?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Únete a la <0>Comunidad de IPFS</0>! Contribuye con <1>código</1>, <2>documentación</2>, <3>traducciones</3> o ayuda <4>apoyando a otros usuarios</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "Demo Alfa de IPFS",

--- a/add-on/_locales/fi/messages.json
+++ b/add-on/_locales/fi/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Related Projects",

--- a/add-on/_locales/fi/messages.json
+++ b/add-on/_locales/fi/messages.json
@@ -611,9 +611,9 @@
     "message": "Juuri nyt solmusi on yhteydessä <0>$1</0> vertaiseen.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS ei vaikuta olevan suorituksessa",
@@ -635,33 +635,33 @@
     "message": "Onko IPFS uusi tuttavuus?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Löydä?",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Kysymyksiä?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Haluatko auttaa?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/fr/messages.json
+++ b/add-on/_locales/fr/messages.json
@@ -663,13 +663,13 @@
     "message": "Rejoignez la <0>communité IPFS</0>! Contribuez au <1>code</1>, à la <2>documentation</2>, aux<3>tranductions</3> ou en venant en <4>aide aux autres utilisateurs</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "Démo Alpha IPFS",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Le Web Permanent",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Projets en relation",

--- a/add-on/_locales/fr/messages.json
+++ b/add-on/_locales/fr/messages.json
@@ -611,9 +611,9 @@
     "message": "Votre nœud est actuellement connecté à <0>$1</0> pairs.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Découvrez ce que vous <0>pouvez faire avec Compagnon </0> et plongez dans le web distribué avec IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS ne semble pas être en cours d'execution",
@@ -635,33 +635,33 @@
     "message": "Nouveau sur IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Lisez la <0>documentation</0> pour apprendre les <1>concepts</1> de base et travailler avec IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Découvrir!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Trouvez des <0>resources utiles</0> pour utiliser IPFS et <1>créer des choses</1> basées dessus.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Des questions?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visitez le forum <0>Discussion et Support </0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Vous souhaitez nous aider?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Rejoignez la <0>communité IPFS</0>! Contribuez au <1>code</1>, à la <2>documentation</2>, aux<3>tranductions</3> ou en venant en <4>aide aux autres utilisateurs</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "Démo Alpha IPFS",

--- a/add-on/_locales/hu/messages.json
+++ b/add-on/_locales/hu/messages.json
@@ -611,9 +611,9 @@
     "message": "Right now your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "New to IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Discover!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Got questions?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Want to help?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/hu/messages.json
+++ b/add-on/_locales/hu/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Related Projects",

--- a/add-on/_locales/id/messages.json
+++ b/add-on/_locales/id/messages.json
@@ -611,9 +611,9 @@
     "message": "Right now your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "New to IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Discover!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Got questions?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Want to help?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/id/messages.json
+++ b/add-on/_locales/id/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Related Projects",

--- a/add-on/_locales/it/messages.json
+++ b/add-on/_locales/it/messages.json
@@ -663,13 +663,13 @@
     "message": "Unisciti alla <0>Comunitià IPFS</0>! Contribuisci con <1>codice</1>, <2>documentazione</2>, <3>traduzioni</3> o dai <4>supporto ad altri utenti</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "Demo Alpha di IPFS",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Il Web Permanente",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Progetti simili ",

--- a/add-on/_locales/it/messages.json
+++ b/add-on/_locales/it/messages.json
@@ -611,9 +611,9 @@
     "message": "Al momento il tuo nodo è connesso a <0>$1</0> nodi.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Scopri cosa <0>puoi fare con Companion</0> e tuffati nel web distribuito con IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "Sembra che IPFS non sia in esecuzione",
@@ -635,33 +635,33 @@
     "message": "Nuovo to IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Leggi la <0>documentazione</0> per scoprire i <1>concetti</1> base e lavorare con IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Scopri!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Trova <0>risorse utili</0> per usare e <1>costruire cose</1> con IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Domande?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visita il <0>Forum di Discussione e Supporto</0>",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Hai bisogno di aiuto?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Unisciti alla <0>Comunitià IPFS</0>! Contribuisci con <1>codice</1>, <2>documentazione</2>, <3>traduzioni</3> o dai <4>supporto ad altri utenti</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "Demo Alpha di IPFS",

--- a/add-on/_locales/ja_JP/messages.json
+++ b/add-on/_locales/ja_JP/messages.json
@@ -611,9 +611,9 @@
     "message": "現在、あなたのノードは<0>$1</0>ピアに接続されています。",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "<0>Companionでできること</0>を見つけて、IPFSで分散Webに飛び込みましょう！",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFSが実行されていないようです",
@@ -635,33 +635,33 @@
     "message": "IPFSは初めてですか？",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "<0>ドキュメント</0>を読んで、基本的な<1>概念</1>とIPFSの操作について学びます。",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "発見！",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "IPFSを使用し、その上で<1>物事を構築する</1>ための<0>有用なリソース</0>を見つけます。",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "質問がありますか？",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "<0>ディスカッションおよびサポートフォーラム</0>にアクセスしてください。",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "助けたい？",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "<0> IPFSコミュニティ</0>に参加しましょう！ <1>コード</1>、<2>ドキュメント</2>、<3>翻訳</3>または<4>他のユーザーのサポート</4>による支援で貢献してください。",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS アルファデモ",

--- a/add-on/_locales/ja_JP/messages.json
+++ b/add-on/_locales/ja_JP/messages.json
@@ -663,13 +663,13 @@
     "message": "<0> IPFSコミュニティ</0>に参加しましょう！ <1>コード</1>、<2>ドキュメント</2>、<3>翻訳</3>または<4>他のユーザーのサポート</4>による支援で貢献してください。",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS アルファデモ",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "パーマネントウェブ",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "関連プロジェクト",

--- a/add-on/_locales/ko_KR/messages.json
+++ b/add-on/_locales/ko_KR/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS 알파 데모",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "영구적인 웹",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "연관된 프로젝트",

--- a/add-on/_locales/ko_KR/messages.json
+++ b/add-on/_locales/ko_KR/messages.json
@@ -611,9 +611,9 @@
     "message": "Right now your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS가 응답하지 않습니다",
@@ -635,33 +635,33 @@
     "message": "IPFS가 처음이세요?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Discover!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "질문이 있으신가요?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "도움이 필요하신 가요?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS 알파 데모",

--- a/add-on/_locales/nl/messages.json
+++ b/add-on/_locales/nl/messages.json
@@ -663,13 +663,13 @@
     "message": "Word lid van de <0>IPFS-community</0>! Draag bij met <1>code</1>, <2>documentatie</2>, <3>vertalingen</3>of help door<4>andere gebruikers te ondersteunen</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Het permanente web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Verwante projecten",

--- a/add-on/_locales/nl/messages.json
+++ b/add-on/_locales/nl/messages.json
@@ -611,9 +611,9 @@
     "message": "Je node is verbonden met <0> $1 </0>peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Ontdek wat je <0>met de Companion kan doen </0> en duik in het gedistribueerd web met IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS lijkt niet te draaien",
@@ -635,33 +635,33 @@
     "message": "Onbekend met IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Lees de <0>documentatie</0> om de <1>basis concepten</1> van IPFS te leren.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Ontdek!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Vind <0>hulp bronnen</0> voor het gebruik van IPFS of <1>bouw er op</1>.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Vragen?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Bezoek het <0>discussie- en ondersteuningsforum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Wil je helpen?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Word lid van de <0>IPFS-community</0>! Draag bij met <1>code</1>, <2>documentatie</2>, <3>vertalingen</3>of help door<4>andere gebruikers te ondersteunen</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha demo",

--- a/add-on/_locales/no/messages.json
+++ b/add-on/_locales/no/messages.json
@@ -611,9 +611,9 @@
     "message": "Akkurat nå er din node tilkoblet <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Oppdag hva du <0>kan gjøre med Companion</0> og dykk inn i det distribuerte nettet med IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "Ny på IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Les <0>dokumentasjonen </0> for å lære om de grunnleggende <1>konseptene</1>, og jobbe med IPFS",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Utforsk!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Finn <0>nyttige ressurser</0> for å bruke IPFS, og <1>bygge ting</1>på toppen av det.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Har du spørsmål?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Besøk <0>diskusjons- og supportforumet</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Ønsker du å hjelpe til?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Bli med i <0>IPFS-fellesskapet</0>! Bidra med <1>kode</1>, <2>dokumentasjon</2>, <3>oversettelser</3> eller hjelp ved å <4>støtte andre brukere</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/no/messages.json
+++ b/add-on/_locales/no/messages.json
@@ -663,13 +663,13 @@
     "message": "Bli med i <0>IPFS-fellesskapet</0>! Bidra med <1>kode</1>, <2>dokumentasjon</2>, <3>oversettelser</3> eller hjelp ved å <4>støtte andre brukere</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Det permanente nettet",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Relaterte prosjekter",

--- a/add-on/_locales/pl/messages.json
+++ b/add-on/_locales/pl/messages.json
@@ -663,13 +663,13 @@
     "message": "Dołącz do <0>społeczności IPFS</0>! Ulepszaj <1>kod</1>, <2>dokumentację</2>, <3>tłumaczenia</3> lub pomagaj <4>odpowiadając na pytania i problemy</4> innych użytkowników.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo (ang.)",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web (ang.)",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Powiązane projekty",

--- a/add-on/_locales/pl/messages.json
+++ b/add-on/_locales/pl/messages.json
@@ -611,9 +611,9 @@
     "message": "Twój węzeł jest połączony z <0>$1</0> innymi.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Odkryj co <0>możesz zrobić dzięki temu rozszerzeniu</0> i rozpocznij przygodę z IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS nie jest dostępny",
@@ -635,33 +635,33 @@
     "message": "Zaczynasz z IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Przeczytaj <0>dokumentację</0> i zapoznaj się z podstawową  <1>terminologią</1> oraz pracą z IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Odkryj więcej!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Poznaj <0>istniejące zasoby</0> związane z użytkowaniem i <1>tworzeniem rozwiązań</1> opartych o IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Masz pytania?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Odwiedź <0>forum dyskusyjne</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Chcesz pomóc?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Dołącz do <0>społeczności IPFS</0>! Ulepszaj <1>kod</1>, <2>dokumentację</2>, <3>tłumaczenia</3> lub pomagaj <4>odpowiadając na pytania i problemy</4> innych użytkowników.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo (ang.)",

--- a/add-on/_locales/pt/messages.json
+++ b/add-on/_locales/pt/messages.json
@@ -611,9 +611,9 @@
     "message": "Agora mesmo o seu nó está conectado a to <0>$1</0> pares.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Descubra o que <0>pode fazer com o Companion</0> e mergulhe na rede distribuída com o IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "Parece que o IPFS não está em execução",
@@ -635,33 +635,33 @@
     "message": "Novo no IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Leia a <0>documentação</0> para aprender os <1>conceitos</1> básicos e a trabalhar com o IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Descubra!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Encontre <0>recursos úteis</0> para usar o IPFS e como <1>criar coisas</1> nele.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Tem questões?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visite o <0>fórum de ajuda e discussão</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Quer ajudar?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Junte-se à <0>comunidade IPFS</0>! Contribua com <1>código</1>, <2>documentação</2>, <3>traduções</3>  ou ajude <4>outros utilizadores</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/pt/messages.json
+++ b/add-on/_locales/pt/messages.json
@@ -663,13 +663,13 @@
     "message": "Junte-se à <0>comunidade IPFS</0>! Contribua com <1>código</1>, <2>documentação</2>, <3>traduções</3>  ou ajude <4>outros utilizadores</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "A Web Permanente",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Projetos relacionados",

--- a/add-on/_locales/pt_BR/messages.json
+++ b/add-on/_locales/pt_BR/messages.json
@@ -663,13 +663,13 @@
     "message": "Junte-se à comunidade IPFS<0>! Contribua com <1>código</1>, <2>documentação</2>, <3>traduções</3> ou ajude <4>dando apoio a outros usuários</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "Demo do IPFS versão alfa",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "A Web Permanente",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Projetos relacionados",

--- a/add-on/_locales/pt_BR/messages.json
+++ b/add-on/_locales/pt_BR/messages.json
@@ -611,9 +611,9 @@
     "message": "Neste momento seu nó está conectado a <0>$1</0> pares.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Descubra o que você <0>pode fazer com o Companion</0> e mergulhe na web distribuída com o IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "Primeira vez no IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Leia a <0>documentação</0> para aprender sobre os <1>conceitos</1> básicos e como usar o IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Descubra!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Encontre <0>recursos úteis</0> para usar o IPFS e <1>criar coisas</1> com ele.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Tem perguntas?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visite o <0>fórum de discussão e suporte</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Quer ajudar?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Junte-se à comunidade IPFS<0>! Contribua com <1>código</1>, <2>documentação</2>, <3>traduções</3> ou ajude <4>dando apoio a outros usuários</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "Demo do IPFS versão alfa",

--- a/add-on/_locales/ro/messages.json
+++ b/add-on/_locales/ro/messages.json
@@ -611,9 +611,9 @@
     "message": "Right now your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "New to IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Discover!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Got questions?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Want to help?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/ro/messages.json
+++ b/add-on/_locales/ro/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Related Projects",

--- a/add-on/_locales/ru/messages.json
+++ b/add-on/_locales/ru/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Альфа версия",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Связанные проекты",

--- a/add-on/_locales/ru/messages.json
+++ b/add-on/_locales/ru/messages.json
@@ -611,9 +611,9 @@
     "message": "Прямо сейчас ваш узел присоединён к <0>$1</0> пирам.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "Новичок в IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Исследуй!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Есть вопросы?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Хотите помочь?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Альфа версия",

--- a/add-on/_locales/sv/messages.json
+++ b/add-on/_locales/sv/messages.json
@@ -611,9 +611,9 @@
     "message": "Din nod är just nu kopplad till <0>$1</0> andra noder.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Upptäck vad du <0>kan göra med hjälparen</0> och dyk in i den distribuerade webben med IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "Ny till IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Läs <0>dokumentationen</0> för att lära dig om de grundläggande <1>koncepten</1> och att arbeta med IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Upptäck!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Hitta <0>användbara resurser</0> för användning av IPFS och att <1>bygga saker</1> med det.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Har du frågor?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Besök <0>diskussion och support-forumet</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Vill du hjälpa till?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Gå med i <0>IPFS-gemenskapen</0>! Bidra med <1>kod</1>, <2>dokumentation</2>, <3>översättningar</3> eller hjälp genom att <4>stödja andra användare</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS alfa-demo",

--- a/add-on/_locales/sv/messages.json
+++ b/add-on/_locales/sv/messages.json
@@ -663,13 +663,13 @@
     "message": "Gå med i <0>IPFS-gemenskapen</0>! Bidra med <1>kod</1>, <2>dokumentation</2>, <3>översättningar</3> eller hjälp genom att <4>stödja andra användare</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS alfa-demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "Den permanenta webben",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Relaterade projekt",

--- a/add-on/_locales/tr/messages.json
+++ b/add-on/_locales/tr/messages.json
@@ -611,9 +611,9 @@
     "message": "Right now your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -635,33 +635,33 @@
     "message": "New to IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Keşfedin!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "Got questions?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "Want to help?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/_locales/tr/messages.json
+++ b/add-on/_locales/tr/messages.json
@@ -663,13 +663,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "İlişkili Projeler",

--- a/add-on/_locales/zh_CN/messages.json
+++ b/add-on/_locales/zh_CN/messages.json
@@ -663,13 +663,13 @@
     "message": "加入<0>IPFS社区</0>！贡献<1>代码</1>，<2>文档</2>，<3>翻译</3>或通过<4>给其他用户提供支持</4>来帮忙。",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha 演示",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "永久性网络",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "相关项目",

--- a/add-on/_locales/zh_CN/messages.json
+++ b/add-on/_locales/zh_CN/messages.json
@@ -611,9 +611,9 @@
     "message": "当前您的节点已经连接上<0>$1</0>个节点",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "发现什么是你 <0>通过伴侣能做的</0> 并通过 IPFS 参与到分布式 web ！",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS 似乎没有运行",
@@ -635,33 +635,33 @@
     "message": "刚接触 IPFS？",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "阅读<0>文档</0>来学习基本的<1>概念</1>，开始 IPFS 相关的工作",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "发现！",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "在它上面寻找使用IPFS的 <0>有用资源</0> 和 <1>正在做的事</1> 。",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "遇到问题？",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "浏览<0>讨论与支持论坛</0>。",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "需要帮助？",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "加入<0>IPFS社区</0>！贡献<1>代码</1>，<2>文档</2>，<3>翻译</3>或通过<4>给其他用户提供支持</4>来帮忙。",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha 演示",

--- a/add-on/_locales/zh_TW/messages.json
+++ b/add-on/_locales/zh_TW/messages.json
@@ -603,13 +603,13 @@
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
     "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
   },
-  "page_landingWelcome_videos_alpha_demo": {
+  "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",
-    "description": "Videos section title (page_landingWelcome_videos_alpha_demo)"
+    "description": "Videos section title (page_landingWelcome_videos_why_ipfs)"
   },
-  "page_landingWelcome_videos_permanent_web": {
+  "page_landingWelcome_videos_how_ipfs_works": {
     "message": "The Permanent Web",
-    "description": "Videos section title (page_landingWelcome_videos_permanent_web)"
+    "description": "Videos section title (page_landingWelcome_videos_how_ipfs_works)"
   },
   "page_landingWelcome_projects_title": {
     "message": "Related Projects",

--- a/add-on/_locales/zh_TW/messages.json
+++ b/add-on/_locales/zh_TW/messages.json
@@ -551,9 +551,9 @@
     "message": "Right now your node is connected to <0>$1</0> peers.",
     "description": "Ready message copy (page_landingWelcome_welcome_peers)"
   },
-  "page_landingWelcome_welcome_discover": {
+  "page_landingWelcome_resources_new_ipfs_companion_features": {
     "message": "Discover what you <0>can do with Companion</0> and dive into the distributed web with IPFS!",
-    "description": "Ready message copy (page_landingWelcome_welcome_discover)"
+    "description": "Ready message copy (page_landingWelcome_resources_new_ipfs_companion_features)"
   },
   "page_landingWelcome_installSteps_notRunning_title": {
     "message": "IPFS does not seem to be running",
@@ -575,33 +575,33 @@
     "message": "New to IPFS?",
     "description": "Resources title (page_landingWelcome_resources_title_new_ipfs)"
   },
-  "page_landingWelcome_resources_new_ipfs": {
+  "page_landingWelcome_resources_new_ipfs_docs": {
     "message": "Read the <0>documentation</0> to learn about the basic <1>concepts</1> and working with IPFS.",
-    "description": "Resources copy (page_landingWelcome_resources_new_ipfs)"
+    "description": "Resources copy (page_landingWelcome_resources_new_ipfs_docs)"
   },
-  "page_landingWelcome_resources_title_discover": {
+  "page_landingWelcome_resources_title_build": {
     "message": "Discover!",
-    "description": "Resources title (page_landingWelcome_resources_title_discover)"
+    "description": "Resources title (page_landingWelcome_resources_title_build)"
   },
-  "page_landingWelcome_resources_discover": {
+  "page_landingWelcome_resources_build_examples": {
     "message": "Find <0>useful resources</0> for using IPFS and <1>building things</1> on top of it.",
-    "description": "Resources copy (page_landingWelcome_resources_discover)"
+    "description": "Resources copy (page_landingWelcome_resources_build_examples)"
   },
-  "page_landingWelcome_resources_title_got_questions": {
+  "page_landingWelcome_resources_title_get_help": {
     "message": "遇到問題?",
-    "description": "Resources title (page_landingWelcome_resources_title_got_questions)"
+    "description": "Resources title (page_landingWelcome_resources_title_get_help)"
   },
-  "page_landingWelcome_resources_got_questions": {
+  "page_landingWelcome_resources_get_help": {
     "message": "Visit the <0>Discussion and Support Forum</0>.",
-    "description": "Resources copy (page_landingWelcome_resources_got_questions)"
+    "description": "Resources copy (page_landingWelcome_resources_get_help)"
   },
-  "page_landingWelcome_resources_title_want_to_help": {
+  "page_landingWelcome_resources_title_community": {
     "message": "需要幫助?",
-    "description": "Resources title (page_landingWelcome_resources_title_want_to_help)"
+    "description": "Resources title (page_landingWelcome_resources_title_community)"
   },
-  "page_landingWelcome_resources_want_to_help": {
+  "page_landingWelcome_resources_community_resources": {
     "message": "Join the <0>IPFS Community</0>! Contribute with <1>code</1>, <2>documentation</2>, <3>translations</3> or help by <4>supporting other users</4>.",
-    "description": "Resources copy (page_landingWelcome_resources_want_to_help)"
+    "description": "Resources copy (page_landingWelcome_resources_community)"
   },
   "page_landingWelcome_videos_why_ipfs": {
     "message": "IPFS Alpha Demo",

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -81,9 +81,8 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
     <div class="w-80 flex flex-column justify-center">
       <div class="mb4 flex flex-column justify-center items-center">
         ${checkmarkSvg()}
-        <p class="mt2 mb0 f3">${i18n.getMessage('page_landingWelcome_welcome_title')}</p>
+        <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
-      <p class="${copyClass}">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       <p class="${copyClass} mb4">${renderTranslatedLinks('page_landingWelcome_welcome_discover', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</p>
       <div class="mt4 f5 flex justify-center items-center">
         <button class="pv3 ph4 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -79,14 +79,14 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
 
   return html`
     <div class="w-80 flex flex-column justify-center">
-      <div class="mb4 flex flex-column justify-center items-center">
+      <div class="mb3 flex flex-column justify-center items-center">
         ${checkmarkSvg()}
         <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
-      <div class="mt4 f5 flex justify-center items-center">
+      <div class="mt3 f5 flex justify-center items-center">
         <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Browse Files</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Explore Peers</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -103,7 +103,7 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="120" fill="#ffffff"><path d="M86.39 70.49L58.6 22.37a7.13 7.13 0 00-12.37 0L18.45 70.49a7.15 7.15 0 006.19 10.72H80.2a7.15 7.15 0 006.19-10.72zm-2.26 5.84a4.48 4.48 0 01-3.93 2.28H24.64a4.55 4.55 0 01-3.94-6.82l27.78-48.12a4.55 4.55 0 017.87 0l27.78 48.12a4.45 4.45 0 010 4.54z"/><path d="M55.16 64.24h-5.49a.76.76 0 00-.75.75v5.49a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V65a.76.76 0 00-.75-.76zm-.75 5.49h-4v-4h4zm.75-32.02h-5.49a.76.76 0 00-.75.75v21.76a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V38.46a.76.76 0 00-.75-.75zm-.75 21.76h-4V39.21h4z"/></svg>
         <p class="mt2 mb0 f3 tc">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
       </div>
-      <p class="mb2 aqua b f4 lh-title">IPFS Desktop users</p>
+      <p class="mb2 aqua b f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_desktop_title')}</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="mb2 aqua b f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/how-to/command-line-quick-start/'], `target="_blank" class="${anchorClass}"`)}</p>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -75,9 +75,9 @@ const renderWelcome = (i18n, peerCount, openWebUi) => {
         <p class="mt0 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/')}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/files')}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/peers')}>${i18n.getMessage('page_landingWelcome_welcome_peers')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/')}>${i18n.getMessage('page_landingWelcome_welcome_statusButton_text')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/files')}>${i18n.getMessage('page_landingWelcome_welcome_filesButton_text')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/peers')}>${i18n.getMessage('page_landingWelcome_welcome_peersButton_text')}</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -160,7 +160,7 @@ const renderVideos = (i18n) => {
       <div class="flex flex-column mr1">
         <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}</p>
         <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=zE_WSLbqqvo" target="_blank">
-          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/zb2rhoo8LXEwek8HLLYsXhra9YuYxRDEun3rHRc18mLvK3A5w" alt="${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}" />
+          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/QmS4Ae3WBzkaANSPD82Dsax8QuJQpS4TEfaC53FMPkdxMA" alt="${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}" />
           ${overlayDiv()}
           ${playSvg()}
         </a>
@@ -169,7 +169,7 @@ const renderVideos = (i18n) => {
       <div class="flex flex-column">
         <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_permanent_web')}</p>
         <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=0IGzEYixJHk" target="_blank">
-          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/zb2rhbCqh6W5Veot1sgZC5v7oLMnrkxq8ikd7auyy9UKSLBBa" alt="${i18n.getMessage('page_landingWelcome_videos_permanent_web')}" />
+          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/QmP5uNwDjYZmoLxw8zJeeheSJEnBKYpFn4uuEQQWFYGKvM" alt="${i18n.getMessage('page_landingWelcome_videos_permanent_web')}" />
           ${overlayDiv()}
           ${playSvg()}
         </a>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -83,9 +83,10 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
         ${checkmarkSvg()}
         <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
-      <p class="${copyClass} mb4">${renderTranslatedLinks('page_landingWelcome_welcome_discover', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</p>
       <div class="mt4 f5 flex justify-center items-center">
-        <button class="pv3 ph4 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
       </div>
     </div>
   `
@@ -123,6 +124,7 @@ const renderResources = (i18n) => {
   return html`
     <div class="w-80 mv4 navy f5">
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_new_ipfs')}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_welcome_discover', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs', ['https://docs.ipfs.io', 'https://docs.ipfs.io/guides/concepts'], `target="_blank" class="${anchorClass}"`)}</p>
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_discover')}</p>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -104,9 +104,9 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
         <p class="mt2 mb0 f3 tc">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
       </div>
       <p class="mb2 aqua b f4 lh-title">IPFS Desktop users</p>
-      <p class="${copyClass}">Make sure your copy of IPFS Desktop is running. Don't have IPFS Desktop? ${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="mb2 aqua b f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
-      <p class="${copyClass}">If you already have IPFS installed on the command line, start a daemon by entering <code class="yellow">ipfs daemon</code> in your terminal. Don't have it installed yet? ${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
     </div>
   `
 }
@@ -158,18 +158,18 @@ const renderVideos = (i18n) => {
   return html`
     <div class="w-80 flex flex-column flex-row-ns justify-between-ns aqua f5">
       <div class="flex flex-column mr1">
-        <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}</p>
+        <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_why_ipfs')}</p>
         <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=zE_WSLbqqvo" target="_blank">
-          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/QmS4Ae3WBzkaANSPD82Dsax8QuJQpS4TEfaC53FMPkdxMA" alt="${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}" />
+          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/QmS4Ae3WBzkaANSPD82Dsax8QuJQpS4TEfaC53FMPkdxMA" alt="${i18n.getMessage('page_landingWelcome_videos_why_ipfs')}" />
           ${overlayDiv()}
           ${playSvg()}
         </a>
       </div>
 
       <div class="flex flex-column">
-        <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_permanent_web')}</p>
+        <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_how_ipfs_works')}</p>
         <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=0IGzEYixJHk" target="_blank">
-          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/QmP5uNwDjYZmoLxw8zJeeheSJEnBKYpFn4uuEQQWFYGKvM" alt="${i18n.getMessage('page_landingWelcome_videos_permanent_web')}" />
+          <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/QmP5uNwDjYZmoLxw8zJeeheSJEnBKYpFn4uuEQQWFYGKvM" alt="${i18n.getMessage('page_landingWelcome_videos_how_ipfs_works')}" />
           ${overlayDiv()}
           ${playSvg()}
         </a>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -99,7 +99,10 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
 
   return html`
     <div class="w-80 mt3 flex flex-column transition-all ${stateUnknown && 'state-unknown'}">
-      <p class="mt0 mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
+      <div class="mb4 flex flex-column justify-center items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="120" fill="#ffffff"><path d="M86.39 70.49L58.6 22.37a7.13 7.13 0 00-12.37 0L18.45 70.49a7.15 7.15 0 006.19 10.72H80.2a7.15 7.15 0 006.19-10.72zm-2.26 5.84a4.48 4.48 0 01-3.93 2.28H24.64a4.55 4.55 0 01-3.94-6.82l27.78-48.12a4.55 4.55 0 017.87 0l27.78 48.12a4.45 4.45 0 010 4.54z"/><path d="M55.16 64.24h-5.49a.76.76 0 00-.75.75v5.49a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V65a.76.76 0 00-.75-.76zm-.75 5.49h-4v-4h4zm.75-32.02h-5.49a.76.76 0 00-.75.75v21.76a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V38.46a.76.76 0 00-.75-.75zm-.75 21.76h-4V39.21h4z"/></svg>
+        <p class="mt2 mb0 f3 tc">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
+      </div>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -124,24 +124,28 @@ const renderResources = (i18n) => {
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_new_ipfs')}</p>
       <ul class="${copyClass}">
-        <li>${renderTranslatedLinks('page_landingWelcome_welcome_discover', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</li>
-        <li>${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs', ['https://docs.ipfs.io', 'https://docs.ipfs.io/guides/concepts'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs_companion_features', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs_concepts', ['https://docs.ipfs.io/concepts/how-ipfs-works/'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs_docs', ['https://docs.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</li>
       </ul>
 
-      <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_discover')}</p>
+      <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_build')}</p>
       <ul class="${copyClass}">
-        <li>${renderTranslatedLinks('page_landingWelcome_resources_discover', ['https://awesome.ipfs.io', 'https://github.com/ipfs/ipfs#project-links'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_build_tutorials', ['https://docs.ipfs.io/how-to/'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_build_examples', ['https://awesome.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</li>
       </ul>
 
-      <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_got_questions')}</p>
+      <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_get_help')}</p>
       <ul class="${copyClass}">
-        <li>${renderTranslatedLinks('page_landingWelcome_resources_got_questions', ['https://discuss.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_get_help', ['https://discuss.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</li>
       </ul>
 
-      <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_want_to_help')}</p>
+      <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_community')}</p>
       <ul class="${copyClass}">
-        <li>${renderTranslatedLinks('page_landingWelcome_resources_want_to_help', ['https://github.com/ipfs/community/#community', 'https://github.com/ipfs/ipfs#project-links', 'https://github.com/ipfs/docs', 'https://github.com/ipfs/i18n#ipfs-translation-project--%EF%B8%8F', 'https://discuss.ipfs.io/c/help'], `target="_blank" class="${anchorClass}"`)}</li>
-      </ul>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_community_contribute', ['https://docs.ipfs.io/community/contribute/ways-to-contribute/'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_community_translate', ['https://www.transifex.com/ipfs/public/'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_community_resources', ['https://docs.ipfs.io/community/'], `target="_blank" class="${anchorClass}"`)}</li>
+    </ul>
     </div>
   `
 }

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -84,9 +84,9 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
         <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Status</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Files</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Peers</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_statusSwarmPeers')}</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -84,7 +84,7 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
         <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_openWebui')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>View Node Status</button>
         <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Browse Files</button>
         <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Explore Peers</button>
       </div>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -77,7 +77,7 @@ const renderWelcome = (i18n, peerCount, openWebUi) => {
       <div class="mt3 f5 flex justify-center items-center">
         <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/')}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
         <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/files')}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/peers')}>${i18n.getMessage('panel_statusSwarmPeers')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/peers')}>${i18n.getMessage('page_landingWelcome_welcome_peers')}</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -84,9 +84,9 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
         <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>View Node Status</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Browse Files</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Explore Peers</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Status</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Files</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>Peers</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -106,7 +106,7 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
       <p class="mb2 aqua b f4 lh-title">IPFS Desktop users</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
       <p class="mb2 aqua b f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/how-to/command-line-quick-start/'], `target="_blank" class="${anchorClass}"`)}</p>
     </div>
   `
 }

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -12,6 +12,7 @@ const ipldLogo = '../../../images/ipld.svg'
 // Colors
 const colorIpfsLogo = '#57cbd0'
 const colorWhite = '#ffffff'
+const colorYellow = '#f39021'
 
 function createWelcomePage (i18n) {
   return function welcomePage (state, emit) {
@@ -49,7 +50,7 @@ const renderCompanionLogo = (i18n, isIpfsOnline) => {
   const stateUnknown = isIpfsOnline === null
 
   return html`
-    <div class="mt4 mb4 flex flex-column justify-center items-center transition-all ${stateUnknown && 'state-unknown'}">
+    <div class="mt4 mb2 flex flex-column justify-center items-center transition-all ${stateUnknown && 'state-unknown'}">
       ${logo({ path: logoPath, size: logoSize, isIpfsOnline: isIpfsOnline })}
       <p class="montserrat mt3 mb0 f2">${i18n.getMessage('page_landingWelcome_logo_title')}</p>
     </div>
@@ -59,29 +60,20 @@ const renderCompanionLogo = (i18n, isIpfsOnline) => {
 const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
   const anchorClass = 'aqua hover-white'
   const copyClass = 'mv0 tc lh-copy f5'
-  const svgWidth = 80
+  const svgWidth = 130
 
-  const checkmarkSvg = () => html`
-    <svg x="0px" y="0px" viewBox="0 0 84 84" width="${svgWidth}">
-      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g transform="translate(-802.000000, -218.000000)">
-          <g transform="translate(805.000000, 221.000000)">
-            <rect stroke="${colorIpfsLogo}" stroke-width="5" x="0" y="0" width="78" height="78" rx="39"/>
-            <g transform="translate(15.000000, 23.000000)" fill="${colorWhite}">
-              <rect transform="translate(10.747845, 24.447908) scale(-1, -1) rotate(-135.000000) translate(-10.747845, -24.447908) " x="-1" y="21.4479076" width="23.495689" height="6" rx="3"/>
-              <rect transform="translate(30.017983, 17.552092) scale(-1, -1) rotate(-45.000000) translate(-30.017983, -17.552092) " x="8.51798323" y="14.5520924" width="43" height="6" rx="3"/>
-            </g>
-          </g>
-        </g>
-      </g>
+  const nodeOnSvg = () => html`
+    <svg x="0px" y="0px" viewBox="0 0 100 100" width="${svgWidth}">
+      <path fill="${colorIpfsLogo}" d="M52.42 18.81A31.19 31.19 0 1083.6 50a31.22 31.22 0 00-31.18-31.19zm0 59.78A28.59 28.59 0 1181 50a28.62 28.62 0 01-28.58 28.59z"/>
+      <path fill="${colorWhite}" d="M66.49 35.87a.75.75 0 00-1.06 0L46.6 54.7l-7.2-7.2a.75.75 0 00-1.06 0l-3.92 3.92a.75.75 0 000 1.06l11.65 11.65a.75.75 0 001.06 0l23.28-23.28a.74.74 0 000-1.06zM46.6 62.54L36 52l2.86-2.86 7.2 7.2a.75.75 0 001.06 0L66 37.46l2.86 2.86z"/>
     </svg>
   `
 
   return html`
     <div class="w-80 flex flex-column justify-center">
       <div class="mb3 flex flex-column justify-center items-center">
-        ${checkmarkSvg()}
-        <p class="mt2 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
+        ${nodeOnSvg()}
+        <p class="mt0 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
         <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
@@ -96,12 +88,19 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
   const copyClass = 'mv0 white f5 lh-copy'
   const anchorClass = 'aqua hover-white'
   const stateUnknown = isIpfsOnline === null
+  const svgWidth = 130
+
+  const nodeOffSvg = () => html`
+    <svg x="0px" y="0px" viewBox="0 0 100 100" width="${svgWidth}">
+      <path fill="${colorYellow}" d="M82.84 71.14L55.06 23a5.84 5.84 0 00-10.12 0L17.16 71.14a5.85 5.85 0 005.06 8.77h55.56a5.85 5.85 0 005.06-8.77zm-30.1-.66h-5.48V65h5.48zm0-10.26h-5.48V38.46h5.48z"/>
+    </svg>
+  `
 
   return html`
-    <div class="w-80 mt3 flex flex-column transition-all ${stateUnknown && 'state-unknown'}">
+    <div class="w-80 mt0 flex flex-column transition-all ${stateUnknown && 'state-unknown'}">
       <div class="mb4 flex flex-column justify-center items-center">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="120" fill="#ffffff"><path d="M86.39 70.49L58.6 22.37a7.13 7.13 0 00-12.37 0L18.45 70.49a7.15 7.15 0 006.19 10.72H80.2a7.15 7.15 0 006.19-10.72zm-2.26 5.84a4.48 4.48 0 01-3.93 2.28H24.64a4.55 4.55 0 01-3.94-6.82l27.78-48.12a4.55 4.55 0 017.87 0l27.78 48.12a4.45 4.45 0 010 4.54z"/><path d="M55.16 64.24h-5.49a.76.76 0 00-.75.75v5.49a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V65a.76.76 0 00-.75-.76zm-.75 5.49h-4v-4h4zm.75-32.02h-5.49a.76.76 0 00-.75.75v21.76a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V38.46a.76.76 0 00-.75-.75zm-.75 21.76h-4V39.21h4z"/></svg>
-        <p class="mt2 mb0 f3 tc">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
+        ${nodeOffSvg()}
+        <p class="mt0 mb0 f3 tc">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
       </div>
       <p class="mb2 aqua b f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_desktop_title')}</p>
       <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -159,7 +159,7 @@ const renderVideos = (i18n) => {
     <div class="w-80 flex flex-column flex-row-ns justify-between-ns aqua f5">
       <div class="flex flex-column mr1">
         <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}</p>
-        <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=8CMxDNuuAiQ" target="_blank">
+        <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=zE_WSLbqqvo" target="_blank">
           <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/zb2rhoo8LXEwek8HLLYsXhra9YuYxRDEun3rHRc18mLvK3A5w" alt="${i18n.getMessage('page_landingWelcome_videos_alpha_demo')}" />
           ${overlayDiv()}
           ${playSvg()}
@@ -168,7 +168,7 @@ const renderVideos = (i18n) => {
 
       <div class="flex flex-column">
         <p class="ttu tracked f6 fw4 teal mt0 mb3">${i18n.getMessage('page_landingWelcome_videos_permanent_web')}</p>
-        <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=HUVmypx9HGI" target="_blank">
+        <a class="${anchorClass}" style="height: ${videoHeight}px" href="https://www.youtube.com/watch?feature=player_embedded&v=0IGzEYixJHk" target="_blank">
           <img width="${videoWidth}" height="${videoHeight}" src="https://ipfs.io/ipfs/zb2rhbCqh6W5Veot1sgZC5v7oLMnrkxq8ikd7auyy9UKSLBBa" alt="${i18n.getMessage('page_landingWelcome_videos_permanent_web')}" />
           ${overlayDiv()}
           ${playSvg()}

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -120,19 +120,28 @@ const renderResources = (i18n) => {
   const anchorClass = 'link underline-under hover-aqua'
 
   return html`
-    <div class="w-80 mv4 navy f5">
+    <div class="w-80 mt4 mb2 navy f5">
+
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_new_ipfs')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_welcome_discover', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs', ['https://docs.ipfs.io', 'https://docs.ipfs.io/guides/concepts'], `target="_blank" class="${anchorClass}"`)}</p>
+      <ul class="${copyClass}">
+        <li>${renderTranslatedLinks('page_landingWelcome_welcome_discover', ['https://github.com/ipfs-shipyard/ipfs-companion#features'], `target="_blank" class="${anchorClass}"`)}</li>
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_new_ipfs', ['https://docs.ipfs.io', 'https://docs.ipfs.io/guides/concepts'], `target="_blank" class="${anchorClass}"`)}</li>
+      </ul>
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_discover')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_resources_discover', ['https://awesome.ipfs.io', 'https://github.com/ipfs/ipfs#project-links'], `target="_blank" class="${anchorClass}"`)}</p>
+      <ul class="${copyClass}">
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_discover', ['https://awesome.ipfs.io', 'https://github.com/ipfs/ipfs#project-links'], `target="_blank" class="${anchorClass}"`)}</li>
+      </ul>
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_got_questions')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_resources_got_questions', ['https://discuss.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</p>
+      <ul class="${copyClass}">
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_got_questions', ['https://discuss.ipfs.io'], `target="_blank" class="${anchorClass}"`)}</li>
+      </ul>
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_want_to_help')}</p>
-      <p class="${copyClass} mv0">${renderTranslatedLinks('page_landingWelcome_resources_want_to_help', ['https://github.com/ipfs/community/#community', 'https://github.com/ipfs/ipfs#project-links', 'https://github.com/ipfs/docs', 'https://github.com/ipfs/i18n#ipfs-translation-project--%EF%B8%8F', 'https://discuss.ipfs.io/c/help'], `target="_blank" class="${anchorClass}"`)}</p>
+      <ul class="${copyClass}">
+        <li>${renderTranslatedLinks('page_landingWelcome_resources_want_to_help', ['https://github.com/ipfs/community/#community', 'https://github.com/ipfs/ipfs#project-links', 'https://github.com/ipfs/docs', 'https://github.com/ipfs/i18n#ipfs-translation-project--%EF%B8%8F', 'https://discuss.ipfs.io/c/help'], `target="_blank" class="${anchorClass}"`)}</li>
+      </ul>
     </div>
   `
 }

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -30,7 +30,7 @@ function createWelcomePage (i18n) {
           ${isIpfsOnline ? renderWelcome(i18n, peerCount, onOpenWebUiStatus) : renderInstallSteps(i18n, isIpfsOnline)}
         </div>
 
-        <div id="right-col" class="min-vh-100 flex flex-column justify-around items-center">
+        <div id="right-col" class="min-vh-100 w-100 flex flex-column justify-around items-center">
           ${renderResources(i18n)}
           ${renderVideos(i18n)}
           ${renderProjects(i18n)}
@@ -120,7 +120,7 @@ const renderResources = (i18n) => {
   const anchorClass = 'link underline-under hover-aqua'
 
   return html`
-    <div class="w-80 mt4 mb2 navy f5">
+    <div class="w-80 mt4 mb0 navy f5">
 
       <p class="${labelClass}">${i18n.getMessage('page_landingWelcome_resources_title_new_ipfs')}</p>
       <ul class="${copyClass}">

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -103,14 +103,10 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="120" fill="#ffffff"><path d="M86.39 70.49L58.6 22.37a7.13 7.13 0 00-12.37 0L18.45 70.49a7.15 7.15 0 006.19 10.72H80.2a7.15 7.15 0 006.19-10.72zm-2.26 5.84a4.48 4.48 0 01-3.93 2.28H24.64a4.55 4.55 0 01-3.94-6.82l27.78-48.12a4.55 4.55 0 017.87 0l27.78 48.12a4.45 4.45 0 010 4.54z"/><path d="M55.16 64.24h-5.49a.76.76 0 00-.75.75v5.49a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V65a.76.76 0 00-.75-.76zm-.75 5.49h-4v-4h4zm.75-32.02h-5.49a.76.76 0 00-.75.75v21.76a.76.76 0 00.75.75h5.49a.76.76 0 00.75-.75V38.46a.76.76 0 00-.75-.75zm-.75 21.76h-4V39.21h4z"/></svg>
         <p class="mt2 mb0 f3 tc">${i18n.getMessage('page_landingWelcome_installSteps_notRunning_title')}</p>
       </div>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
-      <p class="mb2 yellow f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
-      <p class="${copyClass}">${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
-      <div className='db w-100 mw6 mv3 pa3 bg-black-70 bt bw4 br2 snow f7'>
-        <code className='db'>$ ipfs daemon</code>
-        <code className='db'>Initializing daemon...</code>
-        <code className='db'>API server listening on /ip4/127.0.0.1/tcp/5001</code>
-      </div>
+      <p class="mb2 aqua b f4 lh-title">IPFS Desktop users</p>
+      <p class="${copyClass}">Make sure your copy of IPFS Desktop is running. Don't have IPFS Desktop? ${renderTranslatedLinks('page_landingWelcome_installSteps_desktop_install', ['https://github.com/ipfs-shipyard/ipfs-desktop#ipfs-desktop'], `target="_blank" class="${anchorClass}"`)}</p>
+      <p class="mb2 aqua b f4 lh-title">${i18n.getMessage('page_landingWelcome_installSteps_cli_title')}</p>
+      <p class="${copyClass}">If you already have IPFS installed on the command line, start a daemon by entering <code class="yellow">ipfs daemon</code> in your terminal. Don't have it installed yet? ${renderTranslatedLinks('page_landingWelcome_installSteps_cli_install', ['https://docs.ipfs.io/introduction/usage/'], `target="_blank" class="${anchorClass}"`)}</p>
     </div>
   `
 }
@@ -193,17 +189,17 @@ const renderProjects = (i18n) => {
       <div class="flex justify-between-ns">
         <a class="${anchorClass}" href="https://multiformats.io/" target="_blank">
           <img width="${logoWidth}" src="${multiformatsLogo}" alt="Multiformats Logo">
-          <p>multiformats.io</p>
+          <p>Multiformats</p>
         </a>
 
         <a class="${anchorClass}" href="https://ipld.io/" target="_blank">
           <img width="${logoWidth}" src="${ipldLogo}" alt="IPLD Logo">
-          <p>ipld.io</p>
+          <p>IPLD</p>
         </a>
 
         <a class="${anchorClass}" href="https://libp2p.io/" target="_blank">
         <img width="${logoWidth}" src="${libp2pLogo}" alt="libp2p Logo">
-          <p>libp2p.io</p>
+          <p>libp2p</p>
         </a>
       </div>
     </div>

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -18,7 +18,7 @@ function createWelcomePage (i18n) {
   return function welcomePage (state, emit) {
     const isIpfsOnline = state.isIpfsOnline
     const peerCount = state.peerCount
-    const onOpenWebUi = () => emit('openWebUi')
+    const onOpenWebUiStatus = () => emit('openWebUiStatus')
 
     // Set translated title
     document.title = i18n.getMessage('page_landingWelcome_title')
@@ -27,7 +27,7 @@ function createWelcomePage (i18n) {
       <div class="flex flex-column flex-row-l">
         <div id="left-col" class="min-vh-100 flex flex-column justify-center items-center bg-navy white">
           ${renderCompanionLogo(i18n, isIpfsOnline)}
-          ${isIpfsOnline ? renderWelcome(i18n, peerCount, onOpenWebUi) : renderInstallSteps(i18n, isIpfsOnline)}
+          ${isIpfsOnline ? renderWelcome(i18n, peerCount, onOpenWebUiStatus) : renderInstallSteps(i18n, isIpfsOnline)}
         </div>
 
         <div id="right-col" class="min-vh-100 flex flex-column justify-around items-center">
@@ -57,7 +57,7 @@ const renderCompanionLogo = (i18n, isIpfsOnline) => {
   `
 }
 
-const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
+const renderWelcome = (i18n, peerCount, onOpenWebUiStatus) => {
   const anchorClass = 'aqua hover-white'
   const copyClass = 'mv0 tc lh-copy f5'
   const svgWidth = 130
@@ -76,9 +76,9 @@ const renderWelcome = (i18n, peerCount, onOpenWebUi) => {
         <p class="mt0 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUi}>${i18n.getMessage('panel_statusSwarmPeers')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUiStatus}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUiStatus}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUiStatus}>${i18n.getMessage('panel_statusSwarmPeers')}</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -16,9 +16,8 @@ const colorYellow = '#f39021'
 
 function createWelcomePage (i18n) {
   return function welcomePage (state, emit) {
-    const isIpfsOnline = state.isIpfsOnline
-    const peerCount = state.peerCount
-    const onOpenWebUiStatus = () => emit('openWebUiStatus')
+    const { isIpfsOnline, peerCount } = state
+    const openWebUi = (page) => () => emit('openWebUi', page)
 
     // Set translated title
     document.title = i18n.getMessage('page_landingWelcome_title')
@@ -27,7 +26,7 @@ function createWelcomePage (i18n) {
       <div class="flex flex-column flex-row-l">
         <div id="left-col" class="min-vh-100 flex flex-column justify-center items-center bg-navy white">
           ${renderCompanionLogo(i18n, isIpfsOnline)}
-          ${isIpfsOnline ? renderWelcome(i18n, peerCount, onOpenWebUiStatus) : renderInstallSteps(i18n, isIpfsOnline)}
+          ${isIpfsOnline ? renderWelcome(i18n, peerCount, openWebUi) : renderInstallSteps(i18n, isIpfsOnline)}
         </div>
 
         <div id="right-col" class="min-vh-100 w-100 flex flex-column justify-around items-center">
@@ -57,9 +56,9 @@ const renderCompanionLogo = (i18n, isIpfsOnline) => {
   `
 }
 
-const renderWelcome = (i18n, peerCount, onOpenWebUiStatus) => {
-  const anchorClass = 'aqua hover-white'
-  const copyClass = 'mv0 tc lh-copy f5'
+const renderWelcome = (i18n, peerCount, openWebUi) => {
+  // const anchorClass = 'aqua hover-white'
+  // const copyClass = 'mv0 tc lh-copy f5'
   const svgWidth = 130
 
   const nodeOnSvg = () => html`
@@ -76,9 +75,9 @@ const renderWelcome = (i18n, peerCount, onOpenWebUiStatus) => {
         <p class="mt0 mb0 f3 tc">${renderTranslatedSpans('page_landingWelcome_welcome_peers', [peerCount], 'class="aqua fw6"')}</p>
       </div>
       <div class="mt3 f5 flex justify-center items-center">
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUiStatus}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUiStatus}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
-        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${onOpenWebUiStatus}>${i18n.getMessage('panel_statusSwarmPeers')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/')}>${i18n.getMessage('page_landingWelcome_welcome_status')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/files')}>${i18n.getMessage('page_landingWelcome_welcome_files')}</button>
+        <button class="pv3 ph4 mh2 b navy br2 bn bg-white hover-bg-white-90 pointer" onclick=${openWebUi('/peers')}>${i18n.getMessage('panel_statusSwarmPeers')}</button>
       </div>
     </div>
   `

--- a/add-on/src/landing-pages/welcome/store.js
+++ b/add-on/src/landing-pages/welcome/store.js
@@ -26,11 +26,12 @@ function createWelcomePageStore (i18n, runtime) {
       })
     })
 
-    emitter.on('openWebUiStatus', async () => {
+    emitter.on('openWebUi', async (page = '/') => {
+      const url = `${state.webuiRootUrl}#${page}`
       try {
-        browser.tabs.create({ url: state.webuiRootUrl })
+        await browser.tabs.create({ url })
       } catch (error) {
-        console.error(`Unable Open Web UI due to ${error}`)
+        console.error(`Unable Open Web UI (${url})`, error)
       }
     })
   }

--- a/add-on/src/landing-pages/welcome/store.js
+++ b/add-on/src/landing-pages/welcome/store.js
@@ -26,7 +26,7 @@ function createWelcomePageStore (i18n, runtime) {
       })
     })
 
-    emitter.on('openWebUi', async () => {
+    emitter.on('openWebUiStatus', async () => {
       try {
         browser.tabs.create({ url: state.webuiRootUrl })
       } catch (error) {

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -3,6 +3,8 @@
 
 const browser = require('webextension-polyfill')
 
+exports.welcomePage = '/dist/landing-pages/welcome/index.html'
+
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`
   if (details.reason === 'install' || details.temporary) {
@@ -16,7 +18,7 @@ exports.showPendingLandingPages = async () => {
     case 'onInstallWelcome':
       await browser.storage.local.remove('showLandingPage')
       return browser.tabs.create({
-        url: '/dist/landing-pages/welcome/index.html'
+        url: exports.welcomePage
       })
     // case 'onVersionUpdate'
   }

--- a/add-on/src/popup/browser-action/header.js
+++ b/add-on/src/popup/browser-action/header.js
@@ -9,11 +9,14 @@ const optionsIcon = require('./options-icon')
 const gatewayStatus = require('./gateway-status')
 
 module.exports = function header (props) {
-  const { ipfsNodeType, active, onToggleActive, onOpenPrefs, isIpfsOnline } = props
+  const { ipfsNodeType, active, onToggleActive, onOpenPrefs, isIpfsOnline, onOpenWelcomePage } = props
   return html`
     <div class="pt3 pb1 br2 br--top ba bw1 b--white" style="background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%,#043b55 100%); background-size: 100%; background-repeat: repeat;">
       <div class="no-user-select">
-        <div class="tc mb2 transition-all ${active ? '' : 'o-40'}" style="${active ? '' : 'filter: blur( .15em )'}">
+        <div
+          onclick=${onOpenWelcomePage}
+          class="tc mb2 transition-all pointer ${active ? '' : 'o-40'}"
+          style="${active ? '' : 'filter: blur( .15em )'}">
   ${logo({
     size: 52,
     path: '../../../icons',

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -17,7 +17,7 @@ module.exports = function browserActionPage (state, emit) {
   const onUnPin = () => emit('unPin')
 
   const onQuickImport = () => emit('quickImport')
-  const onOpenWebUi = () => emit('openWebUi')
+  const onOpenWebUiStatus = () => emit('openWebUiStatus')
   const onOpenPrefs = () => emit('openPrefs')
   const onToggleGlobalRedirect = () => emit('toggleGlobalRedirect')
   const onToggleSiteIntegrations = () => emit('toggleSiteIntegrations')
@@ -25,7 +25,7 @@ module.exports = function browserActionPage (state, emit) {
 
   const headerProps = Object.assign({ onToggleActive, onOpenPrefs }, state)
   const activeTabActionsProps = Object.assign({ onViewOnGateway, onToggleSiteIntegrations, onCopy, onPin, onUnPin }, state)
-  const opsProps = Object.assign({ onQuickImport, onOpenWebUi, onToggleGlobalRedirect }, state)
+  const opsProps = Object.assign({ onQuickImport, onOpenWebUiStatus, onToggleGlobalRedirect }, state)
 
   return html`
     <div class="sans-serif" style="text-rendering: optimizeLegibility;">

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -18,12 +18,13 @@ module.exports = function browserActionPage (state, emit) {
 
   const onQuickImport = () => emit('quickImport')
   const onOpenWebUi = () => emit('openWebUi', '/')
+  const onOpenWelcomePage = () => emit('openWelcomePage')
   const onOpenPrefs = () => emit('openPrefs')
   const onToggleGlobalRedirect = () => emit('toggleGlobalRedirect')
   const onToggleSiteIntegrations = () => emit('toggleSiteIntegrations')
   const onToggleActive = () => emit('toggleActive')
 
-  const headerProps = Object.assign({ onToggleActive, onOpenPrefs }, state)
+  const headerProps = Object.assign({ onToggleActive, onOpenPrefs, onOpenWelcomePage }, state)
   const activeTabActionsProps = Object.assign({ onViewOnGateway, onToggleSiteIntegrations, onCopy, onPin, onUnPin }, state)
   const opsProps = Object.assign({ onQuickImport, onOpenWebUi, onToggleGlobalRedirect }, state)
 

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -17,7 +17,7 @@ module.exports = function browserActionPage (state, emit) {
   const onUnPin = () => emit('unPin')
 
   const onQuickImport = () => emit('quickImport')
-  const onOpenWebUiStatus = () => emit('openWebUiStatus')
+  const onOpenWebUi = () => emit('openWebUi', '/')
   const onOpenPrefs = () => emit('openPrefs')
   const onToggleGlobalRedirect = () => emit('toggleGlobalRedirect')
   const onToggleSiteIntegrations = () => emit('toggleSiteIntegrations')
@@ -25,7 +25,7 @@ module.exports = function browserActionPage (state, emit) {
 
   const headerProps = Object.assign({ onToggleActive, onOpenPrefs }, state)
   const activeTabActionsProps = Object.assign({ onViewOnGateway, onToggleSiteIntegrations, onCopy, onPin, onUnPin }, state)
-  const opsProps = Object.assign({ onQuickImport, onOpenWebUiStatus, onToggleGlobalRedirect }, state)
+  const opsProps = Object.assign({ onQuickImport, onOpenWebUi, onToggleGlobalRedirect }, state)
 
   return html`
     <div class="sans-serif" style="text-rendering: optimizeLegibility;">

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -133,12 +133,13 @@ module.exports = (state, emitter) => {
     window.close()
   })
 
-  emitter.on('openWebUiStatus', async () => {
+  emitter.on('openWebUi', async (page = '/') => {
+    const url = `${state.webuiRootUrl}#${page}`
     try {
-      browser.tabs.create({ url: state.webuiRootUrl })
+      await browser.tabs.create({ url })
       window.close()
     } catch (error) {
-      console.error(`Unable Open Web UI due to ${error}`)
+      console.error(`Unable Open Web UI (${url})`, error)
     }
   })
 

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -4,6 +4,7 @@
 const browser = require('webextension-polyfill')
 const isIPFS = require('is-ipfs')
 const { trimHashAndSearch, ipfsContentPath } = require('../../lib/ipfs-path')
+const { welcomePage } = require('../../lib/on-installed')
 const { contextMenuViewOnGateway, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
 
 // The store contains and mutates the state for the app
@@ -131,6 +132,15 @@ module.exports = (state, emitter) => {
   emitter.on('quickImport', () => {
     browser.tabs.create({ url: browser.extension.getURL('dist/popup/quick-import.html') })
     window.close()
+  })
+
+  emitter.on('openWelcomePage', async () => {
+    try {
+      await browser.tabs.create({ url: welcomePage })
+      window.close()
+    } catch (error) {
+      console.error(`Unable Open WelcomePage (${welcomePage})`, error)
+    }
   })
 
   emitter.on('openWebUi', async (page = '/') => {

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -133,7 +133,7 @@ module.exports = (state, emitter) => {
     window.close()
   })
 
-  emitter.on('openWebUi', async () => {
+  emitter.on('openWebUiStatus', async () => {
     try {
       browser.tabs.create({ url: state.webuiRootUrl })
       window.close()

--- a/add-on/src/popup/browser-action/tools.js
+++ b/add-on/src/popup/browser-action/tools.js
@@ -12,7 +12,7 @@ module.exports = function tools ({
   isIpfsOnline,
   isApiAvailable,
   onQuickImport,
-  onOpenWebUiStatus
+  onOpenWebUi
 }) {
   const activeQuickImport = active && isIpfsOnline && isApiAvailable
   const activeWebUI = active && isIpfsOnline && ipfsNodeType !== 'embedded'
@@ -30,7 +30,7 @@ module.exports = function tools ({
   ${navItem({
     text: browser.i18n.getMessage('panel_openWebui'),
     disabled: !activeWebUI,
-    onClick: onOpenWebUiStatus
+    onClick: onOpenWebUi
   })}
     </div>
     </div>

--- a/add-on/src/popup/browser-action/tools.js
+++ b/add-on/src/popup/browser-action/tools.js
@@ -12,7 +12,7 @@ module.exports = function tools ({
   isIpfsOnline,
   isApiAvailable,
   onQuickImport,
-  onOpenWebUi
+  onOpenWebUiStatus
 }) {
   const activeQuickImport = active && isIpfsOnline && isApiAvailable
   const activeWebUI = active && isIpfsOnline && ipfsNodeType !== 'embedded'
@@ -30,7 +30,7 @@ module.exports = function tools ({
   ${navItem({
     text: browser.i18n.getMessage('panel_openWebui'),
     disabled: !activeWebUI,
-    onClick: onOpenWebUi
+    onClick: onOpenWebUiStatus
   })}
     </div>
     </div>


### PR DESCRIPTION
Updates welcome page content to improve usefulness of right-pane resources and clarity of left-pane messaging. Plus some visual tweaks.

- Left-pane (node-on state): standardizes check icon to ipfs-css
- Left-pane (node-on): Increases prominence of peer connection message
- Left-pane (node-on): adds buttons for files and peers, renames generic "Web UI" button to "Status"
- Left-pane (node-off): Adds ipfs-css caution icon for consistency
- Left-pane (node-off): Clarifies next steps for IPFS desktop and CLI users; checks links
- Right-pane: Rewords resources as bullets in a more topical format, and adds newly improved resources
- Right-pane: Updates both videos to more recent content

Still to do (requesting help from @lidel or @rafaelramalho19 if possible!):
- [x] Make cube logo in pop-up a link to the welcome page
- [x] Send left-pane (node-on state) buttons for files and peers to the appropriate screens in Web UI - right now they just go to Web UI status page

**Note! Links to docs won't work until after docs beta migration is complete -- right now this is slated for 27 May.**

Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/818.