### PR TITLE
fix: include CSS assets in the install package

### DIFF
--- a/add-on/manifest.common.json
+++ b/add-on/manifest.common.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_manifest_extensionName__",
   "short_name": "__MSG_manifest_shortExtensionName__",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "__MSG_manifest_extensionDescription__",
   "homepage_url": "https://github.com/ipfs-shipyard/ipfs-companion",
   "author": "IPFS Community",

--- a/package.json
+++ b/package.json
@@ -61,14 +61,15 @@
     "ci:build": "./ci/update-manifest.sh && npx yarn@1.22.4 build",
     "ci:test": "npx yarn@1.22.4 test",
     "ci:lint": "npx yarn@1.22.4 lint",
-    "beta-build": "docker build -t ipfs-companion-beta-build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) . && mkdir -p build && docker run --rm -it --net=host -e RELEASE_CHANNEL=beta -v $(pwd)/build:/home/node/app/build ipfs-companion-beta-build yarn ci:build",
-    "release-build": "docker build -t ipfs-companion-release-build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) . && mkdir -p build && docker run --rm -it --net=host -e RELEASE_CHANNEL=stable -v $(pwd)/build:/home/node/app/build ipfs-companion-release-build yarn ci:build",
+    "beta-build": "docker rmi -f ipfs-companion-beta-build && docker build -t ipfs-companion-beta-build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) . && mkdir -p build && docker run --rm -it --net=host -e RELEASE_CHANNEL=beta -v $(pwd)/build:/home/node/app/build ipfs-companion-beta-build yarn ci:build",
+    "release-build": "docker rmi -f ipfs-companion-release-build && docker build -t ipfs-companion-release-build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) . && mkdir -p build && docker run --rm -it --net=host -e RELEASE_CHANNEL=stable -v $(pwd)/build:/home/node/app/build ipfs-companion-release-build yarn ci:build",
     "dev-build": "npx yarn@1.22.4 && npx yarn@1.22.4 build",
     "yarn-build": "npm run dev-build"
   },
   "private": true,
   "preferGlobal": false,
   "resolutions": {
+    "v8": "npm:empty-module@0.0.2",
     "@hapi/hapi": "18.4.0",
     "iso-stream-http": "0.1.2",
     "stream-http": "npm:iso-stream-http@0.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ const commonConfig = {
         test: /\.(png|jpe?g|gif|svg|eot|otf|ttf|woff|woff2)$/i,
         loader: 'file-loader',
         options: {
-          name: '[path][name].[ext]'
+          name: 'assets/[name].[ext]'
         }
       },
       {


### PR DESCRIPTION
Turns out `web-ext` ignores everything under `node_modules` no matter how deep in the project tree it is:

https://github.com/mozilla/web-ext/blob/065188db35a4f63c2d17ff744cc1de2601a62222/src/util/file-filter.js#L40-L46

That caused `/dist/bundles/node_modules/ipfs-css/fonts` to be excluded from the production package :-(

The fix here is to put all assets under hardcoded `/dist/bundles/assets/` which is not excluded.


cc @jessicaschilling – ignore if fonts look weird, this will fix them 