### PR TITLE
chore: update docs links to non-beta site

### DIFF
--- a/add-on/src/lib/http-proxy.js
+++ b/add-on/src/lib/http-proxy.js
@@ -13,7 +13,7 @@ log.error = debug('ipfs-companion:http-proxy:error')
 // When go-ipfs runs on localhost, it exposes two types of gateway:
 // 127.0.0.1:8080 - old school path gateway
 // localhost:8080 - subdomain gateway supporting Origins like $cid.ipfs.localhost
-// More: https://docs-beta.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway
+// More: https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway
 //
 // In a web browser contexts we care about Origin per content root (CID)
 // because entire web security model uses it as a basis for sandboxing and

--- a/add-on/src/options/forms/dnslink-form.js
+++ b/add-on/src/options/forms/dnslink-form.js
@@ -25,7 +25,7 @@ function dnslinkForm ({
               <dt>${browser.i18n.getMessage('option_dnslinkPolicy_title')}</dt>
               <dd>
                 ${browser.i18n.getMessage('option_dnslinkPolicy_description')}
-                <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/dnslink-companion/" target="_blank">
+                <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/dnslink-companion/" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>
@@ -65,7 +65,7 @@ function dnslinkForm ({
               <dd>
                 ${browser.i18n.getMessage('option_dnslinkRedirect_description')}
                 ${dnslinkRedirect ? html`<p class="red i">${browser.i18n.getMessage('option_dnslinkRedirect_warning')}</p>` : null}
-                <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
+                <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -69,7 +69,7 @@ function experimentsForm ({
             <dl>
               <dt>${browser.i18n.getMessage('option_detectIpfsPathHeader_title')}</dt>
               <dd>${browser.i18n.getMessage('option_detectIpfsPathHeader_description')}
-                <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/companion-x-ipfs-path-header/" target="_blank">
+                <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/companion-x-ipfs-path-header/" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>
@@ -91,7 +91,7 @@ function experimentsForm ({
                     </a>` : html`<del>${browser.i18n.getMessage('option_ipfsProxy_link_manage_permissions')}</del>`}
                 </p>
                 -->
-                <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/companion-window-ipfs/" target="_blank">
+                <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/companion-window-ipfs/" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>

--- a/add-on/src/options/forms/file-import-form.js
+++ b/add-on/src/options/forms/file-import-form.js
@@ -19,7 +19,7 @@ function fileImportForm ({ importDir, openViaWebUI, preloadAtPublicGateway, onOp
               <dt>${browser.i18n.getMessage('option_importDir_title')}</dt>
               <dd>
                 ${browser.i18n.getMessage('option_importDir_description')}
-                <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/concepts/file-systems/#mutable-file-system-mfs" target="_blank">
+                <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/concepts/file-systems/#mutable-file-system-mfs" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>

--- a/add-on/src/options/forms/gateways-form.js
+++ b/add-on/src/options/forms/gateways-form.js
@@ -60,7 +60,7 @@ function gatewaysForm ({
                 <dt>${browser.i18n.getMessage('option_publicSubdomainGatewayUrl_title')}</dt>
                 <dd>
                   ${browser.i18n.getMessage('option_publicSubdomainGatewayUrl_description')}
-                  <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
+                  <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
                     ${browser.i18n.getMessage('option_legend_readMore')}
                   </a></p>
                 </dd>
@@ -121,7 +121,7 @@ function gatewaysForm ({
                   <dt>${browser.i18n.getMessage('option_useSubdomains_title')}</dt>
                   <dd>
                     ${browser.i18n.getMessage('option_useSubdomains_description')}
-                    <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
+                    <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
                       ${browser.i18n.getMessage('option_legend_readMore')}
                     </a></p>
                   </dd>

--- a/add-on/src/options/forms/ipfs-node-form.js
+++ b/add-on/src/options/forms/ipfs-node-form.js
@@ -20,7 +20,7 @@ function ipfsNodeForm ({ ipfsNodeType, ipfsNodeConfig, onOptionChange }) {
               <dd>
                 <p>${browser.i18n.getMessage('option_ipfsNodeType_external_description')}</p>
                 <p>${browser.i18n.getMessage(withChromeSockets ? 'option_ipfsNodeType_embedded_chromesockets_description' : 'option_ipfsNodeType_embedded_description')}</p>
-                <p><a class="link underline hover-aqua" href="https://docs-beta.ipfs.io/how-to/companion-node-types/" target="_blank">
+                <p><a class="link underline hover-aqua" href="https://docs.ipfs.io/how-to/companion-node-types/" target="_blank">
                   ${browser.i18n.getMessage('option_legend_readMore')}
                 </a></p>
               </dd>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-Content present in this directory was moved to [IPFS Docs](https://docs-beta.ipfs.io).
+Content present in this directory was moved to [IPFS Docs](https://docs.ipfs.io).

--- a/docs/dnslink.md
+++ b/docs/dnslink.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs-beta.ipfs.io/how-to/dnslink-companion/)
+Moved [here](https://docs.ipfs.io/how-to/dnslink-companion/)

--- a/docs/node-types.md
+++ b/docs/node-types.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs-beta.ipfs.io/how-to/companion-node-types/)
+Moved [here](https://docs.ipfs.io/how-to/companion-node-types/)

--- a/docs/window.ipfs.md
+++ b/docs/window.ipfs.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs-beta.ipfs.io/how-to/companion-window-ipfs/)
+Moved [here](https://docs.ipfs.io/how-to/companion-window-ipfs/)

--- a/docs/x-ipfs-path-header.md
+++ b/docs/x-ipfs-path-header.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs-beta.ipfs.io/how-to/companion-x-ipfs-path-header/)
+Moved [here](https://docs.ipfs.io/how-to/companion-x-ipfs-path-header/)


### PR DESCRIPTION
The legacy IPFS Docs site has been deprecated, so links to `docs-beta.ipfs.io` will auto-redirect to `docs.ipfs.io`. This PR doesn't change much from the user's perspective, but it makes things a bit tidier.