### PR TITLE
chore: precache ipfs-webui v2.9.0

### DIFF
--- a/add-on/src/lib/precache.js
+++ b/add-on/src/lib/precache.js
@@ -12,7 +12,7 @@ log.error = debug('ipfs-companion:precache:error')
 
 // Web UI release that should be precached
 // WARNING: do not remove this constant, as its used in package.json
-const webuiCid = 'Qmexhq2sBHnXQbvyP2GfUdbnY7HCagH2Mw5vUNSBn2nxip' // v2.7.2
+const webuiCid = 'bafybeigkbbjnltbd4ewfj7elajsbnjwinyk6tiilczkqsibf3o7dcr6nn4' // v2.9.0
 module.exports.precachedWebuiCid = webuiCid
 
 const PRECACHE_ARCHIVES = [


### PR DESCRIPTION
Before this PR can be merged, we need upstream releases to ship with new webui:
- https://github.com/ipfs/go-ipfs/pull/7387
- https://github.com/ipfs/js-ipfs/pull/3054
- https://github.com/ipfs-shipyard/ipfs-desktop/pull/1531

...and I need to finish #811  and switch to latest js-ipfs

cc @rafaelramalho19 