### PR TITLE
docs: npm run watch

### DIFF
--- a/DEVELOPER-NOTES.md
+++ b/DEVELOPER-NOTES.md
@@ -6,6 +6,7 @@
     * [Clone and install dependencies](#clone-and-install-dependencies)
     * [Build and run in Firefox](#build-and-run-in-firefox)
     * [Build and manually install in Chromium](#build-and-manually-install-in-chromium)
+    * [Run build on file changes](#run-build-on-file-changes)
 * [Useful tasks](#useful-tasks)
 * [Other tips](#other-tips)
 * [Using IPFS Companion on Firefox for Android](#using-ipfs-companion-on-firefox-for-android)
@@ -73,6 +74,16 @@ Then open `chrome://extensions` in your Chromium-based browser, enable "Develope
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ![installing ipfs-companion as an unpacked extension in chrome](https://bafybeih34e3a5sgkh57lwv26c6253fxn2jdvte6ilhyld6l4ghuhybzldi.ipfs.dweb.link/ipfs-companion-install-chrome-dev.gif) | ![installing ipfs-companion as a temporary add on in firefox](https://bafybeih34e3a5sgkh57lwv26c6253fxn2jdvte6ilhyld6l4ghuhybzldi.ipfs.dweb.link/ipfs-companion-install-firefox-dev.gif) |
 
+### Run build on file changes
+
+Regular build minifies code and strips source maps. It is possible to run build  in the `watch` mode, which will rebuild a debug version of all changed bundles:
+
+```bash
+npm run build # do regular build first
+npm run watch # watch for new changes
+```
+
+**Note:** `watch` is a blocking command, so one needs to run it in a different terminal than `firefox` or `chromium`. Press ctrl+c to stop it.
 
 ## Useful tasks
 
@@ -80,6 +91,7 @@ Each `npm` task can run separately, but most of the time, `dev-build`, `test`, a
 
 - `npm install`: Install all NPM dependencies
 - `npm run build`: Build the add-on (copy external libraries, create `.zip` bundles for Chrome and Firefox)
+- `npm run watch`: Rebuild JS/CSS on file changes (run regular `build` first to ensure everything else is in place)
 - `npm run bundle:chromium`: Overwrite manifest and package a generic, Chromium-compatible version
 - `npm run bundle:brave`: Overwrite manifest and package a Brave-compatible version requesting access to `chrome.sockets`
 - `npm run bundle:firefox`: Overwrite manifest and package a Firefox-compatible version


### PR DESCRIPTION
This PR adds docs on `npm run watch` (Run build on file changes)

(dannycarrera on IRC was looking for functionality provided by `watch`,  but it was missing from `DEVELOPER-NOTES.md`)