### PR TITLE
style: update manifest_extensionDescription

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -508,7 +508,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickImport_subhead_peers": {

--- a/add-on/_locales/fi/messages.json
+++ b/add-on/_locales/fi/messages.json
@@ -508,7 +508,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickImport_subhead_peers": {

--- a/add-on/_locales/hu/messages.json
+++ b/add-on/_locales/hu/messages.json
@@ -508,7 +508,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickImport_subhead_peers": {

--- a/add-on/_locales/ko_KR/messages.json
+++ b/add-on/_locales/ko_KR/messages.json
@@ -508,7 +508,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickImport_subhead_peers": {

--- a/add-on/_locales/ru/messages.json
+++ b/add-on/_locales/ru/messages.json
@@ -508,7 +508,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickImport_subhead_peers": {

--- a/add-on/_locales/tr/messages.json
+++ b/add-on/_locales/tr/messages.json
@@ -508,7 +508,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickImport_subhead_peers": {

--- a/add-on/_locales/zh_TW/messages.json
+++ b/add-on/_locales/zh_TW/messages.json
@@ -436,7 +436,7 @@
     "description": "Short extension name in the Manifest file (manifest_shortExtensionName)"
   },
   "manifest_extensionDescription": {
-    "message": "Browser extension that simplifies access to IPFS resources",
+    "message": "Harness the power of IPFS in your browser",
     "description": "Extension description in the Manifest file (manifest_extensionDescription)"
   },
   "quickUpload_subhead_peers": {


### PR DESCRIPTION
This PR changes `manifest_extensionDescription` in order to update taglines in Chrome and Firefox extension stores.

Old: "Browser extension that simplifies access to IPFS resources"
New: "Harness the power of IPFS in your browser"

Ref https://github.com/ipfs-shipyard/ipfs-companion/issues/896