### PR TITLE
docs: improved "Cannot process IPFS request" page

### DIFF
--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -37,32 +37,32 @@
     {
       "protocol": "web+dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
     },
     {
       "protocol": "web+ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
     },
     {
       "protocol": "web+ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
     },
     {
       "protocol": "dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
     },
     {
       "protocol": "ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
     },
     {
       "protocol": "ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
     }
   ]
 }

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -507,7 +507,7 @@ function isSafeToRedirect (request, runtime) {
 
 // This is just a placeholder that we had to provide -- removed in normalizedRedirectingProtocolRequest()
 // It has to match URL from manifest.json/protocol_handlers
-const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#'
+const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#'
 
 function redirectingProtocolRequest (request) {
   return request.url.startsWith(redirectingProtocolEndpoint)

--- a/test/functional/lib/ipfs-request-protocol-handlers.test.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.test.js
@@ -59,81 +59,81 @@ describe('modifyRequest.onBeforeRequest:', function () {
 
         // without web+ prefix (Firefox > 59: https://github.com/ipfs-shipyard/ipfs-companion/issues/164#issuecomment-356301174)
         it('should not be normalized if ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if ipns:/{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipns://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if ipfs://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
 
         // web+ prefixed versions (Firefox < 59 and Chrome)
         it('should not be normalized if web+ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+ipns:/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipns://{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if web+dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}:/bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}://bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
       })


### PR DESCRIPTION
This PR search/replaces globally: bafkreiewrj2pugsghd3flw2lk2fhvtmz6wipecnxep5qc5m3lfpf2mvjk4 -> QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc

https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc is an improved "Cannot process IPFS request" page with better information hierarchy and clearer guidance for next steps. 

Local screenshots with fake URIs bashed in for the sake of illustration:

![image](https://user-images.githubusercontent.com/1507828/87708209-955de280-c75f-11ea-88cb-aa4a5511fe50.png)
![image](https://user-images.githubusercontent.com/1507828/87708235-a3136800-c75f-11ea-825e-d6e3de57a9aa.png)

Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/815