### PR TITLE
Display channel-appropriate release notes upon Companion version update

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -428,7 +428,7 @@
     "description": "An option description on the Preferences screen (option_displayNotifications_description)"
   },
   "option_displayReleaseNotes_title": {
-    "message": "Show Release Notes",
+    "message": "Show Release Notes on Update",
     "description": "An option title on the Preferences screen (option_displayReleaseNotes_title)"
   },
   "option_displayReleaseNotes_description": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -427,6 +427,14 @@
     "message": "Display OS-level notifications when a link is copied to the clipboard,the API state changes, etc.",
     "description": "An option description on the Preferences screen (option_displayNotifications_description)"
   },
+  "option_displayReleaseNotes_title": {
+    "message": "Show Release Notes",
+    "description": "An option title on the Preferences screen (option_displayReleaseNotes_title)"
+  },
+  "option_displayReleaseNotes_description": {
+    "message": "Open Release Notes in a new tab after an update is installed.",
+    "description": "An option description on the Preferences screen (option_displayReleaseNotes_description)"
+  },
   "option_catchUnhandledProtocols_title": {
     "message": "Catch Unhandled IPFS Protocols",
     "description": "An option title on the Preferences screen (option_catchUnhandledProtocols_title)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -432,7 +432,7 @@
     "description": "An option title on the Preferences screen (option_displayReleaseNotes_title)"
   },
   "option_displayReleaseNotes_description": {
-    "message": "Open Release Notes in a new tab after an update is installed.",
+    "message": "Open release notes in a new tab when a new version of IPFS Companion is installed.",
     "description": "An option description on the Preferences screen (option_displayReleaseNotes_description)"
   },
   "option_catchUnhandledProtocols_title": {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -699,6 +699,7 @@ module.exports = async function init () {
         case 'linkify':
         case 'catchUnhandledProtocols':
         case 'displayNotifications':
+        case 'displayReleaseNotes':
         case 'automaticMode':
         case 'detectIpfsPathHeader':
         case 'preloadAtPublicGateway':

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 
 exports.welcomePage = '/dist/landing-pages/welcome/index.html'
-exports.updatePage = ('https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v' + browser.runtime.getManifest().version)
+exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v' + browser.runtime.getManifest().version
 
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -16,7 +16,10 @@ exports.onInstalled = async (details) => {
 }
 
 exports.showPendingLandingPages = async () => {
-  const hint = await browser.storage.local.get('showLandingPage')
+  const hint = await browser.storage.local.get([
+    'showLandingPage',
+    'displayReleaseNotes'
+  ])
   switch (hint.showLandingPage) {
     case 'onInstallWelcome':
       await browser.storage.local.remove('showLandingPage')
@@ -25,6 +28,7 @@ exports.showPendingLandingPages = async () => {
       })
     case 'onVersionUpdate':
       await browser.storage.local.remove('showLandingPage')
+      if (!hint.displayReleaseNotes) return
       return browser.tabs.create({
         url: exports.updatePage + browser.runtime.getManifest().version
       })

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 
 exports.welcomePage = '/dist/landing-pages/welcome/index.html'
-exports.updatePage = 'https://github.com/ipfs/ipfs-companion/releases/latest'
+exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v' + browser.runtime.getManifest().version
 
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 
 exports.welcomePage = '/dist/landing-pages/welcome/index.html'
-exports.updatePage = 'https://github.com/ipfs/ipfs-companion/releases/latest'
+exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v'
 
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`
@@ -26,7 +26,7 @@ exports.showPendingLandingPages = async () => {
     case 'onVersionUpdate':
       await browser.storage.local.remove('showLandingPage')
       return browser.tabs.create({
-        url: exports.updatePage
+        url: exports.updatePage + browser.runtime.getManifest().version
       })
   }
 }

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 
 exports.welcomePage = '/dist/landing-pages/welcome/index.html'
-exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v' + browser.runtime.getManifest().version
+exports.updatePage = ('https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v' + browser.runtime.getManifest().version)
 
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,11 +4,14 @@
 const browser = require('webextension-polyfill')
 
 exports.welcomePage = '/dist/landing-pages/welcome/index.html'
+exports.updatePage = 'https://github.com/ipfs/ipfs-companion/releases/latest'
 
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`
   if (details.reason === 'install' || details.temporary) {
     await browser.storage.local.set({ showLandingPage: 'onInstallWelcome' })
+  } else if (details.reason === 'update' || details.temporary) {
+    await browser.storage.local.set({ showLandingPage: 'onVersionUpdate' })
   }
 }
 
@@ -20,6 +23,10 @@ exports.showPendingLandingPages = async () => {
       return browser.tabs.create({
         url: exports.welcomePage
       })
-    // case 'onVersionUpdate'
+    case 'onVersionUpdate':
+      await browser.storage.local.remove('showLandingPage')
+      return browser.tabs.create({
+        url: exports.updatePage
+      })
   }
 }

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 
 exports.welcomePage = '/dist/landing-pages/welcome/index.html'
-exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v' + browser.runtime.getManifest().version
+exports.updatePage = 'https://github.com/ipfs/ipfs-companion/releases/latest'
 
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -25,6 +25,7 @@ exports.optionDefaults = Object.freeze({
   preloadAtPublicGateway: true,
   catchUnhandledProtocols: true,
   displayNotifications: true,
+  displayReleaseNotes: true,
   customGatewayUrl: buildCustomGatewayUrl(),
   ipfsApiUrl: buildIpfsApiUrl(),
   ipfsApiPollMs: 3000,

--- a/add-on/src/options/forms/experiments-form.js
+++ b/add-on/src/options/forms/experiments-form.js
@@ -8,6 +8,7 @@ const switchToggle = require('../../pages/components/switch-toggle')
 function experimentsForm ({
   useLatestWebUI,
   displayNotifications,
+  displayReleaseNotes,
   catchUnhandledProtocols,
   linkify,
   recoverFailedHttpRequests,
@@ -17,6 +18,7 @@ function experimentsForm ({
   onOptionChange
 }) {
   const onDisplayNotificationsChange = onOptionChange('displayNotifications')
+  const onDisplayReleaseNotesChange = onOptionChange('displayReleaseNotes')
   const onUseLatestWebUIChange = onOptionChange('useLatestWebUI')
   const onCatchUnhandledProtocolsChange = onOptionChange('catchUnhandledProtocols')
   const onLinkifyChange = onOptionChange('linkify')
@@ -46,6 +48,15 @@ function experimentsForm ({
             </dl>
           </label>
           <div class="self-center-ns">${switchToggle({ id: 'displayNotifications', checked: displayNotifications, onchange: onDisplayNotificationsChange })}</div>
+        </div>
+        <div class="flex-row-ns pb0-ns">
+          <label for="displayReleaseNotes">
+            <dl>
+              <dt>${browser.i18n.getMessage('option_displayReleaseNotes_title')}</dt>
+              <dd>${browser.i18n.getMessage('option_displayReleaseNotes_description')}</dd>
+            </dl>
+          </label>
+          <div class="self-center-ns">${switchToggle({ id: 'displayReleaseNotes', checked: displayReleaseNotes, onchange: onDisplayReleaseNotesChange })}</div>
         </div>
         <div class="flex-row-ns pb0-ns">
           <label for="catchUnhandledProtocols">

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -89,6 +89,7 @@ module.exports = function optionsPage (state, emit) {
   ${experimentsForm({
     useLatestWebUI: state.options.useLatestWebUI,
     displayNotifications: state.options.displayNotifications,
+    displayReleaseNotes: state.options.displayReleaseNotes,
     catchUnhandledProtocols: state.options.catchUnhandledProtocols,
     linkify: state.options.linkify,
     recoverFailedHttpRequests: state.options.recoverFailedHttpRequests,


### PR DESCRIPTION
This PR adds functionality for displaying the GitHub page for latest version release notes (taken from `browser.runtime.getManifest().version` in order to be accurate for Beta channel users) upon version update of the extension.

Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/912