### PR TITLE
fix: support API on ipv6 with go-ipfs 0.8+

### DIFF
--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -5,15 +5,13 @@ const debug = require('debug')
 const log = debug('ipfs-companion:client:external')
 log.error = debug('ipfs-companion:client:external:error')
 
-const IpfsApi = require('ipfs-http-client')
+const httpClient = require('ipfs-http-client')
 
 exports.init = async function (opts) {
   log(`init with IPFS API at ${opts.apiURLString}`)
-
-  const url = opts.apiURL
-  const protocol = url.protocol.substr(0, url.protocol.length - 1) // http: -> http
-  const host = url.hostname.replace(/[[\]]+/g, '') // temporary fix for ipv6: https://github.com/ipfs-shipyard/ipfs-companion/issues/668
-  const api = IpfsApi({ host, port: url.port, protocol })
+  const clientConfig = opts.apiURLString
+  // https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client#importing-the-module-and-usage
+  const api = httpClient(clientConfig)
   return api
 }
 


### PR DESCRIPTION
This removes unnecessary normalization of ipv6 URLs and partially unblocks (#904)

Real fix needs to land in go-ipfs (https://github.com/ipfs/go-ipfs/pull/7731)
