### PR TITLE
Fix/offline mode

### DIFF
--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -163,7 +163,7 @@ function createContextMenus (getState, runtime, ipfsPathValidator, { onAddFromCo
             ipfsContext = ipfsPathValidator.isIpfsPageActionsContext(currentTab.url)
           }
         }
-        const ifApi = getState().peerCount >= 0
+        const ifApi = getState().peerCount > -1
         for (const item of apiMenuItems) {
           await browser.contextMenus.update(item, { enabled: ifApi })
         }

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -41,7 +41,7 @@ function contextActions ({
   onUnPin
 }) {
   const activeCidResolver = active && isIpfsOnline && isApiAvailable && currentTabCid
-  const activePinControls = active && isIpfsOnline && isApiAvailable
+  const activePinControls = active && isApiAvailable
   const activeViewOnGateway = (currentTab) => {
     if (!currentTab) return false
     const { url } = currentTab

--- a/add-on/src/popup/browser-action/tools.js
+++ b/add-on/src/popup/browser-action/tools.js
@@ -13,8 +13,8 @@ module.exports = function tools ({
   onQuickImport,
   onOpenWebUi
 }) {
-  const activeQuickImport = active && isIpfsOnline && isApiAvailable
-  const activeWebUI = active && isIpfsOnline && ipfsNodeType !== 'embedded'
+  const activeQuickImport = active && isApiAvailable
+  const activeWebUI = active && isApiAvailable && ipfsNodeType !== 'embedded'
 
   return html`
     <div class="fade-in pv1">


### PR DESCRIPTION
This is a fix for https://github.com/ipfs-shipyard/ipfs-companion/issues/790

When the IPFS daemon is running in offline mode, pinning should still be enabled in the extension.

This fix functions by replacing `isIpfsOnline` with `isApiAvailable` to allow pinning actions in the Tools menu and in-page context menu.