### PR TITLE
feat: snapshot link and IPNS path copy options

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -96,7 +96,7 @@
   "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
   },
   "panelCopy_currentIpnsAddressTooltip": {
-    "message": "Use this content path with IPFS tools and gateways to reach the most recently updated version of this tab.",
+    "message": "Use this content path with IPFS tools and gateways to reach the most recently updated version of this tab's content.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
   },
   "panelCopy_currentIpfsAddress": {
@@ -104,7 +104,7 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
   "panelCopy_currentIpfsAddressTooltip": {
-    "message": "Use this content path with IPFS tools and gateways to reach this tab at this moment in time. It won't change, even if content changes later.",
+    "message": "Use this content path with IPFS tools and gateways to reach the content in this tab at this moment in time. This snapshot won't change, even if content changes later.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpfsAddressTooltip)"
   },
   "panelCopy_copyRawCid": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -52,7 +52,7 @@
     "description": "A label tooltip in Node status section of Browser Action pop-up (panel_statusSwarmPeersTitle)"
   },
   "panel_quickImport": {
-    "message": "Quick Import/Share…",
+    "message": "Import",
     "description": "A menu item in Browser Action pop-up (panel_quickImport)"
   },
   "panel_quickImportTooltip": {
@@ -60,7 +60,7 @@
     "description": "A menu item tooltip in Browser Action pop-up (panel_quickImportTooltip)"
   },
   "panel_openWebui": {
-    "message": "Go to My Node…",
+    "message": "My Node",
     "description": "A menu item in Browser Action pop-up (panel_openWebui)"
   },
   "panel_openWebuiTooltip": {
@@ -88,7 +88,7 @@
     "description": "A menu item in Browser Action pop-up (panel_pinCurrentIpfsAddress)"
   },
   "panel_pinCurrentIpfsAddressTooltip": {
-    "message": "Pin the IPFS assets on this page to your node to have local copies that are available offline and never thrown away.",
+    "message": "Pin the IPFS assets on this page (files, images, videos, etc.) to your node to have local copies that are available offline and never thrown away.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
   "panelCopy_currentIpnsAddress": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -84,11 +84,11 @@
     "description": "A menu item tooltip in Browser Action pop-up (panel_activeTabSiteIntegrationsToggleTooltip)"
   },
   "panel_pinCurrentIpfsAddress": {
-    "message": "Pin IPFS Assets",
+    "message": "Pin IPFS Resource",
     "description": "A menu item in Browser Action pop-up (panel_pinCurrentIpfsAddress)"
   },
   "panel_pinCurrentIpfsAddressTooltip": {
-    "message": "Pin the IPFS assets on this tab (e.g. files, images, videos) to your node to have local copies that are available offline and never thrown away.",
+    "message": "Pin this page's IPFS resources to your node to have a local copy that's available offline and never thrown away.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
   "panelCopy_currentIpnsAddress": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -56,7 +56,7 @@
     "description": "A menu item in Browser Action pop-up (panel_quickImport)"
   },
   "panel_quickImportTooltip": {
-    "message": "Import files to IPFS and copy a publicly shareable link to your clipboard",
+    "message": "Import files to IPFS and copy a publicly shareable link to your clipboard.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_quickImportTooltip)"
   },
   "panel_openWebui": {
@@ -64,7 +64,7 @@
     "description": "A menu item in Browser Action pop-up (panel_openWebui)"
   },
   "panel_openWebuiTooltip": {
-    "message": "Open your IPFS node's controls in your browser",
+    "message": "Open your IPFS node's controls in your browser.",
     "description": "A menu item in Browser Action pop-up (panel_openWebuiTooltip)"
   },
   "panel_openPreferences": {
@@ -76,15 +76,15 @@
     "description": "A menu item in Browser Action pop-up (panel_activeTabSiteRedirectEnable)"
   },
   "panel_activeTabSiteIntegrationsToggle": {
-    "message": "Enable on $1",
+    "message": "Enable for $1",
     "description": "A menu item in Browser Action pop-up (panel_activeTabSiteIntegrationsToggle)"
   },
   "panel_activeTabSiteIntegrationsToggleTooltip": {
-    "message": "Enable/disable all IPFS integrations on $1",
+    "message": "Enable/disable all IPFS integrations on $1.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_activeTabSiteIntegrationsToggleTooltip)"
   },
   "panel_pinCurrentIpfsAddress": {
-    "message": "Pin IPFS Resource",
+    "message": "Pin IPFS Resources",
     "description": "A menu item in Browser Action pop-up (panel_pinCurrentIpfsAddress)"
   },
   "panel_pinCurrentIpfsAddressTooltip": {
@@ -92,19 +92,19 @@
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
   "panelCopy_currentIpnsAddress": {
-  "message": "Copy IPNS Content Path",
+  "message": "Copy Content Path",
   "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
   },
   "panelCopy_currentIpnsAddressTooltip": {
-    "message": "A canonical content path that you can use with IPFS tools and gateways",
+    "message": "Use this content path with IPFS tools and gateways to reach the most recently updated version of this page.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
   },
   "panelCopy_currentIpfsAddress": {
-    "message": "Copy IPFS Content Path",
+    "message": "Copy Content Path Snapshot",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
   "panelCopy_currentIpfsAddressTooltip": {
-    "message": "A content path that you can use with IPFS tools and gateways",
+    "message": "Use this content path with IPFS tools and gateways to reach this page at this moment in time. It won't change, even if the content changes later.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpfsAddressTooltip)"
   },
   "panelCopy_copyRawCid": {
@@ -112,7 +112,7 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyRawCid)"
   },
   "panelCopy_copyRawCidTooltip": {
-    "message": "The unique IPFS content identifier for this page",
+    "message": "The unique IPFS content identifier for this page at this moment in time.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_copyRawCidTooltip)"
   },
   "panelCopy_copyRawCidNotReadyHint": {
@@ -124,15 +124,15 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPublicGwUrl)"
   },
   "panel_copyCurrentPublicGwUrlTooltip": {
-    "message": "This link works for anyone, even if they don't use IPFS",
+    "message": "A shareable link that works for anyone, even if they don't use IPFS.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPublicGwUrlTooltip)"
   },
   "panel_copyCurrentPermalink": {
-    "message": "Copy Permalink",
+    "message": "Copy Shareable Snapshot",
     "description": "A menu item in Browser Action pop-up (panel_copyCurrentPermalink)"
   },
   "panel_copyCurrentPermalinkTooltip": {
-    "message": "An immutable permalink using a content ID and IPFS gateway",
+    "message": "A shareable link to this page at this moment in time that works for anyone, even if they don't use IPFS. It won't change, even if the content changes later.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPermalinkTooltip)"
   },
   "panel_contextMenuViewOnGateway": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -91,21 +91,21 @@
     "message": "Pin this page's IPFS resources to your node to have a local copy that's available offline and never thrown away.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
+  "panelCopy_currentIpnsAddress": {
+  "message": "Copy IPNS Content Path",
+  "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
+  },
+  "panelCopy_currentIpnsAddressTooltip": {
+    "message": "A canonical content path that you can use with IPFS tools and gateways",
+    "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
+  },
   "panelCopy_currentIpfsAddress": {
     "message": "Copy IPFS Content Path",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
   "panelCopy_currentIpfsAddressTooltip": {
-    "message": "A canonical content path that you can use with IPFS tools and gateways",
+    "message": "A content path that you can use with IPFS tools and gateways",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpfsAddressTooltip)"
-  },
-    "panelCopy_currentIpnsAddress": {
-    "message": "Copy IPNS Content Path",
-    "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
-  },
-  "panelCopy_currentIpnsAddressTooltip": {
-    "message": "A canonical content path that you can use with IPFS tools and gateways",
-    "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
   },
   "panelCopy_copyRawCid": {
     "message": "Copy CID",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -128,7 +128,7 @@
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPublicGwUrlTooltip)"
   },
   "panel_copyCurrentPermalink": {
-    "message": "Copy Shareable Snapshot Link",
+    "message": "Copy Snapshot Link",
     "description": "A menu item in Browser Action pop-up (panel_copyCurrentPermalink)"
   },
   "panel_copyCurrentPermalinkTooltip": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -92,7 +92,7 @@
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
   "panelCopy_currentIpnsAddress": {
-  "message": "Copy Content Path",
+  "message": "Copy IPNS Path",
   "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
   },
   "panelCopy_currentIpnsAddressTooltip": {
@@ -100,7 +100,7 @@
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
   },
   "panelCopy_currentIpfsAddress": {
-    "message": "Copy Content Path Snapshot",
+    "message": "Copy IPFS Path",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
   "panelCopy_currentIpfsAddressTooltip": {
@@ -115,9 +115,9 @@
     "message": "The unique IPFS content identifier for this tab at this moment in time. If content changes later, the CID will change too.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_copyRawCidTooltip)"
   },
-  "panelCopy_copyRawCidNotReadyHint": {
+  "panelCopy_notReadyHint": {
     "message": "(waiting for DAG data)",
-    "description": "A hint in menu item in Browser Action pop-up to indicate CID is still being resolved (panelCopy_copyRawCidNotReadyHint)"
+    "description": "A hint in menu item in Browser Action pop-up to indicate value is still being resolved (panelCopy_notReadyHint)"
   },
   "panel_copyCurrentPublicGwUrl": {
     "message": "Copy Shareable Link",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -99,6 +99,14 @@
     "message": "A canonical content path that you can use with IPFS tools and gateways",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpfsAddressTooltip)"
   },
+    "panelCopy_currentIpnsAddress": {
+    "message": "Copy IPNS Content Path",
+    "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
+  },
+  "panelCopy_currentIpnsAddressTooltip": {
+    "message": "A canonical content path that you can use with IPFS tools and gateways",
+    "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
+  },
   "panelCopy_copyRawCid": {
     "message": "Copy CID",
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyRawCid)"
@@ -118,6 +126,14 @@
   "panel_copyCurrentPublicGwUrlTooltip": {
     "message": "This link works for anyone, even if they don't use IPFS",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPublicGwUrlTooltip)"
+  },
+  "panel_copyCurrentPermalink": {
+    "message": "Copy Permalink",
+    "description": "A menu item in Browser Action pop-up (panel_copyCurrentPermalink)"
+  },
+  "panel_copyCurrentPermalinkTooltip": {
+    "message": "An immutable permalink using a content ID and IPFS gateway",
+    "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPermalinkTooltip)"
   },
   "panel_contextMenuViewOnGateway": {
     "message": "View on Gateway",

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -84,11 +84,11 @@
     "description": "A menu item tooltip in Browser Action pop-up (panel_activeTabSiteIntegrationsToggleTooltip)"
   },
   "panel_pinCurrentIpfsAddress": {
-    "message": "Pin IPFS Resources",
+    "message": "Pin IPFS Assets",
     "description": "A menu item in Browser Action pop-up (panel_pinCurrentIpfsAddress)"
   },
   "panel_pinCurrentIpfsAddressTooltip": {
-    "message": "Pin this page's IPFS resources to your node to have a local copy that's available offline and never thrown away.",
+    "message": "Pin the IPFS assets on this page to your node to have local copies that are available offline and never thrown away.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
   "panelCopy_currentIpnsAddress": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -88,7 +88,7 @@
     "description": "A menu item in Browser Action pop-up (panel_pinCurrentIpfsAddress)"
   },
   "panel_pinCurrentIpfsAddressTooltip": {
-    "message": "Pin the IPFS assets on this page (files, images, videos, etc.) to your node to have local copies that are available offline and never thrown away.",
+    "message": "Pin the IPFS assets on this tab (e.g. files, images, videos) to your node to have local copies that are available offline and never thrown away.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_pinCurrentIpfsAddressTooltip)"
   },
   "panelCopy_currentIpnsAddress": {
@@ -96,7 +96,7 @@
   "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpnsAddress)"
   },
   "panelCopy_currentIpnsAddressTooltip": {
-    "message": "Use this content path with IPFS tools and gateways to reach the most recently updated version of this page.",
+    "message": "Use this content path with IPFS tools and gateways to reach the most recently updated version of this tab.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpnsAddressTooltip)"
   },
   "panelCopy_currentIpfsAddress": {
@@ -104,7 +104,7 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_currentIpfsAddress)"
   },
   "panelCopy_currentIpfsAddressTooltip": {
-    "message": "Use this content path with IPFS tools and gateways to reach this page at this moment in time. It won't change, even if the content changes later.",
+    "message": "Use this content path with IPFS tools and gateways to reach this tab at this moment in time. It won't change, even if content changes later.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_currentIpfsAddressTooltip)"
   },
   "panelCopy_copyRawCid": {
@@ -112,7 +112,7 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panelCopy_copyRawCid)"
   },
   "panelCopy_copyRawCidTooltip": {
-    "message": "The unique IPFS content identifier for this page at this moment in time.",
+    "message": "The unique IPFS content identifier for this tab at this moment in time. If content changes later, the CID will change too.",
     "description": "A menu item tooltip in Browser Action pop-up (panelCopy_copyRawCidTooltip)"
   },
   "panelCopy_copyRawCidNotReadyHint": {
@@ -124,15 +124,15 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPublicGwUrl)"
   },
   "panel_copyCurrentPublicGwUrlTooltip": {
-    "message": "A shareable link that works for anyone, even if they don't use IPFS.",
+    "message": "A shareable link to this tab that works for anyone, even if they don't use IPFS.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPublicGwUrlTooltip)"
   },
   "panel_copyCurrentPermalink": {
-    "message": "Copy Shareable Snapshot",
+    "message": "Copy Shareable Snapshot Link",
     "description": "A menu item in Browser Action pop-up (panel_copyCurrentPermalink)"
   },
   "panel_copyCurrentPermalinkTooltip": {
-    "message": "A shareable link to this page at this moment in time that works for anyone, even if they don't use IPFS. It won't change, even if the content changes later.",
+    "message": "A link to a snapshot of this tab at this moment in time; it won't change, even if content changes later. This link works for anyone, even if they don't use IPFS.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPermalinkTooltip)"
   },
   "panel_contextMenuViewOnGateway": {

--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -55,14 +55,18 @@ const contextMenuImportToIpfs = 'contextMenu_importToIpfs'
 // Add X to IPFS
 const contextMenuImportToIpfsSelection = 'contextMenu_importToIpfsSelection'
 // Copy X
-const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpfsAddress'
+const contextMenuCopyCidAddress = 'panelCopy_currentIpfsAddress'
+const contextMenuCopyCanonicalAddress = 'panelCopy_currentIpnsAddress'
 const contextMenuCopyRawCid = 'panelCopy_copyRawCid'
 const contextMenuCopyAddressAtPublicGw = 'panel_copyCurrentPublicGwUrl'
 const contextMenuViewOnGateway = 'panel_contextMenuViewOnGateway'
+const contextMenuCopyPermalink = 'panel_copyCurrentPermalink'
+module.exports.contextMenuCopyCidAddress = contextMenuCopyCidAddress
 module.exports.contextMenuCopyCanonicalAddress = contextMenuCopyCanonicalAddress
 module.exports.contextMenuCopyRawCid = contextMenuCopyRawCid
 module.exports.contextMenuCopyAddressAtPublicGw = contextMenuCopyAddressAtPublicGw
 module.exports.contextMenuViewOnGateway = contextMenuViewOnGateway
+module.exports.contextMenuCopyPermalink = contextMenuCopyPermalink
 
 // menu items that are enabled only when API is online
 const apiMenuItems = new Set()

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -43,6 +43,12 @@ function createCopier (notify, ipfsPathValidator) {
       await copyTextToClipboard(ipfsPath, notify)
     },
 
+    async copyCidAddress (context, contextType) {
+      const url = await findValueForContext(context, contextType)
+      const ipfsPath = await ipfsPathValidator.resolveToImmutableIpfsPath(url)
+      await copyTextToClipboard(ipfsPath, notify)
+    },
+
     async copyRawCid (context, contextType) {
       const url = await findValueForContext(context, contextType)
       try {
@@ -68,6 +74,12 @@ function createCopier (notify, ipfsPathValidator) {
       const url = await findValueForContext(context, contextType)
       const publicUrl = ipfsPathValidator.resolveToPublicUrl(url)
       await copyTextToClipboard(publicUrl, notify)
+          },
+
+      async copyPermalink (context, contextType) {
+      const url = await findValueForContext(context, contextType)
+      const permalink = await ipfsPathValidator.resolveToPermalink(url)
+      await copyTextToClipboard(permalink, notify)
     }
   }
 }

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -74,9 +74,9 @@ function createCopier (notify, ipfsPathValidator) {
       const url = await findValueForContext(context, contextType)
       const publicUrl = ipfsPathValidator.resolveToPublicUrl(url)
       await copyTextToClipboard(publicUrl, notify)
-          },
+    },
 
-      async copyPermalink (context, contextType) {
+    async copyPermalink (context, contextType) {
       const url = await findValueForContext(context, contextType)
       const permalink = await ipfsPathValidator.resolveToPermalink(url)
       await copyTextToClipboard(permalink, notify)

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -281,6 +281,7 @@ module.exports = async function init () {
       if (info.isIpfsContext) {
         info.currentTabPublicUrl = ipfsPathValidator.resolveToPublicUrl(url)
         info.currentTabContentPath = ipfsPathValidator.resolveToIpfsPath(url)
+        info.currentTabImmutablePath = ipfsPathValidator.resolveToImmutableIpfsPath(url)
         info.currentTabPermalink = ipfsPathValidator.resolveToPermalink(url)
         if (!url2cidCache.has(url)) {
           // run async resolution in the next event loop

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -281,8 +281,8 @@ module.exports = async function init () {
       if (info.isIpfsContext) {
         info.currentTabPublicUrl = ipfsPathValidator.resolveToPublicUrl(url)
         info.currentTabContentPath = ipfsPathValidator.resolveToIpfsPath(url)
-        info.currentTabImmutablePath = ipfsPathValidator.resolveToImmutableIpfsPath(url)
-        info.currentTabPermalink = ipfsPathValidator.resolveToPermalink(url)
+        info.currentTabImmutablePath = await ipfsPathValidator.resolveToImmutableIpfsPath(url)
+        info.currentTabPermalink = await ipfsPathValidator.resolveToPermalink(url)
         if (!url2cidCache.has(url)) {
           // run async resolution in the next event loop
           setImmediate(async () => {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -21,7 +21,7 @@ const createNotifier = require('./notifier')
 const createCopier = require('./copier')
 const createInspector = require('./inspector')
 const { createRuntimeChecks } = require('./runtime-checks')
-const { createContextMenus, findValueForContext, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuViewOnGateway } = require('./context-menus')
+const { createContextMenus, findValueForContext, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuViewOnGateway, contextMenuCopyPermalink, contextMenuCopyCidAddress } = require('./context-menus')
 const createIpfsProxy = require('./ipfs-proxy')
 const { registerSubdomainProxy } = require('./http-proxy')
 const { showPendingLandingPages } = require('./on-installed')
@@ -235,8 +235,10 @@ module.exports = async function init () {
     notification: (message) => notify(message.title, message.message),
     [contextMenuViewOnGateway]: inspector.viewOnGateway,
     [contextMenuCopyCanonicalAddress]: copier.copyCanonicalAddress,
+    [contextMenuCopyCidAddress]: copier.copyCidAddress,
     [contextMenuCopyRawCid]: copier.copyRawCid,
-    [contextMenuCopyAddressAtPublicGw]: copier.copyAddressAtPublicGw
+    [contextMenuCopyAddressAtPublicGw]: copier.copyAddressAtPublicGw,
+    [contextMenuCopyPermalink]: copier.copyPermalink
   }
 
   function handleMessageFromBrowserAction (message) {

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -281,6 +281,7 @@ module.exports = async function init () {
       if (info.isIpfsContext) {
         info.currentTabPublicUrl = ipfsPathValidator.resolveToPublicUrl(url)
         info.currentTabContentPath = ipfsPathValidator.resolveToIpfsPath(url)
+        info.currentTabPermalink = ipfsPathValidator.resolveToPermalink(url)
         if (!url2cidCache.has(url)) {
           // run async resolution in the next event loop
           setImmediate(async () => {

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -254,6 +254,20 @@ function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
       return null
     },
 
+    // Resolve URL or path to HTTP URL with CID:
+    // - IPFS paths are attached to HTTP Gateway root
+    // - URL of DNSLinked websties are resolved to CIDs
+    // The purpose of this resolver is to always return a meaningful, publicly
+    // accessible URL that can be accessed without the need of an IPFS client
+    // and that never changes.
+    async resolveToPermalink (urlOrPath, optionalGatewayUrl) {
+      const input = urlOrPath
+      const ipfsPath = await this.resolveToImmutableIpfsPath(input)
+      const gateway = optionalGatewayUrl || getState().pubGwURLString
+      if (ipfsPath) return pathAtHttpGateway(ipfsPath, gateway)
+      return input.startsWith('http') ? input : null
+    },
+
     // Resolve URL or path to IPFS Path:
     // - The path can be /ipfs/ or /ipns/
     // - Keeps pathname + ?search + #hash from original URL

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -6,7 +6,7 @@ const isIPFS = require('is-ipfs')
 const isFQDN = require('is-fqdn')
 
 // For how long more expensive lookups (DAG traversal etc) should be cached
-const RESULT_TTL_MS = 30 * 1000
+const RESULT_TTL_MS = 300000 // 5 minutes
 
 // Turns URL or URIencoded path into a content path
 function ipfsContentPath (urlOrPath, opts) {

--- a/add-on/src/popup/browser-action/browser-action.css
+++ b/add-on/src/popup/browser-action/browser-action.css
@@ -9,7 +9,7 @@
 
 .header-icon:active {
   color: #edf0f4;
-  transform: translateY(4px);
+  transform: translateY(2px);
 }
 .header-icon[disabled],
 .header-icon[disabled]:active {

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -9,8 +9,10 @@ const { sameGateway } = require('../../lib/ipfs-path')
 const {
   contextMenuViewOnGateway,
   contextMenuCopyAddressAtPublicGw,
+  contextMenuCopyPermalink,
   contextMenuCopyRawCid,
-  contextMenuCopyCanonicalAddress
+  contextMenuCopyCanonicalAddress,
+  contextMenuCopyCidAddress
 } = require('../../lib/context-menus')
 
 // Context Actions are displayed in Browser Action and Page Action (FF only)
@@ -68,6 +70,11 @@ function contextActions ({
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
     helperText: currentTabContentPath,
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
+  })}
+  ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyPermalink),
+    title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
+    onClick: () => onCopy(contextMenuCopyPermalink)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -60,13 +60,6 @@ function contextActions ({
     text: browser.i18n.getMessage(contextMenuViewOnGateway),
     onClick: () => onViewOnGateway(contextMenuViewOnGateway)
   }) : null}
-  ${navItem({
-    text: browser.i18n.getMessage('panel_pinCurrentIpfsAddress'),
-    title: browser.i18n.getMessage('panel_pinCurrentIpfsAddressTooltip'),
-    disabled: !activePinControls,
-    switchValue: (isPinned || isPinning) && !isUnPinning,
-    onClick: isPinned ? onUnPin : onPin
-  })}
   ${isRedirectContext ? navItem({
     text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
     title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
@@ -97,6 +90,13 @@ function contextActions ({
     helperText: (currentTabCid || browser.i18n.getMessage('panelCopy_copyRawCidNotReadyHint')),
     disabled: !activeCidResolver,
     onClick: () => onCopy(contextMenuCopyRawCid)
+  })}
+  ${navItem({
+    text: browser.i18n.getMessage('panel_pinCurrentIpfsAddress'),
+    title: browser.i18n.getMessage('panel_pinCurrentIpfsAddressTooltip'),
+    disabled: !activePinControls,
+    switchValue: (isPinned || isPinning) && !isUnPinning,
+    onClick: isPinned ? onUnPin : onPin
   })}
   </div>
     `

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -58,26 +58,25 @@ function contextActions ({
   ? navItem({
     text: browser.i18n.getMessage(contextMenuViewOnGateway),
     onClick: () => onViewOnGateway(contextMenuViewOnGateway)
-  })
-  : null}
-  ${navItem({
+  }) : null}
+  ${isRedirectContext ? navItem({
     text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
     title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
     helperText: currentTabPublicUrl,
     onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
-  })}
+  }) : ''}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyPermalink),
     title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
     helperText: 'foo ' + currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
-  ${navItem({
+  ${isRedirectContext ? navItem({
     text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpnsAddressTooltip'),
     helperText: currentTabContentPath,
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
-  })}
+  }) : ''}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCidAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -29,6 +29,7 @@ function contextActions ({
   currentTabContentPath,
   currentTabCid,
   currentTabPublicUrl,
+  currentTabPermalink,
   ipfsNodeType,
   isIpfsContext,
   isPinning,
@@ -66,15 +67,16 @@ function contextActions ({
     onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
   })}
   ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyPermalink),
+    title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
+    helperText: 'foo' + currentTabPermalink,
+    onClick: () => onCopy(contextMenuCopyPermalink)
+  })}
+  ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
     helperText: currentTabContentPath,
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
-  })}
-  ${navItem({
-    text: browser.i18n.getMessage(contextMenuCopyPermalink),
-    title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
-    onClick: () => onCopy(contextMenuCopyPermalink)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -56,28 +56,33 @@ function contextActions ({
     if (!isIpfsContext) return
     return html`<div>
   ${activeViewOnGateway(currentTab)
-  ? navItem({
-    text: browser.i18n.getMessage(contextMenuViewOnGateway),
-    onClick: () => onViewOnGateway(contextMenuViewOnGateway)
-  }) : null}
-  ${isRedirectContext ? navItem({
-    text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
-    title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
-    helperText: currentTabPublicUrl,
-    onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
-  }) : ''}
+    ? navItem({
+      text: browser.i18n.getMessage(contextMenuViewOnGateway),
+      onClick: () => onViewOnGateway(contextMenuViewOnGateway)
+    })
+    : null}
+  ${isRedirectContext
+    ? navItem({
+      text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
+      title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
+      helperText: currentTabPublicUrl,
+      onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
+    })
+    : ''}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyPermalink),
     title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
     helperText: currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
-  ${isRedirectContext ? navItem({
-    text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
-    title: browser.i18n.getMessage('panelCopy_currentIpnsAddressTooltip'),
-    helperText: currentTabContentPath,
-    onClick: () => onCopy(contextMenuCopyCanonicalAddress)
-  }) : ''}
+  ${isRedirectContext
+    ? navItem({
+      text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
+      title: browser.i18n.getMessage('panelCopy_currentIpnsAddressTooltip'),
+      helperText: currentTabContentPath,
+      onClick: () => onCopy(contextMenuCopyCanonicalAddress)
+    })
+    : ''}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCidAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -60,6 +60,13 @@ function contextActions ({
     text: browser.i18n.getMessage(contextMenuViewOnGateway),
     onClick: () => onViewOnGateway(contextMenuViewOnGateway)
   }) : null}
+  ${navItem({
+    text: browser.i18n.getMessage('panel_pinCurrentIpfsAddress'),
+    title: browser.i18n.getMessage('panel_pinCurrentIpfsAddressTooltip'),
+    disabled: !activePinControls,
+    switchValue: (isPinned || isPinning) && !isUnPinning,
+    onClick: isPinned ? onUnPin : onPin
+  })}
   ${isRedirectContext ? navItem({
     text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
     title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
@@ -69,7 +76,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyPermalink),
     title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
-    helperText: currentTabPermalink,
+    helperText: 'foo ' + currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
   ${isRedirectContext ? navItem({
@@ -81,7 +88,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCidAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
-    helperText: currentTabImmutablePath,
+    helperText: 'bar ' + currentTabImmutablePath,
     onClick: () => onCopy(contextMenuCopyCidAddress)
   })}
   ${navItem({
@@ -90,13 +97,6 @@ function contextActions ({
     helperText: (currentTabCid || browser.i18n.getMessage('panelCopy_copyRawCidNotReadyHint')),
     disabled: !activeCidResolver,
     onClick: () => onCopy(contextMenuCopyRawCid)
-  })}
-  ${navItem({
-    text: browser.i18n.getMessage('panel_pinCurrentIpfsAddress'),
-    title: browser.i18n.getMessage('panel_pinCurrentIpfsAddressTooltip'),
-    disabled: !activePinControls,
-    switchValue: (isPinned || isPinning) && !isUnPinning,
-    onClick: isPinned ? onUnPin : onPin
   })}
   </div>
     `

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -15,6 +15,8 @@ const {
   contextMenuCopyCidAddress
 } = require('../../lib/context-menus')
 
+const notReady = browser.i18n.getMessage('panelCopy_notReadyHint')
+
 // Context Actions are displayed in Browser Action and Page Action (FF only)
 function contextActions ({
   active,
@@ -26,11 +28,11 @@ function contextActions ({
   currentFqdn,
   currentDnslinkFqdn,
   currentTabIntegrationsOptOut,
-  currentTabContentPath,
-  currentTabImmutablePath,
-  currentTabCid,
-  currentTabPublicUrl,
-  currentTabPermalink,
+  currentTabContentPath = notReady,
+  currentTabImmutablePath = notReady,
+  currentTabCid = notReady,
+  currentTabPublicUrl = notReady,
+  currentTabPermalink = notReady,
   ipfsNodeType,
   isIpfsContext,
   isPinning,
@@ -93,7 +95,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),
     title: browser.i18n.getMessage('panelCopy_copyRawCidTooltip'),
-    helperText: (currentTabCid || browser.i18n.getMessage('panelCopy_copyRawCidNotReadyHint')),
+    helperText: currentTabCid,
     disabled: !activeCidResolver,
     onClick: () => onCopy(contextMenuCopyRawCid)
   })}

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -64,20 +64,20 @@ function contextActions ({
       onClick: () => onViewOnGateway(contextMenuViewOnGateway)
     })
     : null}
+  ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
+    title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
+    helperText: currentTabPublicUrl,
+    onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
+  })}
   ${isMutable
     ? navItem({
-      text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
-      title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
-      helperText: currentTabPublicUrl,
-      onClick: () => onCopy(contextMenuCopyAddressAtPublicGw)
+      text: browser.i18n.getMessage(contextMenuCopyPermalink),
+      title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
+      helperText: currentTabPermalink,
+      onClick: () => onCopy(contextMenuCopyPermalink)
     })
     : ''}
-  ${navItem({
-    text: browser.i18n.getMessage(contextMenuCopyPermalink),
-    title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
-    helperText: currentTabPermalink,
-    onClick: () => onCopy(contextMenuCopyPermalink)
-  })}
   ${isMutable
     ? navItem({
       text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -129,7 +129,7 @@ function activeTabActions (state) {
   const showActiveTabSection = (state.isRedirectContext) || state.isIpfsContext
   if (!showActiveTabSection) return
   return html`
-      <div class="mv1">
+      <div class="mb1">
       ${navHeader('panel_activeTabSectionHeader')}
       <div class="fade-in pv0">
         ${contextActions(state)}      </div>

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -46,6 +46,7 @@ function contextActions ({
 }) {
   const activeCidResolver = active && isIpfsOnline && isApiAvailable && currentTabCid
   const activePinControls = active && isIpfsOnline && isApiAvailable
+  const isMutable = currentTabContentPath.startsWith('/ipns/')
   const activeViewOnGateway = (currentTab) => {
     if (!currentTab) return false
     const { url } = currentTab
@@ -61,7 +62,7 @@ function contextActions ({
       onClick: () => onViewOnGateway(contextMenuViewOnGateway)
     })
     : null}
-  ${isRedirectContext
+  ${isMutable
     ? navItem({
       text: browser.i18n.getMessage(contextMenuCopyAddressAtPublicGw),
       title: browser.i18n.getMessage('panel_copyCurrentPublicGwUrlTooltip'),
@@ -75,7 +76,7 @@ function contextActions ({
     helperText: currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
-  ${isRedirectContext
+  ${isMutable
     ? navItem({
       text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
       title: browser.i18n.getMessage('panelCopy_currentIpnsAddressTooltip'),

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -76,7 +76,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyPermalink),
     title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
-    helperText: 'foo ' + currentTabPermalink,
+    helperText: currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
   ${isRedirectContext ? navItem({
@@ -88,7 +88,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCidAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
-    helperText: 'bar ' + currentTabImmutablePath,
+    helperText: currentTabImmutablePath,
     onClick: () => onCopy(contextMenuCopyCidAddress)
   })}
   ${navItem({

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -27,6 +27,7 @@ function contextActions ({
   currentDnslinkFqdn,
   currentTabIntegrationsOptOut,
   currentTabContentPath,
+  currentTabImmutablePath,
   currentTabCid,
   currentTabPublicUrl,
   currentTabPermalink,
@@ -68,7 +69,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyPermalink),
     title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
-    helperText: 'foo ' + currentTabPermalink,
+    helperText: currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
   ${isRedirectContext ? navItem({
@@ -80,7 +81,7 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCidAddress),
     title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
-    helperText: 'foo',
+    helperText: currentTabImmutablePath,
     onClick: () => onCopy(contextMenuCopyCidAddress)
   })}
   ${navItem({

--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -69,14 +69,20 @@ function contextActions ({
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyPermalink),
     title: browser.i18n.getMessage('panel_copyCurrentPermalinkTooltip'),
-    helperText: 'foo' + currentTabPermalink,
+    helperText: 'foo ' + currentTabPermalink,
     onClick: () => onCopy(contextMenuCopyPermalink)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyCanonicalAddress),
-    title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
+    title: browser.i18n.getMessage('panelCopy_currentIpnsAddressTooltip'),
     helperText: currentTabContentPath,
     onClick: () => onCopy(contextMenuCopyCanonicalAddress)
+  })}
+  ${navItem({
+    text: browser.i18n.getMessage(contextMenuCopyCidAddress),
+    title: browser.i18n.getMessage('panelCopy_currentIpfsAddressTooltip'),
+    helperText: 'foo',
+    onClick: () => onCopy(contextMenuCopyCidAddress)
   })}
   ${navItem({
     text: browser.i18n.getMessage(contextMenuCopyRawCid),

--- a/add-on/src/popup/browser-action/gateway-status.js
+++ b/add-on/src/popup/browser-action/gateway-status.js
@@ -26,7 +26,7 @@ module.exports = function gatewayStatus ({
 }) {
   const api = ipfsApiUrl && ipfsNodeType === 'embedded' ? 'js-ipfs' : ipfsApiUrl
   return html`
-    <ul class="fade-in list mv0 pv2 ph3 white">
+    <ul class="fade-in list mv0 pt2 ph3 white">
     ${statusEntry({
       label: 'panel_statusSwarmPeers',
       labelLegend: 'panel_statusSwarmPeersTitle',

--- a/add-on/src/popup/browser-action/header.js
+++ b/add-on/src/popup/browser-action/header.js
@@ -12,7 +12,7 @@ const gatewayStatus = require('./gateway-status')
 module.exports = function header (props) {
   const { ipfsNodeType, active, onToggleActive, onOpenPrefs, onOpenReleaseNotes, isIpfsOnline, onOpenWelcomePage, showUpdateIndicator } = props
   return html`
-    <div class="br2 br--top ba bw1 b--white ipfs-gradient-0">
+    <div>
       <div class="pt3 pr3 pb2 pl3 no-user-select flex justify-between items-center">
         <div class="inline-flex items-center">
         <div

--- a/add-on/src/popup/browser-action/nav-header.js
+++ b/add-on/src/popup/browser-action/nav-header.js
@@ -6,7 +6,7 @@ const html = require('choo/html')
 
 function navHeader (label) {
   return html`
-    <div class="no-select w-100 outline-0--focus tl ph3 pt3 pb1 o-40 f6 bt b--silver">
+    <div class="no-select w-100 outline-0--focus tl ph3 pt2 mt1 pb1 o-40 f6">
       ${browser.i18n.getMessage(label)}
     </div>
   `

--- a/add-on/src/popup/browser-action/page.js
+++ b/add-on/src/popup/browser-action/page.js
@@ -30,8 +30,10 @@ module.exports = function browserActionPage (state, emit) {
 
   return html`
     <div class="sans-serif" style="text-rendering: optimizeLegibility;">
-      ${header(headerProps)}
-      ${tools(opsProps)}
+      <div class="ba bw1 b--white ipfs-gradient-0">
+        ${header(headerProps)}
+        ${tools(opsProps)}
+      </div>
       ${activeTabActions(activeTabActionsProps)}
     </div>
   `

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -6,7 +6,7 @@ const isIPFS = require('is-ipfs')
 const all = require('it-all')
 const { trimHashAndSearch, ipfsContentPath } = require('../../lib/ipfs-path')
 const { welcomePage } = require('../../lib/on-installed')
-const { contextMenuViewOnGateway, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress } = require('../../lib/context-menus')
+const { contextMenuViewOnGateway, contextMenuCopyAddressAtPublicGw, contextMenuCopyPermalink, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuCopyCidAddress } = require('../../lib/context-menus')
 
 // The store contains and mutates the state for the app
 module.exports = (state, emitter) => {
@@ -76,11 +76,17 @@ module.exports = (state, emitter) => {
       case contextMenuCopyCanonicalAddress:
         port.postMessage({ event: contextMenuCopyCanonicalAddress })
         break
+      case contextMenuCopyCidAddress:
+        port.postMessage({ event: contextMenuCopyCidAddress })
+        break
       case contextMenuCopyRawCid:
         port.postMessage({ event: contextMenuCopyRawCid })
         break
       case contextMenuCopyAddressAtPublicGw:
         port.postMessage({ event: contextMenuCopyAddressAtPublicGw })
+        break
+      case contextMenuCopyPermalink:
+        port.postMessage({ event: contextMenuCopyPermalink })
         break
     }
     window.close()

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -313,7 +313,7 @@ module.exports = (state, emitter) => {
     if (state.isPinning || state.isUnPinning) return
     try {
       const currentPath = await resolveToPinPath(ipfs, status.currentTab.url)
-      const response = await all(ipfs.pin.ls(currentPath, { type: 'recursive', quiet: true }))
+      const response = await all(ipfs.pin.ls({ paths: [currentPath], type: 'recursive' }))
       console.log(`positive ipfs.pin.ls for ${currentPath}: ${JSON.stringify(response)}`)
       state.isPinned = true
     } catch (error) {

--- a/add-on/src/popup/browser-action/tools-button.js
+++ b/add-on/src/popup/browser-action/tools-button.js
@@ -4,7 +4,7 @@
 const html = require('choo/html')
 
 function toolsButton ({ iconD, iconSize, text, title, disabled, style, onClick }) {
-  let buttonStyle = 'button-reset fade-in w-50 ba bw1 snow b--snow bg-transparent f7 ph1 pv0 br4 ma1 flex justify-center items-center truncate'
+  let buttonStyle = 'fade-in w-50 ba bw1 snow b--snow bg-transparent f7 ph1 pv0 br4 ma1 flex justify-center items-center truncate'
   if (disabled) {
     buttonStyle += ' o-60'
   } else {
@@ -19,10 +19,10 @@ function toolsButton ({ iconD, iconSize, text, title, disabled, style, onClick }
 
   return html`
 
-    <button class="${buttonStyle}" onclick=${disabled ? null : onClick}  title="${title || ''}" ${disabled ? 'disabled' : ''}>
+    <div class="${buttonStyle}" onclick=${disabled ? null : onClick}  title="${title || ''}" ${disabled ? 'disabled' : ''}>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="mr1" width="${iconSize}" height="${iconSize}"><path fill="currentColor" d="${iconD}"/></svg>
       <div class="flex flex-row items-center justify-between"><div class="truncate">${text}</div></div>
-    </button>
+    </div>
   `
 }
 

--- a/add-on/src/popup/browser-action/tools-button.js
+++ b/add-on/src/popup/browser-action/tools-button.js
@@ -4,7 +4,7 @@
 const html = require('choo/html')
 
 function toolsButton ({ iconD, iconSize, text, title, disabled, style, onClick }) {
-  let buttonStyle = 'fade-in w-50 ba bw1 snow b--snow bg-transparent f7 ph1 pv0 br4 ma1 flex justify-center items-center truncate'
+  let buttonStyle = 'header-icon fade-in w-50 ba bw1 snow b--snow bg-transparent f7 ph1 pv0 br4 ma1 flex justify-center items-center truncate'
   if (disabled) {
     buttonStyle += ' o-60'
   } else {

--- a/add-on/src/popup/browser-action/tools-button.js
+++ b/add-on/src/popup/browser-action/tools-button.js
@@ -1,0 +1,29 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+const html = require('choo/html')
+
+function toolsButton ({ icon, text, helperText, title, disabled, style, onClick }) {
+  let buttonStyle = 'button-reset fade-in w-50 ba bw1 snow b--snow bg-transparent f7 ph1 pv0 br4 ma1 flex justify-center items-center truncate'
+  if (disabled) {
+    buttonStyle += ' o-60'
+  } else {
+    buttonStyle += ' pointer'
+  }
+  if (style) {
+    buttonStyle += ` ${style}`
+  }
+  if (disabled) {
+    title = ''
+  }
+
+  return html`
+
+    <button class="${buttonStyle}" onclick=${disabled ? null : onClick}  title="${title || ''}" ${disabled ? 'disabled' : ''}>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="mr1" width="20"><path fill="currentColor" d="M71.13 28.87a29.88 29.88 0 100 42.26 29.86 29.86 0 000-42.26zm-18.39 37.6h-5.48V52.74H33.53v-5.48h13.73V33.53h5.48v13.73h13.73v5.48H52.74z"/></svg>
+      <div class="flex flex-row items-center justify-between"><div class="truncate">${text}</div></div>
+    </button>
+  `
+}
+
+module.exports = toolsButton

--- a/add-on/src/popup/browser-action/tools-button.js
+++ b/add-on/src/popup/browser-action/tools-button.js
@@ -3,7 +3,7 @@
 
 const html = require('choo/html')
 
-function toolsButton ({ icon, text, helperText, title, disabled, style, onClick }) {
+function toolsButton ({ iconD, iconSize, text, title, disabled, style, onClick }) {
   let buttonStyle = 'button-reset fade-in w-50 ba bw1 snow b--snow bg-transparent f7 ph1 pv0 br4 ma1 flex justify-center items-center truncate'
   if (disabled) {
     buttonStyle += ' o-60'
@@ -20,7 +20,7 @@ function toolsButton ({ icon, text, helperText, title, disabled, style, onClick 
   return html`
 
     <button class="${buttonStyle}" onclick=${disabled ? null : onClick}  title="${title || ''}" ${disabled ? 'disabled' : ''}>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="mr1" width="20"><path fill="currentColor" d="M71.13 28.87a29.88 29.88 0 100 42.26 29.86 29.86 0 000-42.26zm-18.39 37.6h-5.48V52.74H33.53v-5.48h13.73V33.53h5.48v13.73h13.73v5.48H52.74z"/></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="mr1" width="${iconSize}" height="${iconSize}"><path fill="currentColor" d="${iconD}"/></svg>
       <div class="flex flex-row items-center justify-between"><div class="truncate">${text}</div></div>
     </button>
   `

--- a/add-on/src/popup/browser-action/tools.js
+++ b/add-on/src/popup/browser-action/tools.js
@@ -22,13 +22,17 @@ module.exports = function tools ({
     text: browser.i18n.getMessage('panel_quickImport'),
     title: browser.i18n.getMessage('panel_quickImportTooltip'),
     disabled: !activeQuickImport,
-    onClick: onQuickImport
+    onClick: onQuickImport,
+    iconSize: 20,
+    iconD: 'M71.13 28.87a29.88 29.88 0 100 42.26 29.86 29.86 0 000-42.26zm-18.39 37.6h-5.48V52.74H33.53v-5.48h13.73V33.53h5.48v13.73h13.73v5.48H52.74z'
   })}
   ${toolsButton({
     text: browser.i18n.getMessage('panel_openWebui'),
     title: browser.i18n.getMessage('panel_openWebuiTooltip'),
     disabled: !activeWebUI,
-    onClick: onOpenWebUi
+    onClick: onOpenWebUi,
+    iconSize: 18,
+    iconD: 'M69.69 20.57c-.51-.51-1.06-1-1.62-1.47l-.16-.1c-.56-.46-1.15-.9-1.76-1.32l-.5-.35c-.25-.17-.52-.32-.79-.48A28.27 28.27 0 0050 12.23h-.69a28.33 28.33 0 00-27.52 28.36c0 13.54 19.06 37.68 26 46a3.21 3.21 0 005 0c6.82-8.32 25.46-32.25 25.46-45.84a28.13 28.13 0 00-8.56-20.18zM51.07 49.51a9.12 9.12 0 119.13-9.12 9.12 9.12 0 01-9.13 9.12z'
   })}
     </div>
   `

--- a/add-on/src/popup/browser-action/tools.js
+++ b/add-on/src/popup/browser-action/tools.js
@@ -3,7 +3,7 @@
 
 const browser = require('webextension-polyfill')
 const html = require('choo/html')
-const navItem = require('./nav-item')
+const toolsButton = require('./tools-button')
 
 module.exports = function tools ({
   active,
@@ -17,14 +17,14 @@ module.exports = function tools ({
   const activeWebUI = active && isIpfsOnline && ipfsNodeType !== 'embedded'
 
   return html`
-    <div class="fade-in pv1">
-  ${navItem({
+    <div class="flex pb2 ph2 justify-between">
+  ${toolsButton({
     text: browser.i18n.getMessage('panel_quickImport'),
     title: browser.i18n.getMessage('panel_quickImportTooltip'),
     disabled: !activeQuickImport,
     onClick: onQuickImport
   })}
-  ${navItem({
+  ${toolsButton({
     text: browser.i18n.getMessage('panel_openWebui'),
     title: browser.i18n.getMessage('panel_openWebuiTooltip'),
     disabled: !activeWebUI,

--- a/package.json
+++ b/package.json
@@ -165,5 +165,10 @@
   "engines": {
     "node": ">=10.0.0",
     "npm": ">=6.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run fix:lint:standard"
+    }
   }
 }


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-companion/issues/740.

This PR moves @deedlefake's work originally in https://github.com/ipfs-shipyard/ipfs-companion/pull/745 to account for some significant changes to the codebase since then.

- [x] Adds "Copy Snapshot Link" menu item that generates immutable permalink in the form of `https://bafy..foo.ipfs.dweb.link/wiki/`
- [x] Adds "Copy Content Path Snapshot" menu item that generates path in the form of ` /ipfs/bafy..foo/wiki/`
- [x] Renames existing "Copy IPFS Content Path" menu item to "Copy IPNS Content Path"
- [x] Clean up hover text for all menu items for better clarity/accuracy
- [x] Wire up smaller gray preview text for new menu items
- [x] Move tools options (import, go to node) into header area for semantic clarity (they apply to all of Companion, not just current tab)
- [x] Check height in Firefox and amend if needed
- [x] Test: make sure things do/don't display as expected on different kinds of sites
     - [x] Local page: Companion welcome page
     - [x] Ordinary web2 page: https://http.cat/
     - [x] Gateway page: https://ipfs.io/ipfs/QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D
     - [x] DNSLink page: https://docs.ipfs.io/

### Screenshots

Local page
![image](https://user-images.githubusercontent.com/1507828/97764227-8bc07680-1ad3-11eb-9d21-0a9e5e8becef.png)

🚨 🚨 **Ordinary web2 page (this ain't right!):**
![image](https://user-images.githubusercontent.com/1507828/97764434-4b152d00-1ad4-11eb-9eda-4d2325aaaa25.png)

Gateway page:
![image](https://user-images.githubusercontent.com/1507828/97764290-bca0ab80-1ad3-11eb-9f57-baf24caa52b3.png)

DNSLink page:
![image](https://user-images.githubusercontent.com/1507828/97764336-db9f3d80-1ad3-11eb-9bba-25ca6f049002.png)


