### PR TITLE
fix: isHostname reports malformed IPv6 addresses as valid

### DIFF
--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -119,7 +119,19 @@ exports.safeURL = safeURL
 exports.guiURLString = guiURLString
 
 // ensure value is a valid URL.hostname (FQDN || ipv4 || ipv6 WITH brackets)
-exports.isHostname = x => isFQDN(x) || isIP.v4(x) || (!isIP.v6(x) && isIP.v6(x.replace(/[[\]]+/g, '')))
+exports.isHostname = x => {
+  if (isFQDN(x) || isIP.v4(x)) {
+    return true
+  }
+
+  const match = x.match(/^\[(.*)\]$/)
+
+  if (match == null) {
+    return false
+  }
+
+  return isIP.v6(match[1])
+}
 
 // convert JS array to multiline textarea
 function hostArrayCleanup (array) {

--- a/test/functional/lib/options.test.js
+++ b/test/functional/lib/options.test.js
@@ -77,6 +77,15 @@ describe('isHostname()', function () {
   it('should return false for invalid URL.hostname (ipv6 without brackets)', () => {
     expect(isHostname('fe80::bb67:770c:8a97:1')).to.equal(false)
   })
+  it('should return false for ipv6 with a missing bracket', () => {
+    expect(
+      isHostname('[fe80::bb67:770c:8a97:1') ||
+      isHostname('fe80::bb67:770c:8a97:1]')
+    ).to.equal(false)
+  })
+  it('should return false for ipv6 with malformed brackets', () => {
+    expect(isHostname('[fe80::bb67:770c:8a97]:1]')).to.equal(false)
+  })
 })
 
 describe('hostTextToArray()', function () {


### PR DESCRIPTION
Previous version of the function was reporting addresses like ``]::1[`` or even ``]:]:]1]`` as valid.