### PR TITLE
fix: URI router preserving the URI path

### DIFF
--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -37,32 +37,32 @@
     {
       "protocol": "web+dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
     },
     {
       "protocol": "web+ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
     },
     {
       "protocol": "web+ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
     },
     {
       "protocol": "dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
     },
     {
       "protocol": "ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
     },
     {
       "protocol": "ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
     }
   ]
 }

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -37,32 +37,32 @@
     {
       "protocol": "web+dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#%s"
     },
     {
       "protocol": "web+ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#%s"
     },
     {
       "protocol": "web+ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#%s"
     },
     {
       "protocol": "dweb",
       "name": "IPFS Companion: DWEB Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#%s"
     },
     {
       "protocol": "ipns",
       "name": "IPFS Companion: IPNS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#%s"
     },
     {
       "protocol": "ipfs",
       "name": "IPFS Companion: IPFS Protocol Handler",
-      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#%s"
+      "uriTemplate": "https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#%s"
     }
   ]
 }

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -508,7 +508,7 @@ function isSafeToRedirect (request, runtime) {
 
 // This is just a placeholder that we had to provide -- removed in normalizedRedirectingProtocolRequest()
 // It has to match URL from manifest.json/protocol_handlers
-const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#'
+const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#'
 
 function redirectingProtocolRequest (request) {
   return request.url.startsWith(redirectingProtocolEndpoint)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -508,7 +508,7 @@ function isSafeToRedirect (request, runtime) {
 
 // This is just a placeholder that we had to provide -- removed in normalizedRedirectingProtocolRequest()
 // It has to match URL from manifest.json/protocol_handlers
-const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#'
+const redirectingProtocolEndpoint = 'https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#'
 
 function redirectingProtocolRequest (request) {
   return request.url.startsWith(redirectingProtocolEndpoint)

--- a/test/functional/lib/ipfs-request-protocol-handlers.test.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.test.js
@@ -59,81 +59,81 @@ describe('modifyRequest.onBeforeRequest:', function () {
 
         // without web+ prefix (Firefox > 59: https://github.com/ipfs-shipyard/ipfs-companion/issues/164#issuecomment-356301174)
         it('should not be normalized if ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if ipns:/{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipns://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if ipfs://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
 
         // web+ prefixed versions (Firefox < 59 and Chrome)
         it('should not be normalized if web+ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+ipns:/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipns://{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if web+dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}:/bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}://bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/QmVGC4uCBDVEhCzsaJmvR5nVDgChM97kcYNehVm7L9jxtc#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
       })

--- a/test/functional/lib/ipfs-request-protocol-handlers.test.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.test.js
@@ -59,81 +59,81 @@ describe('modifyRequest.onBeforeRequest:', function () {
 
         // without web+ prefix (Firefox > 59: https://github.com/ipfs-shipyard/ipfs-companion/issues/164#issuecomment-356301174)
         it('should not be normalized if ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#ipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if ipns:/{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#ipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if ipns://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#ipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if ipfs://{fqdn}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#dweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#dweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#dweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#dweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
 
         // web+ prefixed versions (Firefox < 59 and Chrome)
         it('should not be normalized if web+ipfs:/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipfs://{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bipfs%3A%2F%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+ipns:/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bipns%3A%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+ipns://{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bipns%3A%2F%2Fipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should be normalized if web+dweb:/ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bdweb%3A%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).to.equal('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipfs/{CID}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bdweb%3A%2F%2Fipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should be normalized if web+dweb:/ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bdweb%3A%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request).redirectUrl).equal('https://ipfs.io/ipns/ipfs.io?argTest#hashTest')
         })
         it('should not be normalized if web+dweb://ipns/{foo}', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bdweb%3A%2F%2Fipns/ipfs.io%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}:/bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bfoo%3A%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
         it('should not be normalized if web+{foo}://bar', function () {
-          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreihnpo5zt7qt3lvmk4zk2opran7ybbe3gfp5ruqf5iirdyxaxqvwtu#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
+          const request = url2request('https://gateway.ipfs.io/ipfs/bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm#web%2Bfoo%3A%2F%2Fbar%3FargTest%23hashTest')
           expect(modifyRequest.onBeforeRequest(request)).to.equal(undefined)
         })
       })


### PR DESCRIPTION
Some improvements to the intermediate router page we use for URI support:

:point_right: Open "Test" links in incognito window, it will use public gateway as a fallback and give better feeling of how things behave when network is slow.

- [x] hide error UI and display "Processing IPFS request.." while   redirecting for a nicer UX (no error flashing red for a bling of an eye)
- [x] preserve path, so URIs like below work:
  - Demo: https://bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm.ipfs.dweb.link/#ipfs%3A%2F%2FQmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco%2Fwiki%2FDiego_Maradona.html
- [x] add support for dnslink names in ipns namespace
  - This can ship before we land https://github.com/ipfs/in-web-browsers/issues/169 – we will update our GW when go-ipfs 0.8.0 ships
  - Test: https://bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm.ipfs.dweb.link/#ipns%3A%2F%2Fdocs.ipfs.io
- [x] remove `cids` library – delegate all the conversion to path-router at the subdomain gateway
  - this removes the need for bumping library version when new encoding/codec is added, making this more future proof
  - we still check if URI starts with `qm` to display human-friendly help added in #911  
  - Demo: https://bafkreiacamq42cltx3ussmxb2ey3mmpisthrs3kelwuxnwt7oofvqsjvgm.ipfs.dweb.link/#ipfs%3A%2F%2Fqmbwqxbekc3p8tqskc98xmwnzrzdtrlmimpl8wbutgsmnr%2Fwiki%2FDiego_Maradona.html



