### PR TITLE
Change DNS resolution endpoint to allow ipns recursive resolution

### DIFF
--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -138,7 +138,7 @@ module.exports = function createDnslinkResolver (getState) {
       // js-ipfs-api does not provide method for fetching this
       // TODO: revisit after https://github.com/ipfs/js-ipfs-api/issues/501 is addressed
       // TODO: consider worst-case-scenario fallback to https://developers.google.com/speed/public-dns/docs/dns-over-https
-      const apiCall = `${apiProvider}api/v0/name/resolve/${fqdn}`
+      const apiCall = `${apiProvider}api/v0/name/resolve/${fqdn}?r=false`
       const xhr = new XMLHttpRequest() // older XHR API us used because window.fetch appends Origin which causes error 403 in go-ipfs
       // synchronous mode with small timeout
       // (it is okay, because we do it only once, then it is cached and read via readAndCacheDnslink)

--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -138,7 +138,7 @@ module.exports = function createDnslinkResolver (getState) {
       // js-ipfs-api does not provide method for fetching this
       // TODO: revisit after https://github.com/ipfs/js-ipfs-api/issues/501 is addressed
       // TODO: consider worst-case-scenario fallback to https://developers.google.com/speed/public-dns/docs/dns-over-https
-      const apiCall = `${apiProvider}api/v0/dns/${fqdn}?r=true`
+      const apiCall = `${apiProvider}api/v0/name/resolve/${fqdn}`
       const xhr = new XMLHttpRequest() // older XHR API us used because window.fetch appends Origin which causes error 403 in go-ipfs
       // synchronous mode with small timeout
       // (it is okay, because we do it only once, then it is cached and read via readAndCacheDnslink)


### PR DESCRIPTION
This fixes #877. I couldn't add any tests because, from what i saw, readDnslinkFromTxtRecord always get mocked. If this is a problem, and someone can point me to the right direction I could add tests.