### PR TITLE
fix: redirect to native URI in Brave

### DIFF
--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -42,6 +42,14 @@ function ipfsContentPath (urlOrPath, opts) {
 }
 exports.ipfsContentPath = ipfsContentPath
 
+// Turns URL or URIencoded path into a ipfs:// or ipns:// URI
+function ipfsUri (urlOrPath) {
+  const contentPath = ipfsContentPath(urlOrPath, { keepURIParams: true })
+  if (!contentPath) return null
+  return contentPath.replace(/^\/(ip[f|n]s)\//, '$1://')
+}
+exports.ipfsUri = ipfsUri
+
 function subdomainPatternMatch (url) {
   if (typeof url === 'string') {
     url = new URL(url)
@@ -245,8 +253,8 @@ function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
     },
 
     // Version of resolveToPublicUrl that always resolves to URL representing
-    // path gateway at local machine (This is ok, as subdomain will redirect
-    // to corre
+    // path gateway at local machine (This is ok, as localhost gw will redirect
+    // to correct subdomain)
     resolveToLocalUrl (urlOrPath) {
       const { gwURLString } = getState()
       const ipfsPath = ipfsContentPath(urlOrPath, { keepURIParams: true })

--- a/test/functional/lib/dnslink.test.js
+++ b/test/functional/lib/dnslink.test.js
@@ -21,7 +21,7 @@ function spoofDnsTxtRecord (fqdn, dnslinkResolver, value) {
 module.exports.spoofDnsTxtRecord = spoofDnsTxtRecord
 
 function spoofCachedDnslink (fqdn, dnslinkResolver, value) {
-  // spoofs existence of valid DNS TXT record (used on cache miss)
+  // spoofs existence of valid DNS TXT record (used on cache hit)
   dnslinkResolver.setDnslink(fqdn, value)
 }
 module.exports.spoofCachedDnslink = spoofCachedDnslink


### PR DESCRIPTION
This is a cosmetic fix that ensures IPFS resources are redirected to
`ipfs://` or `ipns://` URI and that URI is displayed in the browser UI
in the address bar.

Due to the way Brave implemented URI cloak for local HTTP-based gateway
provided by go-ipfs managed by the browser itself the regular redirect
done via webRequest API did not produce native URI in address bar.

However, `tabs.update` does the trick, so we use that for root requests.
We can remove this in the future, if webRequest behavior is fixed.

cc @autonome (mitigates issue we both discovered independently)