### PR TITLE
fix: inlined DNSLink names and context actions for URIs

### DIFF
--- a/add-on/src/popup/browser-action/context-actions.js
+++ b/add-on/src/popup/browser-action/context-actions.js
@@ -52,7 +52,7 @@ function contextActions ({
   const activeViewOnGateway = (currentTab) => {
     if (!currentTab) return false
     const { url } = currentTab
-    return !(sameGateway(url, gwURLString) || sameGateway(url, pubGwURLString))
+    return !(url.startsWith('ip') || sameGateway(url, gwURLString) || sameGateway(url, pubGwURLString))
   }
 
   const renderIpfsContextItems = () => {

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -218,8 +218,9 @@ module.exports = (state, emitter) => {
       // console.dir('toggleSiteIntegrations', state)
       await browser.storage.local.set({ disabledOn, enabledOn })
 
+      const path = ipfsContentPath(currentTab.url, { keepURIParams: true })
       // Reload the current tab to apply updated redirect preference
-      if (!currentDnslinkFqdn || !isIPFS.ipnsUrl(currentTab.url)) {
+      if (!currentDnslinkFqdn || !isIPFS.ipnsPath(path)) {
         // No DNSLink, reload URL as-is
         await browser.tabs.reload(currentTab.id)
       } else {
@@ -228,7 +229,6 @@ module.exports = (state, emitter) => {
         // from  http?://{fqdn}.ipns.gateway.tld/some/path
         // to    http://{fqdn}/some/path
         // (defaulting to http: https websites will have HSTS or a redirect)
-        const path = ipfsContentPath(currentTab.url, { keepURIParams: true })
         const originalUrl = path.replace(/^.*\/ipns\//, 'http://')
         await browser.tabs.update(currentTab.id, {
           // FF only: loadReplace: true,

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "ipfs-postmsg-proxy": "3.1.1",
     "is-fqdn": "2.0.1",
     "is-ip": "3.1.0",
-    "is-ipfs": "2.0.0",
+    "is-ipfs": "https://github.com/ipfs/is-ipfs/tarball/5d6d1a2aa2fc64b61f374532c1f0766ce38725f3",
     "it-all": "1.0.4",
     "it-concat": "1.0.2",
     "it-tar": "1.2.2",

--- a/test/functional/lib/dnslink.test.js
+++ b/test/functional/lib/dnslink.test.js
@@ -243,6 +243,16 @@ describe('dnslinkResolver (dnslinkPolicy=enabled)', function () {
       spoofDnsTxtRecord(fqdn, dnslinkResolver, dnslinkValue)
       expect(dnslinkResolver.findDNSLinkHostname(url)).to.equal(fqdn)
     })
+    it('should match <dns-label-inlined-fqdn>.ipns on public subdomain gateway', function () {
+      // Context: https://github.com/ipfs/in-web-browsers/issues/169
+      const fqdn = 'dnslink-site.com'
+      const fqdnInDNSLabel = 'dnslink--site-com'
+      const url = `https://${fqdnInDNSLabel}.ipns.dweb.link/some/path?ds=sdads#dfsdf`
+      const dnslinkResolver = createDnslinkResolver(getState)
+      spoofCachedDnslink(fqdnInDNSLabel, dnslinkResolver, false)
+      spoofCachedDnslink(fqdn, dnslinkResolver, dnslinkValue)
+      expect(dnslinkResolver.findDNSLinkHostname(url)).to.equal(fqdn)
+    })
   })
 
   after(() => {

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -87,6 +87,18 @@ describe('ipfs-path.js', function () {
       const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
       expect(ipfsContentPath(url)).to.equal('/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html')
     })
+    it('should resolve CID(libp2p-key)-in-subdomain URL to IPNS path', function () {
+      const url = 'https://k2k4r8ncs1yoluq95unsd7x2vfhgve0ncjoggwqx9vyh3vl8warrcp15.ipns.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsContentPath(url)).to.equal('/ipns/k2k4r8ncs1yoluq95unsd7x2vfhgve0ncjoggwqx9vyh3vl8warrcp15/wiki/Mars.html')
+    })
+    it('should resolve dnslink-in-subdomain URL to IPNS path', function () {
+      const url = 'http://en.wikipedia-on-ipfs.org.ipns.localhost:8080/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsContentPath(url)).to.equal('/ipns/en.wikipedia-on-ipfs.org/wiki/Mars.html')
+    })
+    it('should resolve inlined-dnslink-in-subdomain URL to IPNS path', function () {
+      const url = 'https://en-wikipedia--on--ipfs-org.ipns.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(ipfsContentPath(url)).to.equal('/ipns/en.wikipedia-on-ipfs.org/wiki/Mars.html')
+    })
     it('should return null if there is no valid path for input URL', function () {
       const url = 'https://foo.io/invalid/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
       expect(ipfsContentPath(url)).to.equal(null)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8095,10 +8095,22 @@ is-ip@^2.0.0:
   dependencies:
     ip-regex "^2.0.0"
 
-is-ipfs@2.0.0, is-ipfs@^2.0.0:
+is-ipfs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-2.0.0.tgz#c046622e4daf5435b671aeb9739a832107e06805"
   integrity sha512-X4Cg/JO+h/ygBCrIQSMgicHRLo5QpB+i5tHLhFgGBksKi3zvX6ByFCshDxNBvcq4NFxF3coI2AaLqwzugNzKcw==
+  dependencies:
+    cids "^1.0.0"
+    iso-url "~0.4.7"
+    mafmt "^8.0.0"
+    multiaddr "^8.0.0"
+    multibase "^3.0.0"
+    multihashes "^3.0.1"
+    uint8arrays "^1.1.0"
+
+"is-ipfs@https://github.com/ipfs/is-ipfs/tarball/5d6d1a2aa2fc64b61f374532c1f0766ce38725f3":
+  version "2.0.0"
+  resolved "https://github.com/ipfs/is-ipfs/tarball/5d6d1a2aa2fc64b61f374532c1f0766ce38725f3#91d1f03f4127094aef9e0738c43e67ea7f2c2b72"
   dependencies:
     cids "^1.0.0"
     iso-url "~0.4.7"


### PR DESCRIPTION
Final batch of fast-tracked cosmetics: 
- support for automatic redirect of inlined DNSLink names on subdomain gateways (https://github.com/ipfs/in-web-browsers/issues/169)
- restore context actions for pages loaded via native URIs (when `ipfs://`, `ipns://` is in address bar in Brave)

(in the past two years we've added subdomains and now native URIs: need to clean up and refactor most of ipfs-path, but that will be done in separate PRs as part of #939)