### PR TITLE
feat: switch to brave node if the default port is offline

### DIFF
--- a/add-on/src/lib/ipfs-client/index.js
+++ b/add-on/src/lib/ipfs-client/index.js
@@ -58,16 +58,24 @@ function _isWebuiTab (url) {
   return bundled || ipns
 }
 
+function _isInternalTab (url, extensionOrigin) {
+  return url.startsWith(extensionOrigin)
+}
+
 async function _reloadIpfsClientDependents (browser, instance, opts) {
   // online || offline
   if (browser.tabs && browser.tabs.query) {
     const tabs = await browser.tabs.query({})
     if (tabs) {
+      const extensionOrigin = browser.runtime.getURL('/')
       tabs.forEach((tab) => {
         // detect bundled webui in any of open tabs
         if (_isWebuiTab(tab.url)) {
+          log(`reloading webui at ${tab.url}`)
           browser.tabs.reload(tab.id)
-          log('reloading bundled webui')
+        } else if (_isInternalTab(tab.url, extensionOrigin)) {
+          log(`reloading internal extension page at ${tab.url}`)
+          browser.tabs.reload(tab.id)
         }
       })
     }

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -25,7 +25,7 @@ const { createRuntimeChecks } = require('./runtime-checks')
 const { createContextMenus, findValueForContext, contextMenuCopyAddressAtPublicGw, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuViewOnGateway, contextMenuCopyPermalink, contextMenuCopyCidAddress } = require('./context-menus')
 const createIpfsProxy = require('./ipfs-proxy')
 const { registerSubdomainProxy } = require('./http-proxy')
-const { showPendingLandingPages } = require('./on-installed')
+const { runPendingOnInstallTasks } = require('./on-installed')
 
 // init happens on addon load in background/background.js
 module.exports = async function init () {
@@ -89,7 +89,7 @@ module.exports = async function init () {
     await registerSubdomainProxy(getState, runtime, notify)
     log('init done')
     setApiStatusUpdateInterval(options.ipfsApiPollMs)
-    await showPendingLandingPages()
+    await runPendingOnInstallTasks()
   } catch (error) {
     log.error('Unable to initialize addon due to error', error)
     if (notify) notify('notify_addonIssueTitle', 'notify_addonIssueMsg')

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -10,24 +10,48 @@ exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/t
 exports.onInstalled = async (details) => {
   // details.temporary === run via `npm run firefox`
   if (details.reason === 'install' || details.temporary) {
-    await browser.storage.local.set({ showLandingPage: 'onInstallWelcome' })
+    await browser.storage.local.set({ onInstallTasks: 'onFirstInstall' })
   } else if (details.reason === 'update' || details.temporary) {
-    await browser.storage.local.set({ showLandingPage: 'onVersionUpdate' })
+    await browser.storage.local.set({ onInstallTasks: 'onVersionUpdate' })
   }
 }
 
-exports.showPendingLandingPages = async () => {
-  const { showLandingPage, displayReleaseNotes } = await browser.storage.local.get(['showLandingPage', 'displayReleaseNotes'])
-  switch (showLandingPage) {
-    case 'onInstallWelcome':
-      await browser.storage.local.remove('showLandingPage')
+exports.runPendingOnInstallTasks = async () => {
+  const { onInstallTasks, displayReleaseNotes } = await browser.storage.local.get(['onInstallTasks', 'displayReleaseNotes'])
+  await browser.storage.local.remove('onInstallTasks')
+  switch (onInstallTasks) {
+    case 'onFirstInstall':
+      await useNativeNodeIfFeasible(browser)
       return browser.tabs.create({
         url: exports.welcomePage
       })
     case 'onVersionUpdate':
-      await browser.storage.local.remove('showLandingPage')
       if (!displayReleaseNotes) return
       await browser.storage.local.set({ dismissedUpdate: version })
       return browser.tabs.create({ url: exports.updatePage + version })
+  }
+}
+
+async function useNativeNodeIfFeasible (browser) {
+  // lazy-loaded dependencies due to debug package
+  // depending on the value of localStorage.debug, which is set later
+  const debug = require('debug')
+  const log = debug('ipfs-companion:on-installed')
+  log.error = debug('ipfs-companion:on-installed:error')
+  const { brave, braveNodeType } = require('./ipfs-client/brave')
+  const { ipfsNodeType, ipfsApiUrl } = await browser.storage.local.get(['ipfsNodeType', 'ipfsApiUrl'])
+
+  // Brave >= v1.19 (https://brave.com/ipfs-support/)
+  if (typeof brave !== 'undefined' && ipfsNodeType !== braveNodeType) {
+    try {
+      log(`brave detected, but node type is ${ipfsNodeType}. testing external endpoint at ${ipfsApiUrl}`)
+      const response = await (await fetch(`${ipfsApiUrl}/api/v0/id`, { method: 'post' })).json()
+      if (typeof response.ID === 'undefined') throw new Error(`unable to read PeerID from API at ${ipfsApiUrl}`)
+      log(`endpoint is online, PeerID is ${response.ID}, nothing to do`)
+    } catch (e) {
+      log.error(`endpoint ${ipfsApiUrl} does not work`, e)
+      log('switching node type to one provided by brave')
+      await browser.storage.local.set({ ipfsNodeType: braveNodeType })
+    }
   }
 }


### PR DESCRIPTION
This PR improves onboarding experience  on Brave.

### TLDR

* Before this PR, user had to manually swith node type to "Provided by Brave"
* With this PR, when IPFS Companion is installed for the first time in Brave
  * AND there is no IPFS Daemon on port 8080 (defult go-ipfs and IPFS Desktop)
    * IF Brave node is already running, Companion will use it 
    * IF Brave node is not running, Companion will trigger onboarding flow

### Details 

- This is a small change that will default to endpoint provided by Brave when Brave runtime is detected and if the current endpoint (by default 127.0.0.1:8080) is offline.
  - This means user won't need to go to preferences and switch the backend to "Provided by Brave"
  - new users will have that set for them automatically 
  - (more or less what @Gozala suggested during this week's GUI/Web call).
- It also fixes a bug where "Welcome" page did not update when enabling Brave node required user interaction – we now reload internal pages  when a new backend finished its init chores (fixes bug @autonome reported, but was hard to track down).
- Sadly there is no way to test this other than manual. Looks ok on my end, will publish this as 1% rollout (#964) and we can refine it then.