### PR TITLE
chore: remove beta channel

### DIFF
--- a/DEVELOPER-NOTES.md
+++ b/DEVELOPER-NOTES.md
@@ -117,7 +117,6 @@ Each `npm` task can run separately, but most of the time, `dev-build`, `test`, a
 - `npm run firefox:nightly`: Run as temporary add-on in Firefox Nightly (uses one in `./firefox/`, see `get-firefox-nightly` below)
 - `npm run chromium`: Run as temporary add-on in Chromium
 - `npm run get-firefox-nightly`: Fetch latest Firefox nightly build to `./firefox/`
-- `npm run firefox:beta:add -- --update-link "https://host/path/to/file.xpi" file.xpi`: Add a manifest entry for new self-hosted beta for Firefox
 - `npm run build`: Build the add-on (copy external libraries, create `.zip` bundles for Chrome and Firefox)
 - `npm run watch`: Rebuild JS/CSS on file changes (run regular `build` first to ensure everything else is in place)
 - `npm run bundle:chromium`: Overwrite manifest and package a generic, Chromium-compatible version
@@ -134,7 +133,6 @@ Each `npm` task can run separately, but most of the time, `dev-build`, `test`, a
 Release build shortcuts:
 
 - `npm run dev-build`: All-in-one: fast dependency install, build with yarn (updates `yarn.lock` if needed)
-- `npm run beta-build`: Reproducible beta build in docker with frozen `yarn.lock`
 - `npm run release-build`: Reproducible release build in docker with frozen `yarn.lock`
 
 ## Other tips

--- a/README.md
+++ b/README.md
@@ -121,13 +121,6 @@ IPFS Companion ships with a variety of experimental features. Some are disabled 
 
 **Important!** Make sure you have [IPFS installed](https://ipfs.io/#install) on your computer as well. Because IPFS Companion (in its standard configuration) talks to your computer’s local IPFS node to work its browser magic, you’ll need to have IPFS running on your computer, too.
 
-### Beta channel
-
-Developers and enthusiasts can opt in to the beta-quality channel:
-
-- [Firefox self-hosted signed dev build](https://bafybeibjozlsoxzrxsoklis775aglnwpal2hjl42ippo57jdwiv6zoij7m.ipfs.dweb.link/)
-- [Chromium-based dev build at the Chrome Web Store](https://chrome.google.com/webstore/detail/ipfs-companion-dev-build/hjoieblefckbooibpepigmacodalfndh)
-
 It's also possible to grab [vendor-specific packages for each release](https://github.com/ipfs-shipyard/ipfs-companion/releases),
 but these builds are not signed, nor will automatically update. `.zip` bundles are meant only to be manually loaded via `chrome://extensions` (Chromium) or `about:debugging` (Firefox) for smoke-testing.
 

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -252,6 +252,7 @@ module.exports = async function init () {
     if (!browserActionPort) return
     const dropSlash = url => url.replace(/\/$/, '')
     const currentTab = await browser.tabs.query({ active: true, currentWindow: true }).then(tabs => tabs[0])
+    const { version } = browser.runtime.getManifest()
     const info = {
       active: state.active,
       ipfsNodeType: state.ipfsNodeType,
@@ -265,7 +266,7 @@ module.exports = async function init () {
       redirect: state.redirect,
       enabledOn: state.enabledOn,
       disabledOn: state.disabledOn,
-      showUpdateIndicator: state.dismissedUpdate !== browser.runtime.getManifest().version,
+      newVersion: state.dismissedUpdate !== version ? version : null,
       currentTab
     }
     try {

--- a/add-on/src/popup/browser-action/browser-action.css
+++ b/add-on/src/popup/browser-action/browser-action.css
@@ -43,3 +43,13 @@
   from { opacity: 0; }
   to   { opacity: 1; }
 }
+
+.blink {
+  animation: blink 1s linear infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}

--- a/add-on/src/popup/browser-action/header.js
+++ b/add-on/src/popup/browser-action/header.js
@@ -10,7 +10,7 @@ const ipfsVersion = require('./ipfs-version')
 const gatewayStatus = require('./gateway-status')
 
 module.exports = function header (props) {
-  const { ipfsNodeType, active, onToggleActive, onOpenPrefs, onOpenReleaseNotes, isIpfsOnline, onOpenWelcomePage, showUpdateIndicator } = props
+  const { ipfsNodeType, active, onToggleActive, onOpenPrefs, onOpenReleaseNotes, isIpfsOnline, onOpenWelcomePage, newVersion } = props
   return html`
     <div>
       <div class="pt3 pr3 pb2 pl3 no-user-select flex justify-between items-center">
@@ -36,8 +36,9 @@ module.exports = function header (props) {
           </div>
         </div>
         <div class="tr ma0 pb1">
-          ${showUpdateIndicator
+          ${newVersion
           ? versionUpdateIcon({
+            newVersion,
             active,
             title: 'panel_headerNewVersionTitle',
             action: onOpenReleaseNotes

--- a/add-on/src/popup/browser-action/icon.js
+++ b/add-on/src/popup/browser-action/icon.js
@@ -4,11 +4,11 @@
 const html = require('choo/html')
 const browser = require('webextension-polyfill')
 
-function icon ({ svg, title, active, action }) {
+function icon ({ svg, title, active, action, className }) {
   return html`
-    <button class="header-icon pa0 ma0 dib bn bg-transparent transition-all ${action ? 'pointer' : null} ${active ? 'aqua' : 'gray'}"
+    <button class="header-icon pa0 ma0 dib bn bg-transparent transition-all ${className} ${action ? 'pointer' : null} ${active ? 'aqua' : 'gray'}"
       style="outline:none;"
-      title="${browser.i18n.getMessage(title)}"
+      title="${browser.i18n.getMessage(title) || title}"
       onclick=${action}>
       ${svg}
     </button>

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -163,9 +163,16 @@ module.exports = (state, emitter) => {
 
   emitter.on('openReleaseNotes', async () => {
     const { version } = browser.runtime.getManifest()
-    const url = `https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v${version}`
+    const stableChannel = version.match(/\./g).length === 2
+    let url
     try {
-      await browser.storage.local.set({ dismissedUpdate: version })
+      if (stableChannel) {
+        url = `https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v${version}`
+        await browser.storage.local.set({ dismissedUpdate: version })
+      } else {
+        // swap URL and do not dismiss
+        url = 'https://github.com/ipfs-shipyard/ipfs-companion/issues/964'
+      }
       // Note: opening tab needs to happen after storage.local.set because in Chromium 86
       // it triggers a premature window.close, which aborts storage update
       await browser.tabs.create({ url })

--- a/add-on/src/popup/browser-action/version-update-icon.js
+++ b/add-on/src/popup/browser-action/version-update-icon.js
@@ -4,15 +4,28 @@
 const html = require('choo/html')
 const icon = require('./icon')
 
-function versionUpdateIcon ({ active, title, action, size = '1.8rem' }) {
-  const svg = html`
+function versionUpdateIcon ({ newVersion, active, title, action, className, size = '1.8rem' }) {
+  let svg = html`
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 86 86"
         class="fill-yellow-muted mr1"
         style="width:${size}; height:${size}">
         <path xmlns="http://www.w3.org/2000/svg" d="M71.13 28.87a29.88 29.88 0 100 42.26 29.86 29.86 0 000-42.26zm-18.39 37.6h-5.48V44.71h5.48zm0-26.53h-5.48v-5.49h5.48z"/>
       </svg>
     `
-  return icon({ svg, title, active, action })
+  // special handling for beta and dev builds
+  // TODO: remove when we have no users on beta channel anymore
+  if (newVersion.match(/\./g).length > 2) {
+    svg = html`
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 86 86"
+          class="fill-red-muted mr1"
+          style="width:${size}; height:${size}">
+          <path d="M82.84 71.14L55.06 23a5.84 5.84 0 00-10.12 0L17.16 71.14a5.85 5.85 0 005.06 8.77h55.56a5.85 5.85 0 005.06-8.77zm-30.1-.66h-5.48V65h5.48zm0-10.26h-5.48V38.46h5.48z"/>
+      </svg>
+    `
+    title = 'Beta channel is deprecated, please switch to regular releases'
+    className = `${className} blink`
+  }
+  return icon({ svg, title, active, action, className })
 }
 
 module.exports = versionUpdateIcon


### PR DESCRIPTION
Closes #964 

- [x] detect when running as beta and add icon indicator that opens explainer in #964:
  > ![Peek 2021-01-30 03-03](https://user-images.githubusercontent.com/157609/106344162-5f222380-62a9-11eb-843d-5b57fcf1430d.gif)

- [x] remove "beta channel"  from docs
- [x] keep scripts around in case we need to build a new beta with more prominent messaging in the future
