### PR TITLE
refactor: adjust Brave activation UI flow

### DIFF
--- a/add-on/src/landing-pages/welcome/page.js
+++ b/add-on/src/landing-pages/welcome/page.js
@@ -7,6 +7,7 @@ const { renderTranslatedLinks, renderTranslatedSpans } = require('../../utils/i1
 
 // Brave detection
 const { brave } = require('../../../src/lib/ipfs-client/brave')
+const { optionsPage } = require('../../../src/lib/constants')
 
 // Assets
 const libp2pLogo = '../../../images/libp2p.svg'
@@ -99,7 +100,7 @@ const renderInstallSteps = (i18n, isIpfsOnline) => {
     </svg>
   `
 
-  const optionsUrl = browser.extension.getURL('dist/options/options.html')
+  const optionsUrl = browser.extension.getURL(optionsPage)
   return html`
     <div class="w-80 mt0 flex flex-column transition-all ${stateUnknown && 'state-unknown'}">
       <div class="mb4 flex flex-column justify-center items-center">

--- a/add-on/src/lib/constants.js
+++ b/add-on/src/lib/constants.js
@@ -1,0 +1,6 @@
+'use strict'
+/* eslint-env browser, webextensions */
+
+exports.welcomePage = '/dist/landing-pages/welcome/index.html'
+exports.optionsPage = '/dist/options/options.html'
+exports.tickMs = 250 // no CPU spike, but still responsive enough

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -12,7 +12,7 @@ const LRU = require('lru-cache')
 const all = require('it-all')
 const { optionDefaults, storeMissingOptions, migrateOptions, guiURLString, safeURL } = require('./options')
 const { initState, offlinePeerCount } = require('./state')
-const { createIpfsPathValidator, sameGateway } = require('./ipfs-path')
+const { createIpfsPathValidator, sameGateway, safeHostname } = require('./ipfs-path')
 const createDnslinkResolver = require('./dnslink')
 const { createRequestModifier } = require('./ipfs-request')
 const { initIpfsClient, destroyIpfsClient } = require('./ipfs-client')
@@ -301,7 +301,7 @@ module.exports = async function init () {
         }
       }
       info.currentDnslinkFqdn = dnslinkResolver.findDNSLinkHostname(url)
-      info.currentFqdn = info.currentDnslinkFqdn || new URL(url).hostname
+      info.currentFqdn = info.currentDnslinkFqdn || safeHostname(url)
       info.currentTabIntegrationsOptOut = !state.activeIntegrations(info.currentFqdn)
       info.isRedirectContext = info.currentFqdn && ipfsPathValidator.isRedirectPageActionsContext(url)
     }

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -147,6 +147,18 @@ function sameGateway (url, gwUrl) {
 }
 exports.sameGateway = sameGateway
 
+const safeHostname = (url) => {
+  // In case vendor-specific thing like brave://settings/extensions
+  // cause errors, we don't throw, just return null
+  try {
+    return new URL(url).hostname
+  } catch (e) {
+    console.error(`[ipfs-companion] safeHostname(url) error for url='${url}'`, e)
+  }
+  return null
+}
+exports.safeHostname = safeHostname
+
 function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
   const ipfsPathValidator = {
     // Test if URL is a Public IPFS resource

--- a/add-on/src/lib/on-installed.js
+++ b/add-on/src/lib/on-installed.js
@@ -4,7 +4,7 @@
 const browser = require('webextension-polyfill')
 const { version } = browser.runtime.getManifest()
 
-exports.welcomePage = '/dist/landing-pages/welcome/index.html'
+const { welcomePage } = require('./constants')
 exports.updatePage = 'https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v'
 
 exports.onInstalled = async (details) => {
@@ -23,7 +23,7 @@ exports.runPendingOnInstallTasks = async () => {
     case 'onFirstInstall':
       await useNativeNodeIfFeasible(browser)
       return browser.tabs.create({
-        url: exports.welcomePage
+        url: welcomePage
       })
     case 'onVersionUpdate':
       if (!displayReleaseNotes) return

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -5,7 +5,7 @@ const browser = require('webextension-polyfill')
 const isIPFS = require('is-ipfs')
 const all = require('it-all')
 const { trimHashAndSearch, ipfsContentPath } = require('../../lib/ipfs-path')
-const { welcomePage } = require('../../lib/on-installed')
+const { welcomePage, optionsPage } = require('../../lib/constants')
 const { contextMenuViewOnGateway, contextMenuCopyAddressAtPublicGw, contextMenuCopyPermalink, contextMenuCopyRawCid, contextMenuCopyCanonicalAddress, contextMenuCopyCidAddress } = require('../../lib/context-menus')
 
 // The store contains and mutates the state for the app
@@ -188,7 +188,7 @@ module.exports = (state, emitter) => {
       .catch((err) => {
         console.error('runtime.openOptionsPage() failed, opening options page in tab instead.', err)
         // brave: fallback to opening options page as a tab.
-        browser.tabs.create({ url: browser.extension.getURL('dist/options/options.html') })
+        browser.tabs.create({ url: browser.extension.getURL(optionsPage) })
       })
   })
 

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -3,7 +3,7 @@ const { stub } = require('sinon')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const { expect } = require('chai')
 const { URL } = require('url')
-const { ipfsUri, ipfsContentPath, createIpfsPathValidator, sameGateway } = require('../../../add-on/src/lib/ipfs-path')
+const { ipfsUri, ipfsContentPath, createIpfsPathValidator, sameGateway, safeHostname } = require('../../../add-on/src/lib/ipfs-path')
 const { initState } = require('../../../add-on/src/lib/state')
 const createDnslinkResolver = require('../../../add-on/src/lib/dnslink')
 const { optionDefaults } = require('../../../add-on/src/lib/options')
@@ -106,6 +106,17 @@ describe('ipfs-path.js', function () {
     it('should return null if there is no valid path for input path', function () {
       const path = '/invalid/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
       expect(ipfsContentPath(path)).to.equal(null)
+    })
+  })
+
+  describe('safeHostname', function () {
+    it('should return URL.hostname on http URL', function () {
+      const url = 'https://example.com:8080/path/file.txt'
+      expect(safeHostname(url)).to.equal('example.com')
+    })
+    it('should return null on error', function () {
+      const url = ''
+      expect(safeHostname(url)).to.equal(null)
     })
   })
 


### PR DESCRIPTION
This PR closes #982

- remove custom HTML UI (Brave 1.23.22+ provides own UI)
- use bafkqaaa as the trigger
- cleanup bafkqaaa, switch to Preferences/Welcome page
- single codebase, works in both old and new Brave

