### PR TITLE
feat(telemetry): :sparkles: Adding companion version to segments

### DIFF
--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -179,7 +179,8 @@ export default async function init () {
 
   function onTelemetryMessage (request, sender) {
     if (request.trackView) {
-      return trackView(request.trackView)
+      const { version } = browser.runtime.getManifest()
+      return trackView(request.trackView, { version })
     }
   }
 

--- a/add-on/src/lib/telemetry.js
+++ b/add-on/src/lib/telemetry.js
@@ -34,9 +34,9 @@ export function handleConsentFromState (state) {
 }
 
 const ignoredViewsRegex = []
-export function trackView (view) {
+export function trackView (view, segments) {
   log('trackView called for view: ', view)
-  metricsProvider.trackView(view, ignoredViewsRegex)
+  metricsProvider.trackView(view, ignoredViewsRegex, segments)
 }
 
 export const startSession = (...args) => metricsProvider.startSession(...args)


### PR DESCRIPTION
Closes: #1138 

In this PR:
- Reporting `ipfs-companion` version as a segment.