### PR TITLE
fix: :fire: Allow automation to run from manual triggers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
   release-assets:
     runs-on: ubuntu-latest
     needs: [test]
-    if: contains(github.ref, 'refs/tags/')
+    if: contains(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3.3.0


### PR DESCRIPTION
Removing check `github.event_name == 'push'