### PR TITLE
fix(release-automation): :construction_worker: should no longer be needed

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,4 @@
 {
-  "bootstrap-sha": "65fe66cc283f1ac8c89638034e7db006e1f53791",
-  "last-release-sha": "7td2b9838885b3adf52e78ddd23ac01cb819e631",
   "group-pull-request-title-pattern": "chore${scope}: release${component} v${version}",
   "extra-files": [
     {
@@ -13,8 +11,7 @@
     ".": {
       "release-type": "node",
       "plugins": ["node-workspace"],
-      "package-name": "ipfs-companion",
-      "release-as": "2.22.0"
+      "package-name": "ipfs-companion"
     }
   }
 }


### PR DESCRIPTION
Removing bootstrap shas.