### PR TITLE
Fixing Release PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "include-component-in-tag": false,
   "group-pull-request-title-pattern": "chore${scope}: release${component} v${version}",
   "extra-files": [
     {


### PR DESCRIPTION
the next release-PR created looks wrong: https://github.com/ipfs/ipfs-companion/pull/1159

This is because `release-please` is searching for tag:

```
looking for tagName: ipfs-companion-v2.22.0
```

but it should be looking for `v2.22.0`, `release-please` documentation does not cover this, but there is this property that is referenced in this issue: https://github.com/googleapis/release-please/issues/1497 and validated in code here: https://github.com/googleapis/release-please/blob/main/src/manifest.ts#L157

I [added the documentation](https://github.com/googleapis/release-please/pull/1855/files) for future devs whoever is using this action. It's been a nightmare to work with :-/