### PR TITLE
fix(mv3): :wastebasket: Removing Unnecessary Listener

### DIFF
--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -91,8 +91,6 @@ export function createContextMenus (
         documentUrlPatterns: ['<all_urls>'],
         enabled: false
       }, (context) => onAddFromContext(context, contextType, ipfsAddOptions))
-      return browser.contextMenus.onClicked.addListener((context) => onAddFromContext(context, contextType, ipfsAddOptions)
-      )
     }
 
     const createCopierMenuItem = (parentId, id, contextType, handler) => {


### PR DESCRIPTION
fixes: #1217 

Fixed in brave:
- For some weird reason, this was not an issue for chrome.
- On brave it triggers multiple `tab.create` events.