### PR TITLE
fix(brave): not updating tab to the new redirect url in some cases.

### DIFF
--- a/add-on/src/lib/redirect-handler/blockOrObserve.ts
+++ b/add-on/src/lib/redirect-handler/blockOrObserve.ts
@@ -12,11 +12,11 @@ import { SubdomainRedirectRegexFilter } from './subdomainRedirectRegexFilter.js'
 const log = debug('ipfs-companion:redirect-handler:blockOrObserve')
 log.error = debug('ipfs-companion:redirect-handler:blockOrObserve:error')
 
-const MAX_RETRIES_TO_UPDATE_TAB = 5
 export const DEFAULT_NAMESPACES = new Set(['ipfs', 'ipns'])
-export const GLOBAL_STATE_OPTION_CHANGE = 'GLOBAL_STATE_OPTION_CHANGE'
 export const DELETE_RULE_REQUEST = 'DELETE_RULE_REQUEST'
 export const DELETE_RULE_REQUEST_SUCCESS = 'DELETE_RULE_REQUEST_SUCCESS'
+export const GLOBAL_STATE_OPTION_CHANGE = 'GLOBAL_STATE_OPTION_CHANGE'
+export const MAX_RETRIES_TO_UPDATE_TAB = 5
 
 // We need to match the rest of the URL, so we can use a wildcard.
 export const RULE_REGEX_ENDING = '((?:[^\\.]|$).*)$'

--- a/test/functional/lib/redirect-handler/blockOrObserve.test.ts
+++ b/test/functional/lib/redirect-handler/blockOrObserve.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { before, describe, it } from 'mocha';
 import sinon from 'sinon';
 import browserMock from 'sinon-chrome';
+import { MAX_RETRIES_TO_UPDATE_TAB } from './../../../../add-on/src/lib/redirect-handler/blockOrObserve';
 
 import { optionDefaults } from '../../../../add-on/src/lib/options.js';
 import { RULE_REGEX_ENDING, addRuleToDynamicRuleSetGenerator, cleanupRules, isLocalHost } from '../../../../add-on/src/lib/redirect-handler/blockOrObserve';
@@ -201,7 +202,7 @@ describe('lib/redirect-handler/blockOrObserve', () => {
         originUrl: 'https://ipfs.io/ipns/en.wikipedia-on-ipfs.org',
         redirectUrl: 'http://localhost:8080/ipns/en.wikipedia-on-ipfs.org'
       })
-      await clock.tickAsync(400)
+      await clock.tickAsync(100 * MAX_RETRIES_TO_UPDATE_TAB)
       expect(browserMock.tabs.query.callCount).to.be.equal(2)
       expect(browserMock.tabs.update.called).to.be.true
       expect(browserMock.tabs.update.lastCall.args).to.deep.equal([40, { url: 'http://localhost:8080/ipns/en.wikipedia-on-ipfs.org' }])


### PR DESCRIPTION
Closes: https://github.com/ipfs/ipfs-companion/issues/1283

RCA:
- The timing in brave makes it hard to determine what's happening in the browser.
- When redirecting from brave internal node, companion cannot find the tab containing that URL.
- Checking repeatedly fixes the issue mostly.
- Added tests.

Demo: the double refresh is slightly visible.

https://github.com/ipfs/ipfs-companion/assets/1895906/17254a4d-23cc-4534-85e4-e121879382d4

