### PR TITLE
fix(release-automation): :wrench: removing default command and skippi github release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
       - uses: google-github-actions/release-please-action@v3.7.3
         with:
           changelog-notes-type: github
-          command: manifest-pr
           release-type: node
+          skip-github-release: true
 
   release-assets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Based on: https://github.com/google-github-actions/release-please-action/issues/719