### PR TITLE
feat(chromium): add `protocol_handlers` manifest key

### DIFF
--- a/add-on/manifest.chromium.json
+++ b/add-on/manifest.chromium.json
@@ -19,5 +19,37 @@
     "webNavigation",
     "webRequest"
   ],
-  "incognito": "not_allowed"
+  "incognito": "not_allowed",
+  "protocol_handlers": [
+    {
+      "protocol": "web+dweb",
+      "name": "IPFS Companion: DWEB Protocol Handler",
+      "uriTemplate": "https://dweb.link/ipfs/?uri=%s"
+    },
+    {
+      "protocol": "web+ipns",
+      "name": "IPFS Companion: IPNS Protocol Handler",
+      "uriTemplate": "https://dweb.link/ipns/?uri=%s"
+    },
+    {
+      "protocol": "web+ipfs",
+      "name": "IPFS Companion: IPFS Protocol Handler",
+      "uriTemplate": "https://dweb.link/ipfs/?uri=%s"
+    },
+    {
+      "protocol": "dweb",
+      "name": "IPFS Companion: DWEB Protocol Handler",
+      "uriTemplate": "https://dweb.link/ipfs/?uri=%s"
+    },
+    {
+      "protocol": "ipns",
+      "name": "IPFS Companion: IPNS Protocol Handler",
+      "uriTemplate": "https://dweb.link/ipns/?uri=%s"
+    },
+    {
+      "protocol": "ipfs",
+      "name": "IPFS Companion: IPFS Protocol Handler",
+      "uriTemplate": "https://dweb.link/ipfs/?uri=%s"
+    }
+  ]
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This is parked until Chromium ships with `protocol_handlers` support for Manifest V3 browser extensions.
>
> For now, this PR can be used for testing (build extension and load into a test build from Igalia). 
> TBD when we ship it – we will coordinate with Igalia.


## Summary

This PR adds `protocol_handlers` manifest key to the Chromium build, preparing IPFS Companion for native protocol handling of `ipfs://`, `ipns://`, and `dweb://` URLs.

This aligns the Chromium manifest with Firefox, which has supported `protocol_handlers` since 2017. Chrome currently ignores unknown manifest keys, so this change is safe to ship now and will activate automatically if/when Chrome implements the feature.

- Related: #164

## What this enables

Once Chrome ships the `protocol_handlers` API, users will be able to:
- Click `ipfs://` links and have them handled by IPFS Companion
- Type `ipfs://bafy...` directly in the address bar
- See IPFS Companion listed in `chrome://settings/handlers`
- TBD if subresources can use `ipfs://` (test page: `ipfs://bafkreia72r46hbyeozencwzmb7drksaxwg7cqve6wsor336eo72nkklnki`)

## Implementation notes

- Copies `protocol_handlers` config from `manifest.firefox.json` to `manifest.chromium.json`
- No JS changes needed - handler code already exists in `ipfs-request.js`
- Uses redirect-based handlers via `dweb.link` (same as Firefox)

## Status

The `protocol_handlers` API is **not yet supported in Chrome stable**. Igalia is actively working on bringing this feature to Chromium, and we hope to see it land sometime in 2026, though there's no clear ETA yet.

This PR gets Companion ready and available for testing in dev builds of Chromium that include the prototype:
- [Design doc: The protocol_handlers Web Extension's Manifest key](https://docs.google.com/document/d/1e6mSsbjLqBd1_4EAS_AX543vy53oq8SlycNwQ0mZ46g)
- [Chromium CL: protocol_handlers for WebExtensions](https://chromium-review.googlesource.com/c/chromium/src/+/5518971)

## Background: Igalia's multi-year effort

We've been collaborating with [Igalia](https://www.igalia.com/) since 2022 to bring this capability to Chromium:

**2022: Foundation work**
- [Explainer: Predefined Custom Handlers](https://github.com/Igalia/explainers/tree/main/custom-protocol-handlers/PredefinedHandlers) + [Chromium discussion](https://groups.google.com/a/chromium.org/g/content-owners/c/KIFf1EdM-4c/m/7tGJmPiaAAAJ)
- [SchemeRegistry patch merged](https://chromium-review.googlesource.com/c/chromium/src/+/3652049/)
- [Demo: IPFS handlers in 2 lines of code](https://chromium-review.googlesource.com/c/chromium/src/+/3650554)
- Blog: [New Custom Handlers component for Chrome](https://blogs.igalia.com/jfernandez/2022/08/10/new-custom-handlers-component-for-chrome/)

**2023-2025: WebExtensions API**
- [Defined the long term North Star: ServiceWorker-like protocol handlers](https://github.com/ipfs/in-web-browsers/issues/212)
- Redirect-based prerequisite implementation:
  - [Design doc: The protocol_handlers Web Extension's Manifest key](https://docs.google.com/document/d/1e6mSsbjLqBd1_4EAS_AX543vy53oq8SlycNwQ0mZ46g)
  - [Chromium CL: protocol_handlers for WebExtensions](https://chromium-review.googlesource.com/c/chromium/src/+/5518971)

## Why this matters beyond IPFS

Igalia designed this as a **vendor-agnostic WebExtensions API**, not an IPFS-specific feature. Any extension will be able to register custom protocol handlers. This benefits decentralized protocols (IPFS, DAT, SSB, Bitorrent, Bluesky/ATProto, etc.), application deep-linking, enterprise tools, and any future protocol needing browser integration.

## Next steps

This redirect-based approach is a stepping stone. Future work will explore **ServiceWorker-like handlers** that resolve protocols directly within the extension. See [ipfs/in-web-browsers#212](https://github.com/ipfs/in-web-browsers/issues/212).

## Thanks

Thanks to the Igalia team for their continued effort on this. Good progress is being made toward improving how browsers handle non-HTTP URIs.