### PR TITLE
fix: update MDN links to new URL structure

### DIFF
--- a/docs/DEVELOPER-NOTES.md
+++ b/docs/DEVELOPER-NOTES.md
@@ -235,7 +235,7 @@ npm run compose:e2e:down
   ```
 
 - [Using localization in IPFS Companion](./LOCALIZATION-NOTES.md) (running browsers with specific locale, etc)
-- [Testing persistent and restart features (Mozilla)](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Testing_persistent_and_restart_features)
+- [Testing persistent and restart features (Mozilla)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Testing_persistent_and_restart_features)
 
 ## Legacy Firefox (< 53) and XUL-compatible browsers
 
@@ -301,4 +301,4 @@ The fastest way to connect is to open `chrome://devtools/content/framework/conne
 
 ### Further resources
 
-- [MDN: Developing extensions for Firefox for Android](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android)
+- [MDN: Developing extensions for Firefox for Android](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android)


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates outdated MDN links to the new URL structure.

Changed:
- developer.mozilla.org/en-US/Add-ons/WebExtensions/Testing_persistent_and_restart_features → developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Testing_persistent_and_restart_features
- developer.mozilla.org/en-US/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android → developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*