### PR TITLE
fix: Update deprecated MDN URLs to new URL structure

### DIFF
--- a/add-on/src/lib/context-menus.js
+++ b/add-on/src/lib/context-menus.js
@@ -8,7 +8,7 @@ const log = debug('ipfs-companion:context-menus')
 log.error = debug('ipfs-companion:context-menus:error')
 
 // mapping between context name and field with data for it
-// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/menus/ContextType
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType
 const contextSources = {
   selection: 'selectionText',
   image: 'srcUrl',

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -186,7 +186,7 @@ export default async function init (inQuickImport = false) {
 
   // RUNTIME MESSAGES (one-off messaging)
   // ===================================================================
-  // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/sendMessage
+  // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
   async function onRuntimeMessage (request, sender) {
     // console.log((sender.tab ? 'Message from a content script:' + sender.tab.url : 'Message from the extension'), request)
@@ -200,7 +200,7 @@ export default async function init (inQuickImport = false) {
 
   // PORTS (connection-based messaging)
   // ===================================================================
-  // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/connect
+  // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect
   // Make a connection between different contexts inside the add-on,
   // e.g. signalling between browser action popup and background page that works
   // in everywhere, even in private contexts (https://github.com/ipfs/ipfs-companion/issues/243)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -33,7 +33,7 @@ const onHeadersReceivedRedirect = new Set()
 let addRuleToDynamicRuleSet = null
 
 // Request modifier provides event listeners for the various stages of making an HTTP request
-// API Details: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest
+// API Details: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest
 export function createRequestModifier (getState, dnslinkResolver, ipfsPathValidator, runtime) {
   const browser = runtime.browser
   const runtimeRoot = browser.runtime.getURL('/')

--- a/docs/DEVELOPER-NOTES.md
+++ b/docs/DEVELOPER-NOTES.md
@@ -235,7 +235,7 @@ npm run compose:e2e:down
   ```
 
 - [Using localization in IPFS Companion](./LOCALIZATION-NOTES.md) (running browsers with specific locale, etc)
-- [Testing persistent and restart features (Mozilla)](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Testing_persistent_and_restart_features)
+- [Testing persistent and restart features (Mozilla)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Testing_persistent_and_restart_features)
 
 ## Legacy Firefox (< 53) and XUL-compatible browsers
 
@@ -301,4 +301,4 @@ The fastest way to connect is to open `chrome://devtools/content/framework/conne
 
 ### Further resources
 
-- [MDN: Developing extensions for Firefox for Android](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android)
+- [MDN: Developing extensions for Firefox for Android](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android)


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates 6 broken MDN links from:
- `/en-US/Add-ons/WebExtensions/Testing_persistent_and_restart_features` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/Testing_persistent_and_restart_features`
- `/en-US/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android`
- `/en-US/Add-ons/WebExtensions/API/menus/ContextType` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType`
- `/en-US/Add-ons/WebExtensions/API/webRequest` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest`
- `/en-US/Add-ons/WebExtensions/API/runtime/sendMessage` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage`
- `/en-US/Add-ons/WebExtensions/API/runtime/connect` → `/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect`

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*