### PR TITLE
Fix broken MDN links (developer.mozilla.org/en-US/Add-ons → /en-US/docs/Mozilla/Add-ons)

### DIFF
--- a/docs/DEVELOPER-NOTES.md
+++ b/docs/DEVELOPER-NOTES.md
@@ -235,7 +235,7 @@ npm run compose:e2e:down
   ```
 
 - [Using localization in IPFS Companion](./LOCALIZATION-NOTES.md) (running browsers with specific locale, etc)
-- [Testing persistent and restart features (Mozilla)](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Testing_persistent_and_restart_features)
+- [Testing persistent and restart features (Mozilla)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Testing_persistent_and_restart_features)
 
 ## Legacy Firefox (< 53) and XUL-compatible browsers
 
@@ -301,4 +301,4 @@ The fastest way to connect is to open `chrome://devtools/content/framework/conne
 
 ### Further resources
 
-- [MDN: Developing extensions for Firefox for Android](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android)
+- [MDN: Developing extensions for Firefox for Android](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Firefox_for_Android)


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates 2 old MDN links to use the new path structure.

Old: developer.mozilla.org/en-US/Add-ons/...
New: developer.mozilla.org/en-US/docs/Mozilla/Add-ons/...


---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
