### PR TITLE
feat: make public gateways optional for sharing

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -259,6 +259,22 @@
     "message": "External (Kubo RPC)",
     "description": "An option on the Preferences screen (option_ipfsNodeType_external)"
   },
+  "option_ipfsNodeType_external_explainer": {
+    "message": "IPFS Companion controls your node over the Kubo RPC API, an HTTP interface served by Kubo, the standard IPFS node software. Don't have a node yet? Install Kubo (command line), or IPFS Desktop, a graphical app that runs the same Kubo daemon and provides the same RPC and Web UI in a nicer package.",
+    "description": "Explainer under the IPFS Node section on the Preferences screen (option_ipfsNodeType_external_explainer)"
+  },
+  "option_ipfsNodeType_external_installKubo": {
+    "message": "Install Kubo (command line)",
+    "description": "Link under the IPFS Node section on the Preferences screen (option_ipfsNodeType_external_installKubo)"
+  },
+  "option_ipfsNodeType_external_installDesktop": {
+    "message": "Install IPFS Desktop",
+    "description": "Link under the IPFS Node section on the Preferences screen (option_ipfsNodeType_external_installDesktop)"
+  },
+  "option_ipfsNodeType_external_rpcDocs": {
+    "message": "Kubo RPC API docs",
+    "description": "Link under the IPFS Node section on the Preferences screen (option_ipfsNodeType_external_rpcDocs)"
+  },
   "option_ipfsNodeType_brave": {
     "message": "Provided by Brave",
     "description": "An option on the Preferences screen (option_ipfsNodeType_brave)"

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -120,7 +120,7 @@
     "description": "A menu item in Browser Action pop-up and right-click context menu (panel_copyCurrentPublicGwUrl)"
   },
   "panel_copyCurrentPublicGwUrlTooltip": {
-    "message": "A shareable link to this tab that works for anyone, even if they don't use IPFS.",
+    "message": "A shareable link to this tab that anyone can open. When public gateway sharing is off in Preferences, a native IPFS address is copied instead.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPublicGwUrlTooltip)"
   },
   "panel_copyCurrentPermalink": {
@@ -128,7 +128,7 @@
     "description": "A menu item in Browser Action pop-up (panel_copyCurrentPermalink)"
   },
   "panel_copyCurrentPermalinkTooltip": {
-    "message": "A link to a snapshot of this tab at this moment in time; it won't change, even if content changes later. This link works for anyone, even if they don't use IPFS.",
+    "message": "A link to a snapshot of this tab at this moment in time; it won't change, even if content changes later.",
     "description": "A menu item tooltip in Browser Action pop-up (panel_copyCurrentPermalinkTooltip)"
   },
   "panel_contextMenuViewOnGateway": {
@@ -300,7 +300,7 @@
     "description": "An option title on the Preferences screen (option_useSubdomains_title)"
   },
   "option_useSubdomains_description": {
-    "message": "Isolate content roots from each other by loading them as subdomains (at *.localhost) and creating a unique origin for each CID, IPNS, or DNSLink record. When public gateway sharing is on, this also picks the shareable link shape: on uses your subdomain gateway, off your path gateway.",
+    "message": "Isolate content roots from each other by loading them as subdomains (at *.localhost) and creating a unique origin for each CID, IPNS name, or DNSLink site.",
     "description": "An option description on the Preferences screen (option_useSubdomains_description)"
   },
   "option_dnslinkRedirect_title": {
@@ -340,27 +340,27 @@
     "description": "An option description on the Preferences screen (option_enabledOn_description)"
   },
   "option_publicGatewayUrl_title": {
-    "message": "Default Public Path Gateway",
+    "message": "Public Path Gateway",
     "description": "An option title on the Preferences screen (option_publicGatewayUrl_title)"
   },
   "option_publicGatewayUrl_description": {
-    "message": "A path gateway serves every request from a single origin, so it works well outside the browser but gives no origin isolation. It is used as a fallback when your local gateway is unavailable, and for shareable links when public sharing is enabled below and Use Subdomains is off. Produces links like https://example.com/ipfs/CID. Leave it empty to copy native ipfs:// and ipns:// URIs.",
+    "message": "A public gateway serving links like https://example.com/ipfs/CID. All content shares that one origin, which works everywhere but does not keep sites isolated from each other. Used as a fallback when your local gateway is unavailable, and for shareable links when the subdomain gateway below is empty or cannot serve the address.",
     "description": "An option description on the Preferences screen (option_publicGatewayUrl_description)"
   },
   "option_publicSubdomainGatewayUrl_title": {
-    "message": "Default Public Subdomain Gateway",
+    "message": "Public Subdomain Gateway",
     "description": "An option title on the Preferences screen (option_publicSubdomainGatewayUrl_title)"
   },
   "option_publicSubdomainGatewayUrl_description": {
-    "message": "A subdomain gateway gives each CID, IPNS, or DNSLink its own origin, isolating them the way browsers keep sites apart. It is used to recover broken subdomain links, and for shareable links when public sharing is enabled below and Use Subdomains is on. Produces links like https://CID.ipfs.example.com. Leave it empty to copy native ipfs:// and ipns:// URIs.",
+    "message": "A public gateway serving links like https://CID.ipfs.example.com. Each CID, IPNS name, or DNSLink site gets its own origin, keeping sites isolated the way browsers expect. Preferred for shareable links, and used to repair broken links to other subdomain gateways.",
     "description": "An option description on the Preferences screen (option_publicSubdomainGatewayUrl_description)"
   },
   "option_usePublicGatewaysForShare_title": {
-    "message": "Use Public Gateways above when Sharing links",
+    "message": "Use Public Gateways for Shareable Links",
     "description": "An option title on the Preferences screen (option_usePublicGatewaysForShare_title)"
   },
   "option_usePublicGatewaysForShare_description": {
-    "message": "When on, \"Copy Shareable Link\" copies a URL on the public gateways set above, handy for sending IPFS content to people who don't run IPFS. When off, it copies native ipfs:// and ipns:// URIs. Set the gateway URLs above to enable this.",
+    "message": "When on, copied links such as \"Copy Shareable Link\" and \"Copy Snapshot Link\" point at one of the public gateways above and open for everyone, including people who don't run IPFS. When off, or when both gateway URLs above are empty, a native ipfs:// or ipns:// address is copied instead.",
     "description": "An option description on the Preferences screen (option_usePublicGatewaysForShare_description)"
   },
   "option_header_api": {
@@ -488,7 +488,7 @@
     "description": "An option title on the Preferences screen (option_recoverFailedHttpRequests_title)"
   },
   "option_recoverFailedHttpRequests_description": {
-    "message": "Redirect failed HTTP requests for IPFS resources to the public gateway.",
+    "message": "Redirect failed requests for IPFS resources to another gateway: a public one when set, otherwise your local one.",
     "description": "An option description on the Preferences screen (option_recoverFailedHttpRequests_description)"
   },
   "option_detectIpfsPathHeader_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -304,11 +304,11 @@
     "description": "An option description on the Preferences screen (option_useSubdomains_description)"
   },
   "option_dnslinkRedirect_title": {
-    "message": "Load DNSLink Sites from Custom Gateway",
+    "message": "Load DNSLink Sites from Local Gateway",
     "description": "An option title on the Preferences screen (option_dnslinkRedirect_title)"
   },
   "option_dnslinkRedirect_description": {
-    "message": "When global gateway redirect is enabled, include DNSLink websites by redirecting them to their respective /ipns/{fqdn} paths at your custom gateway.",
+    "message": "When redirects to your local gateway are enabled, include DNSLink websites by redirecting them to their respective /ipns/{fqdn} paths.",
     "description": "An option description on the Preferences screen (option_dnslinkRedirect_description)"
   },
   "option_dnslinkDataPreload_title": {
@@ -388,11 +388,11 @@
     "description": "An option title on the Preferences screen (option_automaticMode_title)"
   },
   "option_automaticMode_description": {
-    "message": "Automatically enables automatic redirection to your local gateway when the Kubo RPC endpoint is accessible, and disable it when the endpoint is unavailable.",
+    "message": "Automatically enable redirection to your local gateway when the Kubo RPC endpoint is accessible, and disable it when the endpoint is unavailable.",
     "description": "An option description on the Preferences screen (option_automaticMode_description)"
   },
   "option_automaticMode_description_subtext": {
-    "message": "Note: disabling this feature will result in static redirects, independent of the Kubo RPC endpoint's availability, and may produce error when your node is offline.",
+    "message": "Note: disabling this feature will result in static redirects, independent of the Kubo RPC endpoint's availability, and may produce errors when your node is offline.",
     "description": "An automatic mode option description on the Preferences screen (option_automaticMode_description_subtext)"
   },
   "option_header_dnslink": {
@@ -436,7 +436,7 @@
     "description": "An option title on the Preferences screen (option_displayNotifications_title)"
   },
   "option_displayNotifications_description": {
-    "message": "Display OS-level notifications when a link is copied to the clipboard,the API state changes, etc.",
+    "message": "Display OS-level notifications when a link is copied to the clipboard, the API state changes, etc.",
     "description": "An option description on the Preferences screen (option_displayNotifications_description)"
   },
   "option_displayReleaseNotes_title": {

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -300,7 +300,7 @@
     "description": "An option title on the Preferences screen (option_useSubdomains_title)"
   },
   "option_useSubdomains_description": {
-    "message": "Isolate content roots from each other by loading them as subdomains (at *.localhost) and creating a unique origin for each CID, IPNS, or DNSLink record.",
+    "message": "Isolate content roots from each other by loading them as subdomains (at *.localhost) and creating a unique origin for each CID, IPNS, or DNSLink record. When public gateway sharing is on, this also picks the shareable link shape: on uses your subdomain gateway, off your path gateway.",
     "description": "An option description on the Preferences screen (option_useSubdomains_description)"
   },
   "option_dnslinkRedirect_title": {
@@ -340,11 +340,11 @@
     "description": "An option description on the Preferences screen (option_enabledOn_description)"
   },
   "option_publicGatewayUrl_title": {
-    "message": "Default Public Gateway",
+    "message": "Default Public Path Gateway",
     "description": "An option title on the Preferences screen (option_publicGatewayUrl_title)"
   },
   "option_publicGatewayUrl_description": {
-    "message": "Set the URL of a default public gateway to use in publicly shareable links and as a fallback if your local gateway is unavailable.",
+    "message": "A path gateway serves every request from a single origin, so it works well outside the browser but gives no origin isolation. It is used as a fallback when your local gateway is unavailable, and for shareable links when public sharing is enabled below and Use Subdomains is off. Produces links like https://example.com/ipfs/CID. Leave it empty to copy native ipfs:// and ipns:// URIs.",
     "description": "An option description on the Preferences screen (option_publicGatewayUrl_description)"
   },
   "option_publicSubdomainGatewayUrl_title": {
@@ -352,8 +352,16 @@
     "description": "An option title on the Preferences screen (option_publicSubdomainGatewayUrl_title)"
   },
   "option_publicSubdomainGatewayUrl_description": {
-    "message": "Set the URL of a default public subdomain gateway for the recovery of broken subdomain gateways.",
+    "message": "A subdomain gateway gives each CID, IPNS, or DNSLink its own origin, isolating them the way browsers keep sites apart. It is used to recover broken subdomain links, and for shareable links when public sharing is enabled below and Use Subdomains is on. Produces links like https://CID.ipfs.example.com. Leave it empty to copy native ipfs:// and ipns:// URIs.",
     "description": "An option description on the Preferences screen (option_publicSubdomainGatewayUrl_description)"
+  },
+  "option_usePublicGatewaysForShare_title": {
+    "message": "Use Public Gateways above when Sharing links",
+    "description": "An option title on the Preferences screen (option_usePublicGatewaysForShare_title)"
+  },
+  "option_usePublicGatewaysForShare_description": {
+    "message": "When on, \"Copy Shareable Link\" copies a URL on the public gateways set above, handy for sending IPFS content to people who don't run IPFS. When off, it copies native ipfs:// and ipns:// URIs. Set the gateway URLs above to enable this.",
+    "description": "An option description on the Preferences screen (option_usePublicGatewaysForShare_description)"
   },
   "option_header_api": {
     "message": "Kubo RPC API",
@@ -750,6 +758,22 @@
   "recovery_page_update_preferences": {
     "message": "Update your IPFS Companion preferences",
     "description": "Learn more link on the recovery screen (recovery_page_learn_more)"
+  },
+  "recovery_page_publicUrl": {
+    "message": "Public URL:",
+    "description": "Label before the public gateway URL on the recovery screen (recovery_page_publicUrl)"
+  },
+  "recovery_page_nativeUrl": {
+    "message": "Native address:",
+    "description": "Label before the native ipfs:// address on the recovery screen, shown when no public gateway is set (recovery_page_nativeUrl)"
+  },
+  "recovery_page_message_p2_native": {
+    "message": "The link below is a native IPFS address. To open it, run a local IPFS node, or set a public gateway in your preferences.",
+    "description": "Message on the recovery screen shown when no public gateway is set (recovery_page_message_p2_native)"
+  },
+  "recovery_page_button_installDesktop": {
+    "message": "Install IPFS Desktop",
+    "description": "Button on the recovery screen shown when no public gateway is set (recovery_page_button_installDesktop)"
   },
   "request_permissions_page_title": {
     "message": "Grant Host Permissions | IPFS Companion",

--- a/add-on/src/lib/copier.js
+++ b/add-on/src/lib/copier.js
@@ -119,8 +119,8 @@ export default function createCopier (notify, ipfsPathValidator) {
 
     async copyAddressAtPublicGw (context, contextType) {
       const url = await findValueForContext(context, contextType)
-      const publicUrl = await ipfsPathValidator.resolveToPublicUrl(url)
-      await copyTextToClipboard(publicUrl, notify)
+      const shareableUrl = await ipfsPathValidator.resolveToShareableUrl(url)
+      await copyTextToClipboard(shareableUrl, notify)
     },
 
     async copyPermalink (context, contextType) {

--- a/add-on/src/lib/dnslink.js
+++ b/add-on/src/lib/dnslink.js
@@ -61,7 +61,11 @@ export default function createDnslinkResolver (getState) {
         // to load the correct path from IPFS
         // - https://github.com/ipfs/ipfs-companion/issues/298
         const ipnsPath = dnslinkResolver.convertToIpnsPath(url)
-        const gateway = state.redirect && state.localGwAvailable ? state.gwURLString : state.pubGwURLString
+        // redirect to the local gateway when enabled, and fall back to it when
+        // no public gateway is configured
+        const gateway = (state.redirect && state.localGwAvailable) || !state.pubGwURLString
+          ? state.gwURLString
+          : state.pubGwURLString
         return pathAtHttpGateway(ipnsPath, gateway)
       }
     },

--- a/add-on/src/lib/inspector.js
+++ b/add-on/src/lib/inspector.js
@@ -9,8 +9,10 @@ export default function createInspector (notify, ipfsPathValidator, getState) {
     async viewOnGateway (context, contextType) {
       const url = await findValueForContext(context, contextType)
       const ipfsPath = ipfsPathValidator.resolveToIpfsPath(url)
-      const gateway = getState().pubGwURLString
-      const gatewayUrl = pathAtHttpGateway(ipfsPath, gateway)
+      const { pubGwURLString, gwURLString } = getState()
+      // fall back to the local gateway when no public gateway is configured
+      // (a browser tab can't open a native ipfs:// URI)
+      const gatewayUrl = pathAtHttpGateway(ipfsPath, pubGwURLString || gwURLString)
       await browser.tabs.create({ url: gatewayUrl })
     }
     // TODO: view in WebUI's Files

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -191,8 +191,14 @@ export default async function init (inQuickImport = false) {
     // console.log((sender.tab ? 'Message from a content script:' + sender.tab.url : 'Message from the extension'), request)
     if (request.pubGwUrlForIpfsOrIpnsPath) {
       const path = request.pubGwUrlForIpfsOrIpnsPath
-      const { validIpfsOrIpns, resolveToPublicUrl } = ipfsPathValidator
-      const result = await validIpfsOrIpns(path) ? await resolveToPublicUrl(path) : null
+      const { validIpfsOrIpns, resolveToPublicUrl, resolveToLocalUrl } = ipfsPathValidator
+      let result = null
+      if (await validIpfsOrIpns(path)) {
+        // linkified hrefs must be loadable http(s) URLs; with no public gateway
+        // configured the resolver returns a native URI, use the local gateway then
+        const publicUrl = await resolveToPublicUrl(path)
+        result = publicUrl && publicUrl.startsWith('http') ? publicUrl : resolveToLocalUrl(path)
+      }
       return { pubGwUrlForIpfsOrIpnsPath: result }
     }
   }

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -277,19 +277,20 @@ export default async function init (inQuickImport = false) {
       const url = info.currentTab.url
       info.isIpfsContext = ipfsPathValidator.isIpfsPageActionsContext(url)
       if (info.isIpfsContext) {
-        info.currentTabPublicUrl = await ipfsPathValidator.resolveToPublicUrl(url)
+        info.currentTabPublicUrl = await ipfsPathValidator.resolveToShareableUrl(url)
         info.currentTabContentPath = ipfsPathValidator.resolveToIpfsPath(url)
         if (resolveCache.has(url)) {
-          const [immutableIpfsPath, permalink, cid] = resolveCache.get(url)
+          const [immutableIpfsPath, cid] = resolveCache.get(url)
           info.currentTabImmutablePath = immutableIpfsPath
-          info.currentTabPermalink = permalink
+          // resolve the permalink fresh so it tracks the share toggle; the costly
+          // DAG lookup underneath is memoized, so this stays cheap
+          info.currentTabPermalink = await ipfsPathValidator.resolveToPermalink(url)
           info.currentTabCid = cid
         } else {
           // run async resolution in the next event loop so it does not block the UI
           setTimeout(async () => {
             resolveCache.set(url, [
               await ipfsPathValidator.resolveToImmutableIpfsPath(url),
-              await ipfsPathValidator.resolveToPermalink(url),
               await ipfsPathValidator.resolveToCid(url)
             ])
             await sendStatusUpdateToBrowserAction()
@@ -665,12 +666,12 @@ export default async function init (inQuickImport = false) {
           state.gwURLString = state.gwURL.toString()
           break
         case 'publicGatewayUrl':
-          state.pubGwURL = new URL(change.newValue)
-          state.pubGwURLString = state.pubGwURL.toString()
+          state.pubGwURL = change.newValue ? new URL(change.newValue) : undefined
+          state.pubGwURLString = state.pubGwURL?.toString()
           break
         case 'publicSubdomainGatewayUrl':
-          state.pubSubdomainGwURL = new URL(change.newValue)
-          state.pubSubdomainGwURLString = state.pubSubdomainGwURL.toString()
+          state.pubSubdomainGwURL = change.newValue ? new URL(change.newValue) : undefined
+          state.pubSubdomainGwURLString = state.pubSubdomainGwURL?.toString()
           break
         case 'useCustomGateway':
           state.redirect = change.newValue

--- a/add-on/src/lib/ipfs-import.js
+++ b/add-on/src/lib/ipfs-import.js
@@ -5,7 +5,7 @@ import debug from 'debug'
 import browser from 'webextension-polyfill'
 
 import { redirectOptOutHint } from './ipfs-request.js'
-import { ipfsContentPath } from './ipfs-path.js'
+import { contentPathToSubdomainUrl, ipfsContentPath, pathAtHttpGateway } from './ipfs-path.js'
 const log = debug('ipfs-companion:import')
 log.error = debug('ipfs-companion:import:error')
 
@@ -13,7 +13,6 @@ export const browserActionFilesCpImportCurrentTab = 'browserActionFilesCpImportC
 
 export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, runtime, copier) {
   const {
-    resolveToPublicUrl,
     resolveToShareableUrl,
     resolveToCid
   } = ipfsPathValidator
@@ -76,10 +75,18 @@ export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, r
     async preloadFilesAtPublicGateway (files) {
       const state = getState()
       if (!state.preloadAtPublicGateway) return
+      // preload needs a public gateway; noop when none is configured
+      if (!state.pubGwURLString && !state.pubSubdomainGwURL) return
       for (const file of files) {
         if (file && file.cid) {
           const { path } = ipfsImportHandler.getIpfsPathAndNativeAddress(file.cid)
-          const preloadUrl = await resolveToPublicUrl(`${path}#${redirectOptOutHint}`)
+          const contentPath = `${path}#${redirectOptOutHint}`
+          // spread the load over a random configured gateway when both are set
+          const candidates = [
+            state.pubGwURLString && pathAtHttpGateway(contentPath, state.pubGwURLString),
+            state.pubSubdomainGwURL && contentPathToSubdomainUrl(contentPath, state.pubSubdomainGwURL)
+          ].filter(Boolean)
+          const preloadUrl = candidates[Math.floor(Math.random() * candidates.length)]
           try {
             await fetch(preloadUrl, { method: 'HEAD' })
             log('successfully preloaded', file)

--- a/add-on/src/lib/ipfs-import.js
+++ b/add-on/src/lib/ipfs-import.js
@@ -14,6 +14,7 @@ export const browserActionFilesCpImportCurrentTab = 'browserActionFilesCpImportC
 export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, runtime, copier) {
   const {
     resolveToPublicUrl,
+    resolveToShareableUrl,
     resolveToCid
   } = ipfsPathValidator
   const ipfsImportHandler = {
@@ -23,8 +24,9 @@ export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, r
       if (runtime.hasNativeProtocolHandler) {
         return { path, url: `ipfs://${cid}` }
       } else {
-        // open at public GW (will be redirected to local elsewhere, if enabled)
-        const url = new URL(path, state.pubGwURLString).toString()
+        // open at public GW (will be redirected to local elsewhere, if enabled);
+        // fall back to the local gateway when no public gateway is configured
+        const url = new URL(path, state.pubGwURLString || state.gwURLString).toString()
         return { path, url }
       }
     },
@@ -67,7 +69,7 @@ export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, r
         // share wrapping dir
         path = `/ipfs/${root.cid}/`
       }
-      const url = await resolveToPublicUrl(path)
+      const url = await resolveToShareableUrl(path)
       await copier.copyTextToClipboard(url)
     },
 

--- a/add-on/src/lib/ipfs-import.js
+++ b/add-on/src/lib/ipfs-import.js
@@ -86,6 +86,7 @@ export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, r
             state.pubGwURLString && pathAtHttpGateway(contentPath, state.pubGwURLString),
             state.pubSubdomainGwURL && contentPathToSubdomainUrl(contentPath, state.pubSubdomainGwURL)
           ].filter(Boolean)
+          if (!candidates.length) continue
           const preloadUrl = candidates[Math.floor(Math.random() * candidates.length)]
           try {
             await fetch(preloadUrl, { method: 'HEAD' })

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -103,10 +103,18 @@ export function toCaseInsensitiveRoot (ns, root) {
   throw new Error(`toCaseInsensitiveRoot: unsupported namespace '${ns}'`)
 }
 
+// A subdomain gateway puts the root (CID or IPNS name) in a DNS label, which
+// public DNS caps at 63 characters.
+const DNS_LABEL_MAX = 63
+
 // Build a subdomain-gateway URL from a content path, e.g.
 // /ipfs/<cid>/x + https://dweb.link -> https://<cid-base32>.ipfs.dweb.link/x
 // (the label is normalized to a case-insensitive CID). A DNSLink hostname cannot
-// be a subdomain label, so we share the FQDN website itself.
+// be a subdomain label, so we share the FQDN website itself. Returns null when
+// the path cannot be represented as a subdomain URL: a root that is not a valid
+// hostname (e.g. an /ipns/ name with spaces), or a label longer than a DNS
+// label allows (e.g. a CID with a sha2-512 multihash); callers fall back to a
+// path gateway or a native URI.
 export function contentPathToSubdomainUrl (contentPath, gwURL) {
   const parsed = parseContentPath(contentPath)
   if (!parsed) return null
@@ -116,36 +124,33 @@ export function contentPathToSubdomainUrl (contentPath, gwURL) {
       return trimDoubleSlashes(new URL(`${gwURL.protocol}//${root}${rest}`).toString())
     }
     const label = toCaseInsensitiveRoot(ns, root)
-    // KNOWN BUG: the label length is not checked. Local *.localhost subdomains
-    // tolerate labels longer than 63 characters, but public DNS does not, so a
-    // root CID with a multihash longer than sha2-256 (e.g. sha2-512) produces a
-    // hostname that will not resolve. Content that requires subdomain (origin)
-    // isolation should not use such CIDs as its root.
+    if (label.length > DNS_LABEL_MAX) return null
     return trimDoubleSlashes(new URL(`${gwURL.protocol}//${label}.${ns}.${gwURL.host}${rest}`).toString())
   } catch (e) {
-    // roots that are not valid hostnames (e.g. an /ipns/ name with spaces)
-    // cannot be turned into a subdomain URL
     return null
   }
 }
 
-// Attach a content path to a public gateway for a shareable link. When both
-// public gateways are set, the "Use Subdomains" preference decides which one is
-// used (subdomain gateway -> subdomain link, path gateway -> path link); when
-// only one is set, that one is used. Returns null when neither is configured.
+// Attach a content path to a public gateway for a shareable link, preferring
+// the subdomain gateway (origin isolation) and falling back to the path
+// gateway when the subdomain gateway is not set or cannot represent the path.
+// Returns null when no configured gateway can serve it.
 function publicShareUrl (contentPath, state) {
   if (!contentPath) return null
-  const { useSubdomains, pubGwURLString, pubSubdomainGwURL } = state
-  if (useSubdomains && pubSubdomainGwURL) return contentPathToSubdomainUrl(contentPath, pubSubdomainGwURL)
+  const { pubGwURLString, pubSubdomainGwURL } = state
+  if (pubSubdomainGwURL) {
+    const subdomainUrl = contentPathToSubdomainUrl(contentPath, pubSubdomainGwURL)
+    if (subdomainUrl) return subdomainUrl
+  }
   if (pubGwURLString) return pathAtHttpGateway(contentPath, pubGwURLString)
-  if (pubSubdomainGwURL) return contentPathToSubdomainUrl(contentPath, pubSubdomainGwURL)
   return null
 }
 
 // Shareable form of an already-normalized content path: a public gateway URL
-// when the user opted in and one is configured, the native ipfs:// / ipns://
-// URI otherwise. Takes the path verbatim; it must not be re-parsed here, as
-// another decodeURI pass would corrupt percent-encoded segments.
+// when usePublicGatewaysForShare is on and a public gateway can serve the
+// path, the native ipfs:// / ipns:// URI otherwise. Takes the path verbatim;
+// it must not be re-parsed here, as another decodeURI pass would corrupt
+// percent-encoded segments.
 function shareUrlForContentPath (contentPath, state) {
   if (state.usePublicGatewaysForShare) {
     const publicUrl = publicShareUrl(contentPath, state)
@@ -419,9 +424,9 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
     },
 
     // Resolve URL or path to the link used by "Copy Shareable Link":
-    // native ipfs:// / ipns:// URI by default, or a public gateway URL when the
-    // user opted in via usePublicGatewaysForShare. With public sharing on, the
-    // "Use Subdomains" preference picks which configured gateway is used.
+    // a public gateway URL when usePublicGatewaysForShare is on (subdomain
+    // gateway preferred, path gateway as fallback), or the native
+    // ipfs:// / ipns:// URI when it is off or no public gateway is set.
     async resolveToShareableUrl (urlOrPath) {
       const contentPath = ipfsPathValidator.resolveToIpfsPath(urlOrPath)
       if (contentPath) return shareUrlForContentPath(contentPath, getState())

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -3,11 +3,15 @@
 import pMemoize from 'p-memoize'
 import * as isIPFS from 'is-ipfs'
 import isFQDN from 'is-fqdn'
+import { CID } from 'multiformats/cid'
+import { base32 } from 'multiformats/bases/base32'
+import { base36 } from 'multiformats/bases/base36'
+import { peerIdFromString } from '@libp2p/peer-id'
 
 // For how long more expensive lookups (DAG traversal etc) should be cached
 const RESULT_TTL_MS = 300000 // 5 minutes
 
-export const dropSlash = url => url.replace(/\/$/, '')
+export const dropSlash = url => url ? url.replace(/\/$/, '') : url
 
 // Turns URL or URIencoded path into a content path
 export function ipfsContentPath (urlOrPath, opts) {
@@ -52,7 +56,70 @@ export function ipfsContentPath (urlOrPath, opts) {
 export function ipfsUri (urlOrPath) {
   const contentPath = ipfsContentPath(urlOrPath, { keepURIParams: true })
   if (!contentPath) return null
-  return contentPath.replace(/^\/(ip[f|n]s)\//, '$1://')
+  return contentPathToNativeUri(contentPath)
+}
+
+// Turns a content path (/ipfs/<cid>/... or /ipns/<name>/...) into a native
+// ipfs:// or ipns:// URI. Browsers treat the authority of these URIs as a
+// case-insensitive origin, so the root is normalized to a case-insensitive CID.
+export function contentPathToNativeUri (contentPath) {
+  const match = contentPath.match(/^\/(ipfs|ipns)\/([^/?#]+)(.*)$/)
+  if (!match) return null
+  const [, ns, root, rest] = match
+  return `${ns}://${toCaseInsensitiveRoot(ns, root)}${rest}`
+}
+
+// Normalize the root of a native URI so it survives as a case-insensitive origin.
+// Only ipfs and ipns are valid namespaces; anything else is a programmer error.
+// Roots we cannot parse are returned unchanged.
+export function toCaseInsensitiveRoot (ns, root) {
+  if (ns === 'ipfs') {
+    // any CID collapses to a base32 CIDv1 (its multicodec is preserved)
+    try {
+      return CID.parse(root).toV1().toString(base32)
+    } catch (e) {
+      return root
+    }
+  }
+  if (ns === 'ipns') {
+    // DNSLink hostnames contain a dot and are left as-is; peer ids (PeerId or
+    // CID) normalize to a base36 CIDv1 with the libp2p-key codec
+    if (root.includes('.')) return root
+    try {
+      return peerIdFromString(root).toCID().toString(base36)
+    } catch (e) {
+      return root
+    }
+  }
+  throw new Error(`toCaseInsensitiveRoot: unsupported namespace '${ns}'`)
+}
+
+// Build a subdomain-gateway URL from a content path, e.g.
+// /ipfs/<cid>/x + https://dweb.link -> https://<cid-base32>.ipfs.dweb.link/x
+// (the label is normalized to a case-insensitive CID). A DNSLink hostname cannot
+// be a subdomain label, so we share the FQDN website itself.
+function contentPathToSubdomainUrl (contentPath, gwURL) {
+  const match = contentPath.match(/^\/(ipfs|ipns)\/([^/?#]+)(.*)$/)
+  if (!match) return null
+  const [, ns, root, rest] = match
+  if (ns === 'ipns' && root.includes('.')) {
+    return trimDoubleSlashes(new URL(`${gwURL.protocol}//${root}${rest}`).toString())
+  }
+  const label = toCaseInsensitiveRoot(ns, root)
+  return trimDoubleSlashes(new URL(`${gwURL.protocol}//${label}.${ns}.${gwURL.host}${rest}`).toString())
+}
+
+// Attach a content path to a public gateway for a shareable link. When both
+// public gateways are set, the "Use Subdomains" preference decides which one is
+// used (subdomain gateway -> subdomain link, path gateway -> path link); when
+// only one is set, that one is used. Returns null when neither is configured.
+function publicShareUrl (contentPath, state) {
+  if (!contentPath) return null
+  const { useSubdomains, pubGwURLString, pubSubdomainGwURL } = state
+  if (useSubdomains && pubSubdomainGwURL) return contentPathToSubdomainUrl(contentPath, pubSubdomainGwURL)
+  if (pubGwURLString) return pathAtHttpGateway(contentPath, pubGwURLString)
+  if (pubSubdomainGwURL) return contentPathToSubdomainUrl(contentPath, pubSubdomainGwURL)
+  return null
 }
 
 function subdomainPatternMatch (url) {
@@ -104,6 +171,8 @@ export function trimHashAndSearch (urlString) {
 // Returns true if URL belongs to the gateway.
 // The check includes subdomain gateways and quirks of ipfs.io
 export function sameGateway (url, gwUrl) {
+  // no gateway configured: nothing can belong to it
+  if (!gwUrl) return false
   if (typeof url === 'string') {
     url = new URL(url)
   }
@@ -240,6 +309,8 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
 
       // NATIVE ipns:// with DNSLink requires simple protocol swap
       if (input.startsWith('ipns://')) {
+        // no public gateway configured: keep the native ipns:// URI
+        if (!pubGwURLString) return input
         const dnslinkUrl = new URL(input)
         dnslinkUrl.protocol = 'https:'
         const dnslink = await dnslinkResolver.readAndCacheDnslink(dnslinkUrl.hostname)
@@ -251,6 +322,8 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
       // SUBDOMAINS
       // Detect *.dweb.link and other subdomain gateways
       if (isIPFS.subdomain(input)) {
+        // no public subdomain gateway configured: copy the native ipfs:// / ipns:// URI
+        if (!pubSubdomainGwURL) return ipfsUri(input)
         // Switch Origin to prefered public subdomain gateway (default: dweb.link)
         const subdomainUrl = swapSubdomainGateway(input, pubSubdomainGwURL)
 
@@ -282,10 +355,37 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
       const ipfsPath = ipfsContentPath(input, { keepURIParams: true })
 
       // IPFS Paths should be attached to the public gateway
-      if (isIPFS.path(ipfsPath)) return pathAtHttpGateway(ipfsPath, pubGwURLString)
+      if (isIPFS.path(ipfsPath)) {
+        // no public gateway configured: copy the native ipfs:// / ipns:// URI
+        if (!pubGwURLString) return ipfsUri(input)
+        return pathAtHttpGateway(ipfsPath, pubGwURLString)
+      }
 
       // Return original URL as-is (eg. DNSLink domains) or null if not an URL
       return input && input.startsWith('http') ? input : null
+    },
+
+    // Resolve URL or path to a native ipfs:// or ipns:// URI:
+    // - Gateway URLs and CID-in-subdomain are turned into ipfs://… / ipns://…
+    // - DNSLinked websites resolve to ipns://<fqdn> when a DNSLink is cached
+    // - Non-IPFS HTTP URLs are returned as-is, anything else yields null
+    resolveToNativeUri (urlOrPath) {
+      const ipfsPath = ipfsPathValidator.resolveToIpfsPath(urlOrPath)
+      if (ipfsPath) return contentPathToNativeUri(ipfsPath)
+      return urlOrPath && urlOrPath.startsWith('http') ? urlOrPath : null
+    },
+
+    // Resolve URL or path to the link used by "Copy Shareable Link":
+    // native ipfs:// / ipns:// URI by default, or a public gateway URL when the
+    // user opted in via usePublicGatewaysForShare. With public sharing on, the
+    // "Use Subdomains" preference picks which configured gateway is used.
+    async resolveToShareableUrl (urlOrPath) {
+      const state = getState()
+      if (!state.usePublicGatewaysForShare) {
+        return ipfsPathValidator.resolveToNativeUri(urlOrPath)
+      }
+      const contentPath = ipfsPathValidator.resolveToIpfsPath(urlOrPath)
+      return publicShareUrl(contentPath, state) ?? ipfsPathValidator.resolveToNativeUri(urlOrPath)
     },
 
     // Version of resolveToPublicUrl that always resolves to URL representing
@@ -306,10 +406,15 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
     // and that never changes.
     async resolveToPermalink (urlOrPath, optionalGatewayUrl) {
       const input = urlOrPath
+      const state = getState()
       const ipfsPath = await this.resolveToImmutableIpfsPath(input)
-      const gateway = optionalGatewayUrl || getState().pubGwURLString
-      if (ipfsPath) return pathAtHttpGateway(ipfsPath, gateway)
-      return input.startsWith('http') ? input : null
+      if (!ipfsPath) return input.startsWith('http') ? input : null
+      // an explicit gateway wins; otherwise follow the same share preference as
+      // resolveToShareableUrl (immutable native ipfs:// URI unless public sharing
+      // is on, in which case "Use Subdomains" picks the gateway)
+      if (optionalGatewayUrl) return pathAtHttpGateway(ipfsPath, optionalGatewayUrl)
+      if (!state.usePublicGatewaysForShare) return ipfsUri(ipfsPath)
+      return publicShareUrl(ipfsPath, state) ?? ipfsUri(ipfsPath)
     },
 
     // Resolve URL or path to IPFS Path:

--- a/add-on/src/lib/ipfs-path.js
+++ b/add-on/src/lib/ipfs-path.js
@@ -59,13 +59,22 @@ export function ipfsUri (urlOrPath) {
   return contentPathToNativeUri(contentPath)
 }
 
+// Splits a content path into namespace, root and the remainder, e.g.
+// /ipfs/<cid>/a/b?x#y -> { ns: 'ipfs', root: '<cid>', rest: '/a/b?x#y' }
+function parseContentPath (contentPath) {
+  const match = contentPath.match(/^\/(ipfs|ipns)\/([^/?#]+)(.*)$/)
+  if (!match) return null
+  const [, ns, root, rest] = match
+  return { ns, root, rest }
+}
+
 // Turns a content path (/ipfs/<cid>/... or /ipns/<name>/...) into a native
 // ipfs:// or ipns:// URI. Browsers treat the authority of these URIs as a
 // case-insensitive origin, so the root is normalized to a case-insensitive CID.
 export function contentPathToNativeUri (contentPath) {
-  const match = contentPath.match(/^\/(ipfs|ipns)\/([^/?#]+)(.*)$/)
-  if (!match) return null
-  const [, ns, root, rest] = match
+  const parsed = parseContentPath(contentPath)
+  if (!parsed) return null
+  const { ns, root, rest } = parsed
   return `${ns}://${toCaseInsensitiveRoot(ns, root)}${rest}`
 }
 
@@ -98,15 +107,26 @@ export function toCaseInsensitiveRoot (ns, root) {
 // /ipfs/<cid>/x + https://dweb.link -> https://<cid-base32>.ipfs.dweb.link/x
 // (the label is normalized to a case-insensitive CID). A DNSLink hostname cannot
 // be a subdomain label, so we share the FQDN website itself.
-function contentPathToSubdomainUrl (contentPath, gwURL) {
-  const match = contentPath.match(/^\/(ipfs|ipns)\/([^/?#]+)(.*)$/)
-  if (!match) return null
-  const [, ns, root, rest] = match
-  if (ns === 'ipns' && root.includes('.')) {
-    return trimDoubleSlashes(new URL(`${gwURL.protocol}//${root}${rest}`).toString())
+export function contentPathToSubdomainUrl (contentPath, gwURL) {
+  const parsed = parseContentPath(contentPath)
+  if (!parsed) return null
+  const { ns, root, rest } = parsed
+  try {
+    if (ns === 'ipns' && root.includes('.')) {
+      return trimDoubleSlashes(new URL(`${gwURL.protocol}//${root}${rest}`).toString())
+    }
+    const label = toCaseInsensitiveRoot(ns, root)
+    // KNOWN BUG: the label length is not checked. Local *.localhost subdomains
+    // tolerate labels longer than 63 characters, but public DNS does not, so a
+    // root CID with a multihash longer than sha2-256 (e.g. sha2-512) produces a
+    // hostname that will not resolve. Content that requires subdomain (origin)
+    // isolation should not use such CIDs as its root.
+    return trimDoubleSlashes(new URL(`${gwURL.protocol}//${label}.${ns}.${gwURL.host}${rest}`).toString())
+  } catch (e) {
+    // roots that are not valid hostnames (e.g. an /ipns/ name with spaces)
+    // cannot be turned into a subdomain URL
+    return null
   }
-  const label = toCaseInsensitiveRoot(ns, root)
-  return trimDoubleSlashes(new URL(`${gwURL.protocol}//${label}.${ns}.${gwURL.host}${rest}`).toString())
 }
 
 // Attach a content path to a public gateway for a shareable link. When both
@@ -120,6 +140,18 @@ function publicShareUrl (contentPath, state) {
   if (pubGwURLString) return pathAtHttpGateway(contentPath, pubGwURLString)
   if (pubSubdomainGwURL) return contentPathToSubdomainUrl(contentPath, pubSubdomainGwURL)
   return null
+}
+
+// Shareable form of an already-normalized content path: a public gateway URL
+// when the user opted in and one is configured, the native ipfs:// / ipns://
+// URI otherwise. Takes the path verbatim; it must not be re-parsed here, as
+// another decodeURI pass would corrupt percent-encoded segments.
+function shareUrlForContentPath (contentPath, state) {
+  if (state.usePublicGatewaysForShare) {
+    const publicUrl = publicShareUrl(contentPath, state)
+    if (publicUrl) return publicUrl
+  }
+  return contentPathToNativeUri(contentPath)
 }
 
 function subdomainPatternMatch (url) {
@@ -210,8 +242,10 @@ export function sameGateway (url, gwUrl) {
   }
 
   for (const gwName of gws) {
-    // match against the end to include subdomain gateways
-    if (url.host.endsWith(gwName)) return true
+    // match the exact host or its subdomains (subdomain gateways); the label
+    // boundary keeps unrelated hosts sharing a suffix (nondefaultipfs.io vs
+    // ipfs.io) from matching
+    if (url.host === gwName || url.host.endsWith(`.${gwName}`)) return true
   }
   return false
 }
@@ -295,14 +329,15 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
           !sameGateway(url, apiURL))) // hide on api port
     },
 
-    // Resolve URL or path to HTTP URL:
-    // - IPFS paths are attached to HTTP Path Gateway root
-    // - IPFS subdomains are attached to HTTP Subdomain Gateway root
-    // - URL of DNSLinked websites are returned as-is
-    //
-    // The purpose of this resolver is to always return a meaningful, publicly
-    // accessible URL that can be accessed without the need of IPFS client.
-    // TODO: add Local version
+    // Resolve URL or path to a public HTTP URL:
+    // - content paths are attached to the public path gateway, or to the
+    //   public subdomain gateway when only that one is configured
+    // - subdomain gateway URLs are attached to the public subdomain gateway
+    //   only: a subdomain request asks for origin isolation and is never
+    //   downgraded to a path gateway
+    // - URLs of DNSLinked websites are returned as-is
+    // - the native ipfs:// / ipns:// URI is returned when no acceptable
+    //   public gateway is configured
     async resolveToPublicUrl (urlOrPath) {
       const { pubSubdomainGwURL, pubGwURLString } = getState()
       const input = urlOrPath
@@ -310,9 +345,10 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
       // NATIVE ipns:// with DNSLink requires simple protocol swap
       if (input.startsWith('ipns://')) {
         // no public gateway configured: keep the native ipns:// URI
-        if (!pubGwURLString) return input
-        const dnslinkUrl = new URL(input)
-        dnslinkUrl.protocol = 'https:'
+        if (!pubGwURLString && !pubSubdomainGwURL) return input
+        // the non-special ipns: scheme cannot be swapped in-place via
+        // URL.protocol assignment, so rewrite it before parsing
+        const dnslinkUrl = new URL(input.replace(/^ipns:\/\//, 'https://'))
         const dnslink = await dnslinkResolver.readAndCacheDnslink(dnslinkUrl.hostname)
         if (dnslink) {
           return dnslinkUrl.toString()
@@ -322,7 +358,9 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
       // SUBDOMAINS
       // Detect *.dweb.link and other subdomain gateways
       if (isIPFS.subdomain(input)) {
-        // no public subdomain gateway configured: copy the native ipfs:// / ipns:// URI
+        // A subdomain request asks for origin isolation and is never
+        // downgraded to a path gateway. With no public subdomain gateway
+        // configured, copy the native ipfs:// / ipns:// URI instead.
         if (!pubSubdomainGwURL) return ipfsUri(input)
         // Switch Origin to prefered public subdomain gateway (default: dweb.link)
         const subdomainUrl = swapSubdomainGateway(input, pubSubdomainGwURL)
@@ -356,9 +394,14 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
 
       // IPFS Paths should be attached to the public gateway
       if (isIPFS.path(ipfsPath)) {
+        if (pubGwURLString) return pathAtHttpGateway(ipfsPath, pubGwURLString)
+        // a subdomain gateway can serve a content path too
+        if (pubSubdomainGwURL) {
+          const subdomainUrl = contentPathToSubdomainUrl(ipfsPath, pubSubdomainGwURL)
+          if (subdomainUrl) return subdomainUrl
+        }
         // no public gateway configured: copy the native ipfs:// / ipns:// URI
-        if (!pubGwURLString) return ipfsUri(input)
-        return pathAtHttpGateway(ipfsPath, pubGwURLString)
+        return ipfsUri(input)
       }
 
       // Return original URL as-is (eg. DNSLink domains) or null if not an URL
@@ -380,12 +423,10 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
     // user opted in via usePublicGatewaysForShare. With public sharing on, the
     // "Use Subdomains" preference picks which configured gateway is used.
     async resolveToShareableUrl (urlOrPath) {
-      const state = getState()
-      if (!state.usePublicGatewaysForShare) {
-        return ipfsPathValidator.resolveToNativeUri(urlOrPath)
-      }
       const contentPath = ipfsPathValidator.resolveToIpfsPath(urlOrPath)
-      return publicShareUrl(contentPath, state) ?? ipfsPathValidator.resolveToNativeUri(urlOrPath)
+      if (contentPath) return shareUrlForContentPath(contentPath, getState())
+      // Non-IPFS HTTP URLs are returned as-is, anything else yields null
+      return urlOrPath && urlOrPath.startsWith('http') ? urlOrPath : null
     },
 
     // Version of resolveToPublicUrl that always resolves to URL representing
@@ -406,15 +447,13 @@ export function createIpfsPathValidator (getState, getIpfs, dnslinkResolver) {
     // and that never changes.
     async resolveToPermalink (urlOrPath, optionalGatewayUrl) {
       const input = urlOrPath
-      const state = getState()
       const ipfsPath = await this.resolveToImmutableIpfsPath(input)
       if (!ipfsPath) return input.startsWith('http') ? input : null
-      // an explicit gateway wins; otherwise follow the same share preference as
-      // resolveToShareableUrl (immutable native ipfs:// URI unless public sharing
-      // is on, in which case "Use Subdomains" picks the gateway)
+      // an explicit gateway wins; otherwise the immutable path follows the same
+      // share preference as "Copy Shareable Link" (the path is already decoded,
+      // so it goes to the shared helper without another resolve pass)
       if (optionalGatewayUrl) return pathAtHttpGateway(ipfsPath, optionalGatewayUrl)
-      if (!state.usePublicGatewaysForShare) return ipfsUri(ipfsPath)
-      return publicShareUrl(ipfsPath, state) ?? ipfsUri(ipfsPath)
+      return shareUrlForContentPath(ipfsPath, getState())
     },
 
     // Resolve URL or path to IPFS Path:

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -25,7 +25,9 @@ const recoverableNetworkErrors = new Set([
   'net::ERR_CONNECTION_TIMED_OUT', // eg. httpd is offline
   'net::ERR_INTERNET_DISCONNECTED' // no network
 ])
-const recoverableHttpError = (code) => code && code >= 400
+// 4xx is the gateway answering about the resource (e.g. 404 for missing
+// content); only 5xx means the gateway itself is unhealthy and worth recovering
+const recoverableHttpError = (code) => code && code >= 500
 
 // Tracking late redirects for edge cases such as https://github.com/ipfs-shipyard/ipfs-companion/issues/436
 const onHeadersReceivedRedirect = new Set()
@@ -434,9 +436,8 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       // Check if error can be recovered by opening same content-addresed path
       // using active gateway (public or local, depending on redirect state)
       if (await isRecoverable(request, state, ipfsPathValidator)) {
-        const redirectUrl = await resolveToActiveGatewayUrl(request.url, state, ipfsPathValidator)
-        // only recover to a loadable http(s) gateway; a tab can't open native ipfs://
-        if (redirectUrl && redirectUrl.startsWith('http')) {
+        const redirectUrl = await recoveryUrlForFailedRequest(request, state, ipfsPathValidator, runtimeRoot)
+        if (redirectUrl) {
           log(`onErrorOccurred: attempting to recover from network error (${request.error}) for ${request.url} → ${redirectUrl}`, request)
           // We are unable to redirect in onErrorOccurred, but we can update the tab
           return updateTabWithURL(request, redirectUrl, browser)
@@ -468,9 +469,8 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       }
 
       if (await isRecoverable(request, state, ipfsPathValidator)) {
-        const redirectUrl = await resolveToActiveGatewayUrl(request.url, state, ipfsPathValidator)
-        // only recover to a loadable http(s) gateway; a tab can't open native ipfs://
-        if (redirectUrl && redirectUrl.startsWith('http')) {
+        const redirectUrl = await recoveryUrlForFailedRequest(request, state, ipfsPathValidator, runtimeRoot)
+        if (redirectUrl) {
           log(`onCompleted: attempting to recover from HTTP Error ${request.statusCode} for ${request.url} → ${redirectUrl}`, request)
           return updateTabWithURL(request, redirectUrl, browser)
         }
@@ -673,29 +673,43 @@ function normalizedUnhandledIpfsProtocol (request, pubGwUrl) {
 // RECOVERY OF FAILED REQUESTS
 // ===================================================================
 
-// Resolve a failed request to a loadable gateway URL for recovery: prefer the
-// configured public gateway, otherwise the local gateway when it is available.
-// Returns null (no recovery) when neither is usable, so we never navigate a tab
-// to a native ipfs:// URI that browsers without a protocol handler cannot open.
+// Resolve a failed request to a loadable gateway URL for recovery: a
+// configured public gateway first (skipped when the failure happened at that
+// very gateway), then the local gateway when the node is online. Returns null
+// when nothing loadable is left; callers fall back to the recovery page, so we
+// never navigate a tab to a native ipfs:// URI that browsers without a
+// protocol handler cannot open.
 async function resolveToActiveGatewayUrl (url, state, ipfsPathValidator) {
-  if (state.pubGwURLString) return ipfsPathValidator.resolveToPublicUrl(url)
-  if (state.localGwAvailable) return ipfsPathValidator.resolveToLocalUrl(url)
+  const failedAtPublicGw = sameGateway(url, state.pubGwURL) || sameGateway(url, state.pubSubdomainGwURL)
+  if (!failedAtPublicGw && (state.pubGwURLString || state.pubSubdomainGwURL)) {
+    const publicUrl = await ipfsPathValidator.resolveToPublicUrl(url)
+    if (publicUrl && publicUrl.startsWith('http')) return publicUrl
+  }
+  if (state.localGwAvailable && state.nodeActive) return ipfsPathValidator.resolveToLocalUrl(url)
+  return null
+}
+
+// The URL a failed request is recovered to: a loadable gateway URL when one
+// exists, otherwise the extension's recovery page with the native URI in the
+// hash, where the user can start a local node or install IPFS Desktop.
+async function recoveryUrlForFailedRequest (request, state, ipfsPathValidator, runtimeRoot) {
+  const gatewayUrl = await resolveToActiveGatewayUrl(request.url, state, ipfsPathValidator)
+  if (gatewayUrl) return gatewayUrl
+  const nativeUri = ipfsPathValidator.resolveToNativeUri(request.url)
+  if (nativeUri && nativeUri.startsWith('ip')) {
+    return `${dropSlash(runtimeRoot)}${recoveryPagePath}#${encodeURIComponent(nativeUri)}`
+  }
   return null
 }
 
 // Recovery check for onErrorOccurred (request.error) and onCompleted (request.statusCode)
 async function isRecoverable (request, state, ipfsPathValidator) {
-  // Note: we are unable to recover default public gateways without a local one
   const { error, statusCode, url } = request
-  const { redirect, localGwAvailable, pubGwURL, pubSubdomainGwURL } = state
   return (state.recoverFailedHttpRequests &&
     request.type === 'main_frame' &&
     (recoverableNetworkErrors.has(error) ||
       recoverableHttpError(statusCode)) &&
-    await ipfsPathValidator.publicIpfsOrIpnsResource(url) &&
-    ((redirect && localGwAvailable) ||
-      (!sameGateway(url, pubGwURL) &&
-       !sameGateway(url, pubSubdomainGwURL))))
+    await ipfsPathValidator.publicIpfsOrIpnsResource(url))
 }
 
 // Recovery check for onErrorOccurred (request.error)

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -182,7 +182,7 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       }
       // poor-mans protocol handlers - https://github.com/ipfs/ipfs-companion/issues/164#issuecomment-328374052
       if (state.catchUnhandledProtocols && mayContainUnhandledIpfsProtocol(request)) {
-        const fix = await normalizedUnhandledIpfsProtocol(request, state.pubGwURLString)
+        const fix = await normalizedUnhandledIpfsProtocol(request, state.pubGwURLString || state.gwURLString)
         if (fix) {
           return fix
         }
@@ -190,7 +190,7 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       // handler for protocol_handlers from manifest.json
       if (redirectingProtocolRequest(request)) {
         // fix path passed via custom protocol
-        const fix = normalizedRedirectingProtocolRequest(request, state.pubGwURLString)
+        const fix = normalizedRedirectingProtocolRequest(request, state.pubGwURLString || state.gwURLString)
         if (fix) {
           return fix
         }
@@ -371,7 +371,7 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
                 // (optional redirect to custom one can happen later)
                 const url = new URL(request.url)
                 const pathWithArgs = `${xIpfsPath}${url.search}${url.hash}`
-                const newUrl = pathAtHttpGateway(pathWithArgs, state.pubGwURLString)
+                const newUrl = pathAtHttpGateway(pathWithArgs, state.pubGwURLString || state.gwURLString)
                 // redirect only if local node is around
                 if (newUrl && state.localGwAvailable) {
                   log(`onHeadersReceived: normalized ${request.url} to  ${newUrl}`)
@@ -434,10 +434,13 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       // Check if error can be recovered by opening same content-addresed path
       // using active gateway (public or local, depending on redirect state)
       if (await isRecoverable(request, state, ipfsPathValidator)) {
-        const redirectUrl = await ipfsPathValidator.resolveToPublicUrl(request.url)
-        log(`onErrorOccurred: attempting to recover from network error (${request.error}) for ${request.url} → ${redirectUrl}`, request)
-        // We are unable to redirect in onErrorOccurred, but we can update the tab
-        return updateTabWithURL(request, redirectUrl, browser)
+        const redirectUrl = await resolveToActiveGatewayUrl(request.url, state, ipfsPathValidator)
+        // only recover to a loadable http(s) gateway; a tab can't open native ipfs://
+        if (redirectUrl && redirectUrl.startsWith('http')) {
+          log(`onErrorOccurred: attempting to recover from network error (${request.error}) for ${request.url} → ${redirectUrl}`, request)
+          // We are unable to redirect in onErrorOccurred, but we can update the tab
+          return updateTabWithURL(request, redirectUrl, browser)
+        }
       }
     },
 
@@ -465,9 +468,12 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       }
 
       if (await isRecoverable(request, state, ipfsPathValidator)) {
-        const redirectUrl = await ipfsPathValidator.resolveToPublicUrl(request.url)
-        log(`onCompleted: attempting to recover from HTTP Error ${request.statusCode} for ${request.url} → ${redirectUrl}`, request)
-        return updateTabWithURL(request, redirectUrl, browser)
+        const redirectUrl = await resolveToActiveGatewayUrl(request.url, state, ipfsPathValidator)
+        // only recover to a loadable http(s) gateway; a tab can't open native ipfs://
+        if (redirectUrl && redirectUrl.startsWith('http')) {
+          log(`onCompleted: attempting to recover from HTTP Error ${request.statusCode} for ${request.url} → ${redirectUrl}`, request)
+          return updateTabWithURL(request, redirectUrl, browser)
+        }
       }
     }
   }
@@ -666,6 +672,16 @@ function normalizedUnhandledIpfsProtocol (request, pubGwUrl) {
 
 // RECOVERY OF FAILED REQUESTS
 // ===================================================================
+
+// Resolve a failed request to a loadable gateway URL for recovery: prefer the
+// configured public gateway, otherwise the local gateway when it is available.
+// Returns null (no recovery) when neither is usable, so we never navigate a tab
+// to a native ipfs:// URI that browsers without a protocol handler cannot open.
+async function resolveToActiveGatewayUrl (url, state, ipfsPathValidator) {
+  if (state.pubGwURLString) return ipfsPathValidator.resolveToPublicUrl(url)
+  if (state.localGwAvailable) return ipfsPathValidator.resolveToLocalUrl(url)
+  return null
+}
 
 // Recovery check for onErrorOccurred (request.error) and onCompleted (request.statusCode)
 async function isRecoverable (request, state, ipfsPathValidator) {

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -4,6 +4,21 @@ import isFQDN from 'is-fqdn'
 import { isIPv4, isIPv6 } from 'is-ip'
 import { POSSIBLE_NODE_TYPES } from './state.js'
 
+// Public gateways prefilled on a fresh install; "Copy Shareable Link" builds
+// links on the subdomain one. Clearing a gateway URL in Preferences opts out
+// of it (shareable links then fall back to native ipfs:// and ipns:// URIs).
+// To ship native sharing by default, flip
+// DEFAULT_USE_PUBLIC_GATEWAYS_FOR_SHARE to false and set both gateway
+// constants to ''; everything else already copes with unset gateways.
+// Note: storeMissingOptions persists these values into every profile, so
+// flipping the constants alone only changes fresh installs. To reach existing
+// profiles, the flip also needs a migrateOptions entry that rewrites stored
+// values still equal to the constants below (users who changed them keep
+// their choice).
+export const DEFAULT_PUBLIC_GATEWAY_URL = 'https://ipfs.io'
+export const DEFAULT_PUBLIC_SUBDOMAIN_GATEWAY_URL = 'https://dweb.link'
+export const DEFAULT_USE_PUBLIC_GATEWAYS_FOR_SHARE = true
+
 /**
  * @type {Readonly<import('../types/companion.js').CompanionOptions>}
  */
@@ -11,12 +26,12 @@ export const optionDefaults = Object.freeze({
   active: true, // global ON/OFF switch, overrides everything else
   ipfsNodeType: 'external',
   ipfsNodeConfig: buildDefaultIpfsNodeConfig(),
-  publicGatewayUrl: '',
-  publicSubdomainGatewayUrl: '',
-  // When off (default), "Copy Shareable Link" copies native ipfs:// and ipns://
-  // URIs. Turn it on to copy public gateway URLs instead (needs the two public
-  // gateway URLs above to be set).
-  usePublicGatewaysForShare: false,
+  publicGatewayUrl: DEFAULT_PUBLIC_GATEWAY_URL,
+  publicSubdomainGatewayUrl: DEFAULT_PUBLIC_SUBDOMAIN_GATEWAY_URL,
+  // When on, "Copy Shareable Link" copies a URL at one of the public gateways
+  // above (subdomain preferred); when off, or when no public gateway URL is
+  // set, it copies native ipfs:// and ipns:// URIs.
+  usePublicGatewaysForShare: DEFAULT_USE_PUBLIC_GATEWAYS_FOR_SHARE,
   useCustomGateway: true,
   useSubdomains: true,
   enabledOn: [], // hostnames with explicit integration opt-in

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -11,8 +11,12 @@ export const optionDefaults = Object.freeze({
   active: true, // global ON/OFF switch, overrides everything else
   ipfsNodeType: 'external',
   ipfsNodeConfig: buildDefaultIpfsNodeConfig(),
-  publicGatewayUrl: 'https://ipfs.io',
-  publicSubdomainGatewayUrl: 'https://dweb.link',
+  publicGatewayUrl: '',
+  publicSubdomainGatewayUrl: '',
+  // When off (default), "Copy Shareable Link" copies native ipfs:// and ipns://
+  // URIs. Turn it on to copy public gateway URLs instead (needs the two public
+  // gateway URLs above to be set).
+  usePublicGatewaysForShare: false,
   useCustomGateway: true,
   useSubdomains: true,
   enabledOn: [], // hostnames with explicit integration opt-in
@@ -93,8 +97,10 @@ export function safeURL (url, opts) {
   return url
 }
 
-// Return string without trailing slash
+// Return string without trailing slash (empty input stays empty, so optional
+// gateway URLs can be cleared)
 export function guiURLString (url, opts) {
+  if (!url) return ''
   return safeURL(url, opts).toString().replace(/\/$/, '')
 }
 

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -20,10 +20,11 @@ export function initState (options, overrides) {
   const state = Object.assign({}, options)
   // generate some additional values
   state.peerCount = offlinePeerCount
-  state.pubGwURL = safeURL(options.publicGatewayUrl)
+  // public gateways are optional: empty means "copy native ipfs:// URIs"
+  state.pubGwURL = options.publicGatewayUrl ? safeURL(options.publicGatewayUrl) : undefined
   state.pubGwURLString = state.pubGwURL?.toString()
   delete state.publicGatewayUrl
-  state.pubSubdomainGwURL = safeURL(options.publicSubdomainGatewayUrl)
+  state.pubSubdomainGwURL = options.publicSubdomainGatewayUrl ? safeURL(options.publicSubdomainGatewayUrl) : undefined
   state.pubSubdomainGwURLString = state.pubSubdomainGwURL?.toString()
   delete state.publicSubdomainGatewayUrl
   state.redirect = options.useCustomGateway

--- a/add-on/src/options/forms/gateways-form.js
+++ b/add-on/src/options/forms/gateways-form.js
@@ -20,6 +20,7 @@ export default function gatewaysForm ({
   enabledOn,
   publicGatewayUrl,
   publicSubdomainGatewayUrl,
+  usePublicGatewaysForShare,
   onOptionChange
 }) {
   const onCustomGatewayUrlChange = onOptionChange('customGatewayUrl', (url) => guiURLString(url, { useLocalhostName: useSubdomains }))
@@ -27,6 +28,9 @@ export default function gatewaysForm ({
   const onUseSubdomainProxyChange = onOptionChange('useSubdomains')
   const onPublicGatewayUrlChange = onOptionChange('publicGatewayUrl', guiURLString)
   const onPublicSubdomainGatewayUrlChange = onOptionChange('publicSubdomainGatewayUrl', guiURLString)
+  const onUsePublicGatewaysForShareChange = onOptionChange('usePublicGatewaysForShare')
+  // sharing via public gateways needs at least one gateway URL set
+  const anyPublicGatewayConfigured = Boolean(publicGatewayUrl || publicSubdomainGatewayUrl)
   const onDisabledOnChange = onOptionChange('disabledOn', hostTextToArray)
   const onEnabledOnChange = onOptionChange('enabledOn', hostTextToArray)
   const mixedContentWarning = !secureContextUrl.test(customGatewayUrl)
@@ -37,49 +41,6 @@ export default function gatewaysForm ({
     <form>
       <fieldset class="mb3 pa1 pa4-ns pa3 bg-snow-muted charcoal">
         <h2 class="ttu tracked f6 fw4 teal mt0-ns mb3-ns mb1 mt2 ">${browser.i18n.getMessage('option_header_gateways')}</h2>
-          <div class="flex-row-ns pb0-ns">
-            <label for="publicGatewayUrl">
-              <dl>
-                <dt>${browser.i18n.getMessage('option_publicGatewayUrl_title')}</dt>
-                <dd>${browser.i18n.getMessage('option_publicGatewayUrl_description')}</dd>
-              </dl>
-            </label>
-            <input
-              class="bg-white navy self-center-ns"
-              id="publicGatewayUrl"
-              type="url"
-              inputmode="url"
-              required
-              pattern="https?://.+"
-              spellcheck="false"
-              title="${browser.i18n.getMessage('option_hint_url')}"
-              onchange=${onPublicGatewayUrlChange}
-              value=${publicGatewayUrl} />
-          </div>
-          <div class="flex-row-ns pb0-ns">
-            <label for="publicSubdomainGatewayUrl">
-              <dl>
-                <dt>${browser.i18n.getMessage('option_publicSubdomainGatewayUrl_title')}</dt>
-                <dd>
-                  ${browser.i18n.getMessage('option_publicSubdomainGatewayUrl_description')}
-                  <p><a class="link underline hover-aqua" href="https://docs.ipfs.tech/how-to/address-ipfs-on-web/#subdomain-gateway" target="_blank">
-                    ${browser.i18n.getMessage('option_legend_readMore')}
-                  </a></p>
-                </dd>
-              </dl>
-            </label>
-            <input
-              class="bg-white navy self-center-ns"
-              id="publicSubdomainGatewayUrl"
-              type="url"
-              inputmode="url"
-              required
-              pattern="https?://.+"
-              spellcheck="false"
-              title="${browser.i18n.getMessage('option_hint_url')}"
-              onchange=${onPublicSubdomainGatewayUrlChange}
-              value=${publicSubdomainGatewayUrl} />
-          </div>
           ${supportRedirectToCustomGateway
             ? html`<div class="flex-row-ns pb0-ns">
               <label for="customGatewayUrl">
@@ -131,6 +92,61 @@ export default function gatewaysForm ({
               <div class="self-center-ns">${switchToggle({ id: 'useSubdomains', checked: useSubdomains, onchange: onUseSubdomainProxyChange })}</div>
             </div>`
             : null}
+          <div class="flex-row-ns pb0-ns">
+            <label for="publicGatewayUrl">
+              <dl>
+                <dt>${browser.i18n.getMessage('option_publicGatewayUrl_title')}</dt>
+                <dd>
+                  ${browser.i18n.getMessage('option_publicGatewayUrl_description')}
+                  <p><a class="link underline hover-aqua" href="https://specs.ipfs.tech/http-gateways/path-gateway/" target="_blank">
+                    ${browser.i18n.getMessage('option_legend_readMore')}
+                  </a></p>
+                </dd>
+              </dl>
+            </label>
+            <input
+              class="bg-white navy self-center-ns"
+              id="publicGatewayUrl"
+              type="url"
+              inputmode="url"
+              pattern="https?://.+"
+              spellcheck="false"
+              title="${browser.i18n.getMessage('option_hint_url')}"
+              onchange=${onPublicGatewayUrlChange}
+              value=${publicGatewayUrl} />
+          </div>
+          <div class="flex-row-ns pb0-ns">
+            <label for="publicSubdomainGatewayUrl">
+              <dl>
+                <dt>${browser.i18n.getMessage('option_publicSubdomainGatewayUrl_title')}</dt>
+                <dd>
+                  ${browser.i18n.getMessage('option_publicSubdomainGatewayUrl_description')}
+                  <p><a class="link underline hover-aqua" href="https://specs.ipfs.tech/http-gateways/subdomain-gateway/" target="_blank">
+                    ${browser.i18n.getMessage('option_legend_readMore')}
+                  </a></p>
+                </dd>
+              </dl>
+            </label>
+            <input
+              class="bg-white navy self-center-ns"
+              id="publicSubdomainGatewayUrl"
+              type="url"
+              inputmode="url"
+              pattern="https?://.+"
+              spellcheck="false"
+              title="${browser.i18n.getMessage('option_hint_url')}"
+              onchange=${onPublicSubdomainGatewayUrlChange}
+              value=${publicSubdomainGatewayUrl} />
+          </div>
+          <div class="flex-row-ns pb0-ns">
+            <label for="usePublicGatewaysForShare">
+              <dl>
+                <dt>${browser.i18n.getMessage('option_usePublicGatewaysForShare_title')}</dt>
+                <dd>${browser.i18n.getMessage('option_usePublicGatewaysForShare_description')}</dd>
+              </dl>
+            </label>
+            <div class="self-center-ns">${switchToggle({ id: 'usePublicGatewaysForShare', checked: usePublicGatewaysForShare && anyPublicGatewayConfigured, onchange: onUsePublicGatewaysForShareChange, disabled: !anyPublicGatewayConfigured })}</div>
+          </div>
           ${supportRedirectToCustomGateway
           ? html`<div class="flex-row-ns pb0-ns">
               <label for="disabledOn">

--- a/add-on/src/options/forms/ipfs-node-form.js
+++ b/add-on/src/options/forms/ipfs-node-form.js
@@ -2,30 +2,55 @@
 
 import browser from 'webextension-polyfill'
 import html from 'choo/html/index.js'
+import { POSSIBLE_NODE_TYPES } from '../../lib/state.js'
 
 export default function ipfsNodeForm ({ ipfsNodeType, onOptionChange }) {
   const onIpfsNodeTypeChange = onOptionChange('ipfsNodeType')
+  // with a single possible node type there is nothing to choose, so the
+  // select row is hidden and the section shows only the explainer below
+  const showNodeTypeSelect = POSSIBLE_NODE_TYPES.length > 1
   return html`
     <form>
       <fieldset class="mb3 pa1 pa4-ns pa3 bg-snow-muted charcoal">
         <h2 class="ttu tracked f6 fw4 teal mt0-ns mb3-ns mb1 mt2 ">${browser.i18n.getMessage('option_header_nodeType')}</h2>
-        <div class="flex-row-ns pb0-ns">
-          <label for="ipfsNodeType">
+        ${showNodeTypeSelect
+          ? html`<div class="flex-row-ns pb0-ns">
+            <label for="ipfsNodeType">
+              <dl>
+                <dt>${browser.i18n.getMessage('option_ipfsNodeType_title')}</dt>
+                <dd>
+                  <p>${browser.i18n.getMessage('option_ipfsNodeType_external_description')}</p>
+                </dd>
+              </dl>
+            </label>
+            <select id="ipfsNodeType" name='ipfsNodeType' class="self-center-ns bg-white navy" onchange=${onIpfsNodeTypeChange}>
+              ${POSSIBLE_NODE_TYPES.map(nodeType => html`<option
+                value=${nodeType}
+                selected=${ipfsNodeType === nodeType}>
+                ${browser.i18n.getMessage(`option_ipfsNodeType_${nodeType}`)}
+              </option>`)}
+            </select>
+          </div>`
+          : null}
+        ${ipfsNodeType === 'external'
+          ? html`<div class="flex-row-ns pb0-ns">
             <dl>
-              <dt>${browser.i18n.getMessage('option_ipfsNodeType_title')}</dt>
-              <dd>
-                <p>${browser.i18n.getMessage('option_ipfsNodeType_external_description')}</p>
+              <dt class="fw6">${browser.i18n.getMessage('option_ipfsNodeType_external')}</dt>
+              <dd class="ml0 mv2">
+                ${browser.i18n.getMessage('option_ipfsNodeType_external_explainer')}
+                <p>
+                  <a class="link underline hover-aqua" href="https://docs.ipfs.tech/install/command-line/" target="_blank">
+                    ${browser.i18n.getMessage('option_ipfsNodeType_external_installKubo')}
+                  </a> | <a class="link underline hover-aqua" href="https://docs.ipfs.tech/install/ipfs-desktop/" target="_blank">
+                    ${browser.i18n.getMessage('option_ipfsNodeType_external_installDesktop')}
+                  </a> | <a class="link underline hover-aqua" href="https://docs.ipfs.tech/reference/kubo/rpc/" target="_blank">
+                    ${browser.i18n.getMessage('option_ipfsNodeType_external_rpcDocs')}
+                  </a>
+                </p>
               </dd>
             </dl>
-          </label>
-          <select id="ipfsNodeType" name='ipfsNodeType' class="self-center-ns bg-white navy" onchange=${onIpfsNodeTypeChange}>
-            <option
-              value='external'
-              selected=${ipfsNodeType === 'external'}>
-              ${browser.i18n.getMessage('option_ipfsNodeType_external')}
-            </option>
-          </select>
-        </div>
+          </div>`
+          : null}
       </fieldset>
     </form>
   `

--- a/add-on/src/options/page.js
+++ b/add-on/src/options/page.js
@@ -75,6 +75,7 @@ export default function optionsPage (state, emit) {
     useSubdomains: state.options.useSubdomains,
     publicGatewayUrl: state.options.publicGatewayUrl,
     publicSubdomainGatewayUrl: state.options.publicSubdomainGatewayUrl,
+    usePublicGatewaysForShare: state.options.usePublicGatewaysForShare,
     disabledOn: state.options.disabledOn,
     enabledOn: state.options.enabledOn,
     onOptionChange

--- a/add-on/src/options/store.js
+++ b/add-on/src/options/store.js
@@ -49,17 +49,7 @@ export default function optionStore (state, emitter) {
   })
 
   emitter.on('optionChange', async ({ key, value }) => {
-    const changes = { [key]: value }
-    // clearing the last public gateway URL also turns off public-gateway
-    // sharing, so a URL added later for the recovery fallback does not
-    // silently re-enable it
-    const publicGatewayKeys = ['publicGatewayUrl', 'publicSubdomainGatewayUrl']
-    if (publicGatewayKeys.includes(key) && !value) {
-      const otherKey = publicGatewayKeys.find(k => k !== key)
-      const options = await getOptions()
-      if (!options[otherKey]) changes.usePublicGatewaysForShare = false
-    }
-    browser.storage.local.set(changes)
+    browser.storage.local.set({ [key]: value })
     await notifyOptionChange()
   })
 

--- a/add-on/src/options/store.js
+++ b/add-on/src/options/store.js
@@ -49,7 +49,17 @@ export default function optionStore (state, emitter) {
   })
 
   emitter.on('optionChange', async ({ key, value }) => {
-    browser.storage.local.set({ [key]: value })
+    const changes = { [key]: value }
+    // clearing the last public gateway URL also turns off public-gateway
+    // sharing, so a URL added later for the recovery fallback does not
+    // silently re-enable it
+    const publicGatewayKeys = ['publicGatewayUrl', 'publicSubdomainGatewayUrl']
+    if (publicGatewayKeys.includes(key) && !value) {
+      const otherKey = publicGatewayKeys.find(k => k !== key)
+      const options = await getOptions()
+      if (!options[otherKey]) changes.usePublicGatewaysForShare = false
+    }
+    browser.storage.local.set(changes)
     await notifyOptionChange()
   })
 

--- a/add-on/src/popup/browser-action/store.js
+++ b/add-on/src/popup/browser-action/store.js
@@ -147,7 +147,8 @@ export default (state, emitter) => {
   emitter.on('toggleGlobalRedirect', async () => {
     const redirectEnabled = state.redirect
     state.redirect = !redirectEnabled
-    state.gatewayAddress = state.redirect ? state.gwURLString : state.pubGwURLString
+    // with no public gateway configured, show the local one instead
+    state.gatewayAddress = state.redirect ? state.gwURLString : (state.pubGwURLString || state.gwURLString)
     emitter.emit('render')
     try {
       await browser.storage.local.set({ useCustomGateway: !redirectEnabled })
@@ -210,7 +211,7 @@ export default (state, emitter) => {
     state.active = !prev
     try {
       if (!state.active) {
-        state.gatewayAddress = state.pubGwURLString
+        state.gatewayAddress = state.pubGwURLString || state.gwURLString
         state.ipfsApiUrl = null
         state.kuboRpcBackendVersion = null
         state.swarmPeers = null
@@ -233,7 +234,8 @@ export default (state, emitter) => {
       if (state.active && status.redirect && POSSIBLE_NODE_TYPES.includes(status.ipfsNodeType)) {
         state.gatewayAddress = status.gwURLString
       } else {
-        state.gatewayAddress = status.pubGwURLString
+        // with no public gateway configured, show the local one instead
+        state.gatewayAddress = status.pubGwURLString || status.gwURLString
       }
       state.isApiAvailable = state.active && !browser.extension.inIncognitoContext // https://github.com/ipfs-shipyard/ipfs-companion/issues/243
       state.swarmPeers = !state.active || status.peerCount === -1 ? null : status.peerCount

--- a/add-on/src/recovery/recovery.js
+++ b/add-on/src/recovery/recovery.js
@@ -34,16 +34,26 @@ app.route('*', (state) => {
     }
   }
 
-  // if the IPFS node is online, open the URL from the hash, this will redirect to the local node.
-  if (state.isIpfsOnline) {
-    openURLFromHash()
-    return
-  }
-
   // With no public gateway configured, the resource resolves to a native
   // ipfs:// / ipns:// URI that has no HTTP fallback. Drop the public-gateway
   // copy and point the user at running a local node instead.
   const isNativeUri = /^ip[fn]s:\/\//.test(publicURI)
+
+  // if the IPFS node is online, open the URL from the hash, this will redirect
+  // to the local node. Browsers without an ipfs:// protocol handler cannot
+  // navigate to a native URI, so ask the background to resolve it to a gateway
+  // URL (the local one, unless a public gateway is configured) first.
+  if (state.isIpfsOnline) {
+    if (isNativeUri) {
+      const contentPath = publicURI.replace(/^(ip[fn]s):\/\//, '/$1/')
+      runtime.sendMessage({ pubGwUrlForIpfsOrIpnsPath: contentPath })
+        .then(({ pubGwUrlForIpfsOrIpnsPath: url }) => { if (url) window.location.replace(url) })
+        .catch(err => console.error('Failed to resolve native URI to a gateway URL:', err))
+      return
+    }
+    openURLFromHash()
+    return
+  }
   const openInstallDesktop = () => window.open('https://docs.ipfs.tech/install/ipfs-desktop/', '_blank', 'noopener,noreferrer')
   const [buttonOnclick, buttonLabelKey] = isNativeUri
     ? [openInstallDesktop, 'recovery_page_button_installDesktop']

--- a/add-on/src/recovery/recovery.js
+++ b/add-on/src/recovery/recovery.js
@@ -40,6 +40,12 @@ app.route('*', (state) => {
     return
   }
 
+  // With no public gateway configured, the resource resolves to a native
+  // ipfs:// / ipns:// URI that has no HTTP fallback. Drop the public-gateway
+  // copy and point the user at running a local node instead.
+  const isNativeUri = /^ip[fn]s:\/\//.test(publicURI)
+  const openInstallDesktop = () => window.open('https://docs.ipfs.tech/install/ipfs-desktop/', '_blank', 'noopener,noreferrer')
+
   return html`<div class="flex flex-column flex-row-l">
     <div id="left-col" class="min-vh-100 flex flex-column justify-center items-center bg-navy white">
       <div class="mb4 flex flex-column justify-center items-center">
@@ -50,18 +56,25 @@ app.route('*', (state) => {
 
     <div id="right-col" class="pt7 mt5 w-100 flex flex-column justify-around items-center">
       <p class="f3 fw5">${i18n.getMessage('recovery_page_message_p1')}</p>
-      <p class="f4 fw4">${i18n.getMessage('recovery_page_message_p2')}</p>
-      <p class="f4 fw4 w-100"><span class="b-ns">Public URL:</span> <a class="no-underline no-underline navy link hover-aqua" href="${publicURI}" rel="noopener noreferrer" target="_blank">${publicURI}</a></p>
-      <button
-        class="fade-in ba bw1 b--teal bg-teal snow f7 ph2 pv3 br2 ma4 pointer"
-        onclick=${openURLFromHash}
-        href="${publicURI}"
-      >
-        <span class="f5 fw6">${i18n.getMessage('recovery_page_button')}</span>
-      </button>
+      <p class="f4 fw4">${isNativeUri ? i18n.getMessage('recovery_page_message_p2_native') : i18n.getMessage('recovery_page_message_p2')}</p>
+      <p class="f4 fw4 w-100"><span class="b-ns">${isNativeUri ? i18n.getMessage('recovery_page_nativeUrl') : i18n.getMessage('recovery_page_publicUrl')}</span> <a class="no-underline navy link hover-aqua" href="${publicURI}" rel="noopener noreferrer" target="_blank">${publicURI}</a></p>
+      ${isNativeUri
+        ? html`<button
+            class="fade-in ba bw1 b--teal bg-teal snow f7 ph2 pv3 br2 ma4 pointer"
+            onclick=${openInstallDesktop}
+          >
+            <span class="f5 fw6">${i18n.getMessage('recovery_page_button_installDesktop')}</span>
+          </button>`
+        : html`<button
+            class="fade-in ba bw1 b--teal bg-teal snow f7 ph2 pv3 br2 ma4 pointer"
+            onclick=${openURLFromHash}
+            href="${publicURI}"
+          >
+            <span class="f5 fw6">${i18n.getMessage('recovery_page_button')}</span>
+          </button>`}
       <p class="f5 fw2 pt5">
         ${learnMoreLink} | ${optionsPageLink}
-      </span>
+      </p>
     </div>
   </div>`
 })

--- a/add-on/src/recovery/recovery.js
+++ b/add-on/src/recovery/recovery.js
@@ -45,6 +45,9 @@ app.route('*', (state) => {
   // copy and point the user at running a local node instead.
   const isNativeUri = /^ip[fn]s:\/\//.test(publicURI)
   const openInstallDesktop = () => window.open('https://docs.ipfs.tech/install/ipfs-desktop/', '_blank', 'noopener,noreferrer')
+  const [buttonOnclick, buttonLabelKey] = isNativeUri
+    ? [openInstallDesktop, 'recovery_page_button_installDesktop']
+    : [openURLFromHash, 'recovery_page_button']
 
   return html`<div class="flex flex-column flex-row-l">
     <div id="left-col" class="min-vh-100 flex flex-column justify-center items-center bg-navy white">
@@ -58,20 +61,12 @@ app.route('*', (state) => {
       <p class="f3 fw5">${i18n.getMessage('recovery_page_message_p1')}</p>
       <p class="f4 fw4">${isNativeUri ? i18n.getMessage('recovery_page_message_p2_native') : i18n.getMessage('recovery_page_message_p2')}</p>
       <p class="f4 fw4 w-100"><span class="b-ns">${isNativeUri ? i18n.getMessage('recovery_page_nativeUrl') : i18n.getMessage('recovery_page_publicUrl')}</span> <a class="no-underline navy link hover-aqua" href="${publicURI}" rel="noopener noreferrer" target="_blank">${publicURI}</a></p>
-      ${isNativeUri
-        ? html`<button
-            class="fade-in ba bw1 b--teal bg-teal snow f7 ph2 pv3 br2 ma4 pointer"
-            onclick=${openInstallDesktop}
-          >
-            <span class="f5 fw6">${i18n.getMessage('recovery_page_button_installDesktop')}</span>
-          </button>`
-        : html`<button
-            class="fade-in ba bw1 b--teal bg-teal snow f7 ph2 pv3 br2 ma4 pointer"
-            onclick=${openURLFromHash}
-            href="${publicURI}"
-          >
-            <span class="f5 fw6">${i18n.getMessage('recovery_page_button')}</span>
-          </button>`}
+      <button
+        class="fade-in ba bw1 b--teal bg-teal snow f7 ph2 pv3 br2 ma4 pointer"
+        onclick=${buttonOnclick}
+      >
+        <span class="f5 fw6">${i18n.getMessage(buttonLabelKey)}</span>
+      </button>
       <p class="f5 fw2 pt5">
         ${learnMoreLink} | ${optionsPageLink}
       </p>

--- a/add-on/src/types/companion.d.ts
+++ b/add-on/src/types/companion.d.ts
@@ -4,6 +4,7 @@ export interface CompanionOptions {
   ipfsNodeConfig: string
   publicGatewayUrl: string
   publicSubdomainGatewayUrl: string
+  usePublicGatewaysForShare: boolean
   useCustomGateway: boolean
   useSubdomains: boolean
   enabledOn: string[]
@@ -31,10 +32,10 @@ export interface CompanionOptions {
 
 export interface CompanionState extends Omit<CompanionOptions, 'publicGatewayUrl' | 'publicSubdomainGatewayUrl' | 'useCustomGateway' | 'ipfsApiUrl' | 'customGatewayUrl'> {
   peerCount: number
-  pubGwURL: URL
-  pubGwURLString: string
-  pubSubdomainGwURL: URL
-  pubSubdomainGwURLString: string
+  pubGwURL: URL | undefined
+  pubGwURLString: string | undefined
+  pubSubdomainGwURL: URL | undefined
+  pubSubdomainGwURLString: string | undefined
   redirect: boolean
   apiURL: URL
   apiURLString: string

--- a/test/functional/lib/ipfs-import.test.js
+++ b/test/functional/lib/ipfs-import.test.js
@@ -148,7 +148,29 @@ describe('ipfs-import.js', function () {
     })
 
     describe('preloadFilesAtPublicGateway', () => {
-      it.todo('implement')
+      const files = [{ path: '', cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa' }]
+
+      it('should do nothing when no public gateway is configured', async function () {
+        const fetchStub = sandbox.stub(globalThis, 'fetch').resolves({})
+        getState.returns({ preloadAtPublicGateway: true, gwURLString: 'http://localhost:8080/' })
+        await ipfsImportHandler.preloadFilesAtPublicGateway(files)
+        sinon.assert.notCalled(fetchStub)
+      })
+
+      it('should preload at the public path gateway when only it is configured', async function () {
+        const fetchStub = sandbox.stub(globalThis, 'fetch').resolves({})
+        getState.returns({ preloadAtPublicGateway: true, pubGwURLString: 'https://ipfs.io/' })
+        await ipfsImportHandler.preloadFilesAtPublicGateway(files)
+        sinon.assert.calledWith(fetchStub, 'https://ipfs.io/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa#x-ipfs-companion-no-redirect', { method: 'HEAD' })
+      })
+
+      it('should preload at a random configured gateway when both are set', async function () {
+        const fetchStub = sandbox.stub(globalThis, 'fetch').resolves({})
+        sandbox.stub(Math, 'random').returns(0.99) // picks the second candidate
+        getState.returns({ preloadAtPublicGateway: true, pubGwURLString: 'https://ipfs.io/', pubSubdomainGwURL: new URL('https://dweb.link/') })
+        await ipfsImportHandler.preloadFilesAtPublicGateway(files)
+        sinon.assert.calledWith(fetchStub, 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/#x-ipfs-companion-no-redirect', { method: 'HEAD' })
+      })
     })
 
     describe('filesCpImportCurrentTab', () => {

--- a/test/functional/lib/ipfs-import.test.js
+++ b/test/functional/lib/ipfs-import.test.js
@@ -171,6 +171,15 @@ describe('ipfs-import.js', function () {
         await ipfsImportHandler.preloadFilesAtPublicGateway(files)
         sinon.assert.calledWith(fetchStub, 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/#x-ipfs-companion-no-redirect', { method: 'HEAD' })
       })
+
+      it('should do nothing when the only gateway is a subdomain one and the CID exceeds the DNS label limit', async function () {
+        const fetchStub = sandbox.stub(globalThis, 'fetch').resolves({})
+        // sha2-512 multihash: its base32 form (110 chars) cannot be a DNS label
+        const longCidFiles = [{ path: '', cid: 'bafkrgqfg37dz6kebxts6akxt7c7pjyn4w6yekk3gv7diw7euamcmmfbjskrucx3yjcxsqljdyfmxxjoeqz5j24yhgzkeq4fj4ag25jfblj274' }]
+        getState.returns({ preloadAtPublicGateway: true, pubSubdomainGwURL: new URL('https://dweb.link/'), gwURLString: 'http://localhost:8080/' })
+        await ipfsImportHandler.preloadFilesAtPublicGateway(longCidFiles)
+        sinon.assert.notCalled(fetchStub)
+      })
     })
 
     describe('filesCpImportCurrentTab', () => {

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -21,11 +21,8 @@ describe('ipfs-path.js', function () {
 
   beforeEach(function () {
     global.URL = URL
-    // public gateways are empty by default; these cases exercise configured-gateway behavior
-    state = Object.assign(
-      initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' }),
-      { peerCount: 1 }
-    )
+    // defaults prefill both public gateways (ipfs.io and dweb.link)
+    state = Object.assign(initState(optionDefaults), { peerCount: 1 })
     ipfs = {
       name: {
         resolve (arg) {
@@ -421,10 +418,13 @@ describe('ipfs-path.js', function () {
   })
 
   describe('resolveToShareableUrl (Copy Shareable Link)', function () {
-    // default config: public gateways empty, so shareable links are native URIs
+    // public gateway URLs cleared by the user: shareable links are native URIs
     let nativeValidator
     beforeEach(function () {
-      const nativeState = Object.assign(initState(optionDefaults), { peerCount: 1 })
+      const nativeState = Object.assign(
+        initState({ ...optionDefaults, publicGatewayUrl: '', publicSubdomainGatewayUrl: '' }),
+        { peerCount: 1 }
+      )
       nativeValidator = createIpfsPathValidator(() => nativeState, () => ipfs, dnslinkResolver)
     })
     it('copies a native ipfs:// URI for CID-in-subdomain', async function () {
@@ -443,31 +443,40 @@ describe('ipfs-path.js', function () {
       const url = 'https://en-wikipedia--on--ipfs-org.ipns.dweb.link/wiki/Mars.html?argTest#hashTest'
       expect(await nativeValidator.resolveToShareableUrl(url)).to.equal('ipns://en.wikipedia-on-ipfs.org/wiki/Mars.html?argTest#hashTest')
     })
-    // opted into public sharing; overrides set the gateway URLs + Use Subdomains
-    const optedInValidator = (overrides) => {
-      const state = Object.assign(initState({ ...optionDefaults, usePublicGatewaysForShare: true, ...overrides }), { peerCount: 1 })
+    // public sharing on (the default); overrides adjust the gateway URLs
+    const shareValidator = (overrides) => {
+      const state = Object.assign(initState({ ...optionDefaults, ...overrides }), { peerCount: 1 })
       return createIpfsPathValidator(() => state, () => ipfs, dnslinkResolver)
     }
     const cidPath = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
-    const bothGateways = { publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' }
-    it('public share with Use Subdomains on uses the subdomain gateway', async function () {
-      const v = optedInValidator({ ...bothGateways, useSubdomains: true })
+    // sha2-512 multihash: its base32 form (110 chars) exceeds the 63-char DNS label limit
+    const longCidPath = '/ipfs/bafkrgqfg37dz6kebxts6akxt7c7pjyn4w6yekk3gv7diw7euamcmmfbjskrucx3yjcxsqljdyfmxxjoeqz5j24yhgzkeq4fj4ag25jfblj274/wiki/Mars.html'
+    it('copies a subdomain gateway URL with default settings', async function () {
+      const v = shareValidator({})
       expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest')
     })
-    it('public share with Use Subdomains off uses the path gateway', async function () {
-      const v = optedInValidator({ ...bothGateways, useSubdomains: false })
+    it('copies a native URI when the share toggle is off, even with gateways set', async function () {
+      const v = shareValidator({ usePublicGatewaysForShare: false })
+      expect(await v.resolveToShareableUrl(cidPath)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('falls back to the path gateway when no subdomain gateway is set', async function () {
+      const v = shareValidator({ publicSubdomainGatewayUrl: '' })
       expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://ipfs.io/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
     })
-    it('public share falls back to the only configured gateway (path) with Use Subdomains on', async function () {
-      const v = optedInValidator({ publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: '', useSubdomains: true })
-      expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://ipfs.io/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
-    })
-    it('public share falls back to the only configured gateway (subdomain) with Use Subdomains off', async function () {
-      const v = optedInValidator({ publicGatewayUrl: '', publicSubdomainGatewayUrl: 'https://dweb.link', useSubdomains: false })
+    it('uses the subdomain gateway when only it is set', async function () {
+      const v = shareValidator({ publicGatewayUrl: '' })
       expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest')
+    })
+    it('falls back to the path gateway when the CID exceeds the DNS label limit', async function () {
+      const v = shareValidator({})
+      expect(await v.resolveToShareableUrl(longCidPath)).to.equal('https://ipfs.io/ipfs/bafkrgqfg37dz6kebxts6akxt7c7pjyn4w6yekk3gv7diw7euamcmmfbjskrucx3yjcxsqljdyfmxxjoeqz5j24yhgzkeq4fj4ag25jfblj274/wiki/Mars.html')
+    })
+    it('falls back to a native URI when the CID exceeds the DNS label limit and only the subdomain gateway is set', async function () {
+      const v = shareValidator({ publicGatewayUrl: '' })
+      expect(await v.resolveToShareableUrl(longCidPath)).to.equal('ipfs://bafkrgqfg37dz6kebxts6akxt7c7pjyn4w6yekk3gv7diw7euamcmmfbjskrucx3yjcxsqljdyfmxxjoeqz5j24yhgzkeq4fj4ag25jfblj274/wiki/Mars.html')
     })
     it('public share of a DNSLink page keeps the FQDN with a subdomain gateway', async function () {
-      const v = optedInValidator({ ...bothGateways, useSubdomains: true })
+      const v = shareValidator({})
       const url = 'https://docs.ipfs.tech/concepts/'
       spoofCachedDnslink('docs.ipfs.tech', dnslinkResolver, '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa')
       expect(await v.resolveToShareableUrl(url)).to.equal('https://docs.ipfs.tech/concepts/')
@@ -477,7 +486,10 @@ describe('ipfs-path.js', function () {
   describe('resolveToPublicUrl (no public gateway configured)', function () {
     let nativeValidator
     beforeEach(function () {
-      const nativeState = Object.assign(initState(optionDefaults), { peerCount: 1 })
+      const nativeState = Object.assign(
+        initState({ ...optionDefaults, publicGatewayUrl: '', publicSubdomainGatewayUrl: '' }),
+        { peerCount: 1 }
+      )
       nativeValidator = createIpfsPathValidator(() => nativeState, () => ipfs, dnslinkResolver)
     })
     it('falls back to a native ipfs:// URI for CID-in-subdomain', async function () {
@@ -496,7 +508,7 @@ describe('ipfs-path.js', function () {
     // to a path gateway, so with no subdomain gateway it stays native
     it('keeps a native ipfs:// URI for CID-in-subdomain when only the path gateway is configured', async function () {
       const partialState = Object.assign(
-        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io' }),
+        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: '' }),
         { peerCount: 1 }
       )
       const validator = createIpfsPathValidator(() => partialState, () => ipfs, dnslinkResolver)
@@ -505,7 +517,7 @@ describe('ipfs-path.js', function () {
     })
     it('uses the public subdomain gateway for an /ipfs/ path when only it is configured', async function () {
       const partialState = Object.assign(
-        initState({ ...optionDefaults, publicSubdomainGatewayUrl: 'https://dweb.link' }),
+        initState({ ...optionDefaults, publicGatewayUrl: '', publicSubdomainGatewayUrl: 'https://dweb.link' }),
         { peerCount: 1 }
       )
       const validator = createIpfsPathValidator(() => partialState, () => ipfs, dnslinkResolver)
@@ -516,38 +528,30 @@ describe('ipfs-path.js', function () {
 
   describe('resolveToPermalink (Copy Snapshot Link)', function () {
     const ipnsPointer = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
-    // state (outer beforeEach) has public gateways set but the share toggle off
+    const permalinkValidator = (overrides) => {
+      const state = Object.assign(initState({ ...optionDefaults, ...overrides }), { peerCount: 1 })
+      return createIpfsPathValidator(() => state, () => ipfs, dnslinkResolver)
+    }
     it('copies an immutable native ipfs:// URI when the share toggle is off', async function () {
+      const validator = permalinkValidator({ usePublicGatewaysForShare: false })
       const url = 'https://example.com/ipns/docs.ipfs.io/concepts/glossary/?argTest#hashTest'
       spoofIpfsResolve(ipfs, '/ipns/docs.ipfs.io', ipnsPointer)
       // native permalink normalizes the CIDv0 to a base32 CIDv1
-      expect(await ipfsPathValidator.resolveToPermalink(url)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/concepts/glossary/?argTest#hashTest')
+      expect(await validator.resolveToPermalink(url)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/concepts/glossary/?argTest#hashTest')
     })
-    it('public permalink with Use Subdomains off uses the path gateway', async function () {
-      const optedIn = Object.assign(
-        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link', usePublicGatewaysForShare: true, useSubdomains: false }),
-        { peerCount: 1 }
-      )
-      const validator = createIpfsPathValidator(() => optedIn, () => ipfs, dnslinkResolver)
-      spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
-      expect(await validator.resolveToPermalink('/ipns/libp2p.io/?argTest#hashTest')).to.equal(`https://ipfs.io${ipnsPointer}/?argTest#hashTest`)
-    })
-    it('public permalink with Use Subdomains on uses the subdomain gateway', async function () {
-      const optedIn = Object.assign(
-        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link', usePublicGatewaysForShare: true, useSubdomains: true }),
-        { peerCount: 1 }
-      )
-      const validator = createIpfsPathValidator(() => optedIn, () => ipfs, dnslinkResolver)
+    it('public permalink prefers the subdomain gateway with default settings', async function () {
+      const validator = permalinkValidator({})
       spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
       // immutable CIDv0 normalizes to base32 in the subdomain label
       expect(await validator.resolveToPermalink('/ipns/libp2p.io/?argTest#hashTest')).to.equal('https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.dweb.link/?argTest#hashTest')
     })
+    it('public permalink uses the path gateway when no subdomain gateway is set', async function () {
+      const validator = permalinkValidator({ publicSubdomainGatewayUrl: '' })
+      spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
+      expect(await validator.resolveToPermalink('/ipns/libp2p.io/?argTest#hashTest')).to.equal(`https://ipfs.io${ipnsPointer}/?argTest#hashTest`)
+    })
     it('public permalink does not double-decode percent sequences in the path', async function () {
-      const optedIn = Object.assign(
-        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', usePublicGatewaysForShare: true, useSubdomains: false }),
-        { peerCount: 1 }
-      )
-      const validator = createIpfsPathValidator(() => optedIn, () => ipfs, dnslinkResolver)
+      const validator = permalinkValidator({ publicSubdomainGatewayUrl: '' })
       spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
       // the input decodes once (%2525 -> %25) and must not decode again
       expect(await validator.resolveToPermalink('/ipns/libp2p.io/100%2525.txt')).to.equal(`https://ipfs.io${ipnsPointer}/100%25.txt`)

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -3,7 +3,7 @@ import { stub } from 'sinon'
 import { describe, it, beforeEach, afterEach } from 'vitest'
 import { expect } from 'chai'
 import { URL } from 'url'
-import { ipfsUri, ipfsContentPath, createIpfsPathValidator, sameGateway, safeHostname } from '../../../add-on/src/lib/ipfs-path.js'
+import { ipfsUri, ipfsContentPath, createIpfsPathValidator, sameGateway, safeHostname, toCaseInsensitiveRoot } from '../../../add-on/src/lib/ipfs-path.js'
 import { initState } from '../../../add-on/src/lib/state.js'
 import createDnslinkResolver from '../../../add-on/src/lib/dnslink.js'
 import { optionDefaults } from '../../../add-on/src/lib/options.js'
@@ -21,7 +21,11 @@ describe('ipfs-path.js', function () {
 
   beforeEach(function () {
     global.URL = URL
-    state = Object.assign(initState(optionDefaults), { peerCount: 1 })
+    // public gateways are empty by default; these cases exercise configured-gateway behavior
+    state = Object.assign(
+      initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' }),
+      { peerCount: 1 }
+    )
     ipfs = {
       name: {
         resolve (arg) {
@@ -124,11 +128,11 @@ describe('ipfs-path.js', function () {
   describe('ipfsUri', function () {
     it('should detect /ipfs/ path in URL from a public gateway', function () {
       const url = 'https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
-      expect(ipfsUri(url)).to.equal('ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar')
+      expect(ipfsUri(url)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/foo/bar')
     })
     it('should detect /ipfs/ path in detached IPFS path', function () {
       const path = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
-      expect(ipfsUri(path)).to.equal('ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar')
+      expect(ipfsUri(path)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/foo/bar')
     })
     it('should detect /ipns/ path in URL from a public gateway', function () {
       const url = 'https://ipfs.io/ipns/libp2p.io/bundles/'
@@ -140,19 +144,19 @@ describe('ipfs-path.js', function () {
     })
     it('should keep search and hash from original URL', function () {
       const url = 'https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
-      expect(ipfsUri(url)).to.equal('ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      expect(ipfsUri(url)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?argTest#hashTest')
     })
     it('should preserve search and hash in detached IPFS path', function () {
       const path = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest'
-      expect(ipfsUri(path)).to.equal('ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?argTest#hashTest')
+      expect(ipfsUri(path)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi?argTest#hashTest')
     })
     it('should decode special characters in URL', function () {
       const url = 'https://ipfs.io/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1%20-%20Barrel%20-%20Part%201'
-      expect(ipfsUri(url)).to.equal('ipfs://Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1 - Barrel - Part 1')
+      expect(ipfsUri(url)).to.equal('ipfs://bafybeif6fbogj4sog6hkbvsdktotjbumcmotnwky2z3cmc7imgbr27mc4u/1 - Barrel - Part 1')
     })
     it('should decode special characters in path', function () {
       const path = '/ipfs/Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1%20-%20Barrel%20-%20Part%201'
-      expect(ipfsUri(path)).to.equal('ipfs://Qmb8wsGZNXt5VXZh1pEmYynjB6Euqpq3HYyeAdw2vScTkQ/1 - Barrel - Part 1')
+      expect(ipfsUri(path)).to.equal('ipfs://bafybeif6fbogj4sog6hkbvsdktotjbumcmotnwky2z3cmc7imgbr27mc4u/1 - Barrel - Part 1')
     })
     it('should resolve CID-in-subdomain URL to IPFS path', function () {
       const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
@@ -165,6 +169,41 @@ describe('ipfs-path.js', function () {
     it('should return null if there is no valid path for input path', function () {
       const path = '/invalid/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
       expect(ipfsUri(path)).to.equal(null)
+    })
+    it('should normalize a CIDv0 to a base32 CIDv1 ipfs:// URI', function () {
+      expect(ipfsUri('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR')).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi')
+    })
+    it('should normalize an RSA ipns peer id to a base36 libp2p-key ipns:// URI', function () {
+      expect(ipfsUri('/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GVcPEjHP52ijStQBEs/x')).to.equal('ipns://k2k4r8o6f2xzvywvsl380r29ur6qm6k4f6qhp5tkmsms4h9rvxe45g50/x')
+    })
+    it('should normalize an Ed25519 ipns peer id to a base36 libp2p-key ipns:// URI', function () {
+      expect(ipfsUri('/ipns/12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA')).to.equal('ipns://k51qzi5uqu5dhdmyb9bd18pypu2wp5lpv2xnskfmrqa4lb5knqryrotb05e7or')
+    })
+    it('should leave a DNSLink hostname ipns:// URI unchanged', function () {
+      expect(ipfsUri('/ipns/docs.ipfs.tech/concepts/')).to.equal('ipns://docs.ipfs.tech/concepts/')
+    })
+  })
+
+  describe('toCaseInsensitiveRoot', function () {
+    it('normalizes an ipfs CIDv0 to base32 CIDv1', function () {
+      expect(toCaseInsensitiveRoot('ipfs', 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR')).to.equal('bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi')
+    })
+    it('leaves an already base32 ipfs CIDv1 unchanged', function () {
+      const cid = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+      expect(toCaseInsensitiveRoot('ipfs', cid)).to.equal(cid)
+    })
+    it('normalizes an ipns peer id to a base36 libp2p-key CIDv1', function () {
+      expect(toCaseInsensitiveRoot('ipns', '12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA')).to.equal('k51qzi5uqu5dhdmyb9bd18pypu2wp5lpv2xnskfmrqa4lb5knqryrotb05e7or')
+    })
+    it('leaves an ipns DNSLink hostname unchanged', function () {
+      expect(toCaseInsensitiveRoot('ipns', 'docs.ipfs.tech')).to.equal('docs.ipfs.tech')
+    })
+    it('returns the root unchanged when it cannot be parsed', function () {
+      expect(toCaseInsensitiveRoot('ipfs', 'not-a-cid')).to.equal('not-a-cid')
+      expect(toCaseInsensitiveRoot('ipns', 'not-a-peer-id')).to.equal('not-a-peer-id')
+    })
+    it('throws on an unsupported namespace', function () {
+      expect(() => toCaseInsensitiveRoot('ipld', 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR')).to.throw(/unsupported namespace/)
     })
   })
 
@@ -205,6 +244,10 @@ describe('ipfs-path.js', function () {
       const url = 'https://localhost:8081/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
       const gw = 'http://localhost:8080'
       expect(sameGateway(url, gw)).to.equal(false)
+    })
+    it('should return false when the gateway is not configured', function () {
+      const url = 'https://localhost:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
+      expect(sameGateway(url, undefined)).to.equal(false)
     })
   })
 
@@ -359,6 +402,106 @@ describe('ipfs-path.js', function () {
     it('should resolve to null if input is an invalid URL', async function () {
       const url = 'example.com/foo/bar/?argTest#hashTest'
       expect(await ipfsPathValidator.resolveToPublicUrl(url)).to.equal(null)
+    })
+  })
+
+  describe('resolveToShareableUrl (Copy Shareable Link)', function () {
+    // default config: public gateways empty, so shareable links are native URIs
+    let nativeValidator
+    beforeEach(function () {
+      const nativeState = Object.assign(initState(optionDefaults), { peerCount: 1 })
+      nativeValidator = createIpfsPathValidator(() => nativeState, () => ipfs, dnslinkResolver)
+    })
+    it('copies a native ipfs:// URI for CID-in-subdomain', async function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(await nativeValidator.resolveToShareableUrl(url)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('copies a native ipfs:// URI for an /ipfs/ path', async function () {
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(await nativeValidator.resolveToShareableUrl(path)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('copies a native ipns:// URI for an /ipns/ path', async function () {
+      const path = '/ipns/docs.ipfs.io/?argTest#hashTest'
+      expect(await nativeValidator.resolveToShareableUrl(path)).to.equal('ipns://docs.ipfs.io/?argTest#hashTest')
+    })
+    it('copies a native ipns:// URI for an inlined DNSLink subdomain', async function () {
+      const url = 'https://en-wikipedia--on--ipfs-org.ipns.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(await nativeValidator.resolveToShareableUrl(url)).to.equal('ipns://en.wikipedia-on-ipfs.org/wiki/Mars.html?argTest#hashTest')
+    })
+    // opted into public sharing; overrides set the gateway URLs + Use Subdomains
+    const optedInValidator = (overrides) => {
+      const state = Object.assign(initState({ ...optionDefaults, usePublicGatewaysForShare: true, ...overrides }), { peerCount: 1 })
+      return createIpfsPathValidator(() => state, () => ipfs, dnslinkResolver)
+    }
+    const cidPath = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+    const bothGateways = { publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' }
+    it('public share with Use Subdomains on uses the subdomain gateway', async function () {
+      const v = optedInValidator({ ...bothGateways, useSubdomains: true })
+      expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest')
+    })
+    it('public share with Use Subdomains off uses the path gateway', async function () {
+      const v = optedInValidator({ ...bothGateways, useSubdomains: false })
+      expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://ipfs.io/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('public share falls back to the only configured gateway (path) with Use Subdomains on', async function () {
+      const v = optedInValidator({ publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: '', useSubdomains: true })
+      expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://ipfs.io/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('public share falls back to the only configured gateway (subdomain) with Use Subdomains off', async function () {
+      const v = optedInValidator({ publicGatewayUrl: '', publicSubdomainGatewayUrl: 'https://dweb.link', useSubdomains: false })
+      expect(await v.resolveToShareableUrl(cidPath)).to.equal('https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest')
+    })
+    it('public share of a DNSLink page keeps the FQDN with a subdomain gateway', async function () {
+      const v = optedInValidator({ ...bothGateways, useSubdomains: true })
+      const url = 'https://docs.ipfs.tech/concepts/'
+      spoofCachedDnslink('docs.ipfs.tech', dnslinkResolver, '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa')
+      expect(await v.resolveToShareableUrl(url)).to.equal('https://docs.ipfs.tech/concepts/')
+    })
+  })
+
+  describe('resolveToPublicUrl (no public gateway configured)', function () {
+    let nativeValidator
+    beforeEach(function () {
+      const nativeState = Object.assign(initState(optionDefaults), { peerCount: 1 })
+      nativeValidator = createIpfsPathValidator(() => nativeState, () => ipfs, dnslinkResolver)
+    })
+    it('falls back to a native ipfs:// URI for CID-in-subdomain', async function () {
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(await nativeValidator.resolveToPublicUrl(url)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('falls back to a native ipfs:// URI for an /ipfs/ path', async function () {
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(await nativeValidator.resolveToPublicUrl(path)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+  })
+
+  describe('resolveToPermalink (Copy Snapshot Link)', function () {
+    const ipnsPointer = '/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+    // state (outer beforeEach) has public gateways set but the share toggle off
+    it('copies an immutable native ipfs:// URI when the share toggle is off', async function () {
+      const url = 'https://example.com/ipns/docs.ipfs.io/concepts/glossary/?argTest#hashTest'
+      spoofIpfsResolve(ipfs, '/ipns/docs.ipfs.io', ipnsPointer)
+      // native permalink normalizes the CIDv0 to a base32 CIDv1
+      expect(await ipfsPathValidator.resolveToPermalink(url)).to.equal('ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi/concepts/glossary/?argTest#hashTest')
+    })
+    it('public permalink with Use Subdomains off uses the path gateway', async function () {
+      const optedIn = Object.assign(
+        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link', usePublicGatewaysForShare: true, useSubdomains: false }),
+        { peerCount: 1 }
+      )
+      const validator = createIpfsPathValidator(() => optedIn, () => ipfs, dnslinkResolver)
+      spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
+      expect(await validator.resolveToPermalink('/ipns/libp2p.io/?argTest#hashTest')).to.equal(`https://ipfs.io${ipnsPointer}/?argTest#hashTest`)
+    })
+    it('public permalink with Use Subdomains on uses the subdomain gateway', async function () {
+      const optedIn = Object.assign(
+        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link', usePublicGatewaysForShare: true, useSubdomains: true }),
+        { peerCount: 1 }
+      )
+      const validator = createIpfsPathValidator(() => optedIn, () => ipfs, dnslinkResolver)
+      spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
+      // immutable CIDv0 normalizes to base32 in the subdomain label
+      expect(await validator.resolveToPermalink('/ipns/libp2p.io/?argTest#hashTest')).to.equal('https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.dweb.link/?argTest#hashTest')
     })
   })
 

--- a/test/functional/lib/ipfs-path.test.js
+++ b/test/functional/lib/ipfs-path.test.js
@@ -249,6 +249,16 @@ describe('ipfs-path.js', function () {
       const url = 'https://localhost:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
       expect(sameGateway(url, undefined)).to.equal(false)
     })
+    it('should return true on subdomain of the gateway host', function () {
+      const url = 'https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.dweb.link/foo/bar'
+      const gw = 'https://dweb.link'
+      expect(sameGateway(url, gw)).to.equal(true)
+    })
+    it('should return false on unrelated host sharing a suffix with the gateway host', function () {
+      const url = 'https://nondefaultipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR/foo/bar'
+      const gw = 'https://ipfs.io'
+      expect(sameGateway(url, gw)).to.equal(false)
+    })
   })
 
   describe('validIpfsOrIpns', function () {
@@ -395,6 +405,11 @@ describe('ipfs-path.js', function () {
       const url = 'https://example.com/foo/bar/?argTest#hashTest'
       expect(await ipfsPathValidator.resolveToPublicUrl(url)).to.equal(url)
     })
+    it('should swap ipns:// scheme for https:// on a DNSLink website', async function () {
+      spoofCachedDnslink('en.wikipedia-on-ipfs.org', dnslinkResolver, '/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco')
+      const uri = 'ipns://en.wikipedia-on-ipfs.org/wiki/Mars'
+      expect(await ipfsPathValidator.resolveToPublicUrl(uri)).to.equal('https://en.wikipedia-on-ipfs.org/wiki/Mars')
+    })
     it('should resolve to null if input is an invalid path', async function () {
       const path = '/foo/bar/?argTest#hashTest'
       expect(await ipfsPathValidator.resolveToPublicUrl(path)).to.equal(null)
@@ -473,6 +488,30 @@ describe('ipfs-path.js', function () {
       const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
       expect(await nativeValidator.resolveToPublicUrl(path)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
     })
+    it('keeps a native ipns:// URI when no public gateway is configured', async function () {
+      const uri = 'ipns://en.wikipedia-on-ipfs.org/wiki/Mars'
+      expect(await nativeValidator.resolveToPublicUrl(uri)).to.equal(uri)
+    })
+    // a subdomain request asks for origin isolation and is never downgraded
+    // to a path gateway, so with no subdomain gateway it stays native
+    it('keeps a native ipfs:// URI for CID-in-subdomain when only the path gateway is configured', async function () {
+      const partialState = Object.assign(
+        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io' }),
+        { peerCount: 1 }
+      )
+      const validator = createIpfsPathValidator(() => partialState, () => ipfs, dnslinkResolver)
+      const url = 'https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest'
+      expect(await validator.resolveToPublicUrl(url)).to.equal('ipfs://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest')
+    })
+    it('uses the public subdomain gateway for an /ipfs/ path when only it is configured', async function () {
+      const partialState = Object.assign(
+        initState({ ...optionDefaults, publicSubdomainGatewayUrl: 'https://dweb.link' }),
+        { peerCount: 1 }
+      )
+      const validator = createIpfsPathValidator(() => partialState, () => ipfs, dnslinkResolver)
+      const path = '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa/wiki/Mars.html?argTest#hashTest'
+      expect(await validator.resolveToPublicUrl(path)).to.equal('https://bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa.ipfs.dweb.link/wiki/Mars.html?argTest#hashTest')
+    })
   })
 
   describe('resolveToPermalink (Copy Snapshot Link)', function () {
@@ -502,6 +541,16 @@ describe('ipfs-path.js', function () {
       spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
       // immutable CIDv0 normalizes to base32 in the subdomain label
       expect(await validator.resolveToPermalink('/ipns/libp2p.io/?argTest#hashTest')).to.equal('https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.dweb.link/?argTest#hashTest')
+    })
+    it('public permalink does not double-decode percent sequences in the path', async function () {
+      const optedIn = Object.assign(
+        initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', usePublicGatewaysForShare: true, useSubdomains: false }),
+        { peerCount: 1 }
+      )
+      const validator = createIpfsPathValidator(() => optedIn, () => ipfs, dnslinkResolver)
+      spoofIpfsResolve(ipfs, '/ipns/libp2p.io', ipnsPointer)
+      // the input decodes once (%2525 -> %25) and must not decode again
+      expect(await validator.resolveToPermalink('/ipns/libp2p.io/100%2525.txt')).to.equal(`https://ipfs.io${ipnsPointer}/100%25.txt`)
     })
   })
 

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -38,8 +38,8 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
   })
 
   beforeEach(async function () {
-    // public gateways are empty by default; recovery cases need them configured
-    state = initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' })
+    // defaults prefill both public gateways (ipfs.io and dweb.link)
+    state = initState(optionDefaults)
     const getState = () => state
     const getIpfs = () => {}
     browser.runtime.getURL.returns('chrome-extension://testid/')
@@ -150,8 +150,8 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
   })
 
   beforeEach(async function () {
-    // public gateways are empty by default; recovery cases need them configured
-    state = initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' })
+    // defaults prefill both public gateways (ipfs.io and dweb.link)
+    state = initState(optionDefaults)
     const getState = () => state
     const getIpfs = () => {}
     browser.runtime.getURL.returns('chrome-extension://testid/')
@@ -205,7 +205,7 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should be called with IPFS default public gateway URL')
     })
     it('should recover on the local gateway when no public gateway is configured and node is online', async function () {
-      // default config has empty public gateways, so recovery uses the local gateway
+      // clear the prefilled public gateways so recovery must use the local gateway
       Object.assign(state, { pubGwURL: undefined, pubGwURLString: undefined, pubSubdomainGwURL: undefined, pubSubdomainGwURLString: undefined, peerCount: 1 })
       const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -35,7 +35,8 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
   })
 
   beforeEach(async function () {
-    state = initState(optionDefaults)
+    // public gateways are empty by default; recovery cases need them configured
+    state = initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' })
     const getState = () => state
     const getIpfs = () => {}
     dnslinkResolver = createDnslinkResolver(getState)
@@ -134,7 +135,8 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
   })
 
   beforeEach(async function () {
-    state = initState(optionDefaults)
+    // public gateways are empty by default; recovery cases need them configured
+    state = initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' })
     const getState = () => state
     const getIpfs = () => {}
     dnslinkResolver = createDnslinkResolver(getState)
@@ -183,6 +185,13 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
       assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should be called with IPFS default public gateway URL')
+    })
+    it('should recover on the local gateway when no public gateway is configured', async function () {
+      // default config has empty public gateways, so recovery uses the local gateway
+      Object.assign(state, { pubGwURL: undefined, pubGwURLString: undefined, pubSubdomainGwURL: undefined, pubSubdomainGwURLString: undefined })
+      const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'http://localhost:8080/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should recover on the local gateway')
     })
     it('should recover from unreachable HTTP server by reopening DNSLink on the active gateway', async function () {
       state.dnslinkPolicy = 'best-effort'

--- a/test/functional/lib/ipfs-request-gateway-recover.test.js
+++ b/test/functional/lib/ipfs-request-gateway-recover.test.js
@@ -24,6 +24,9 @@ const urlRequestWithNetworkError = (url, error = 'net::ERR_CONNECTION_TIMED_OUT'
   return { ...url2request(url, type), error }
 }
 
+const recoveryPageUrl = (nativeUri) =>
+  `chrome-extension://testid/dist/recovery/recovery.html#${encodeURIComponent(nativeUri)}`
+
 describe('requestHandler.onCompleted:', function () { // HTTP-level errors
   let state, dnslinkResolver, ipfsPathValidator, requestHandler, runtime
 
@@ -39,6 +42,7 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
     state = initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' })
     const getState = () => state
     const getIpfs = () => {}
+    browser.runtime.getURL.returns('chrome-extension://testid/')
     dnslinkResolver = createDnslinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
     ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
@@ -50,7 +54,17 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
       state.recoverFailedHttpRequests = true
       state.dnslinkPolicy = false
     })
-    it('should do nothing if broken request is for the default subdomain gateway', async function () {
+    it('should show recovery page when broken request is for the configured subdomain gateway and node is offline', async function () {
+      // failures at the configured public gateway cannot recover to it; with
+      // the node offline the user gets the recovery page with the native URI
+      const request = urlRequestWithStatus('https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/', 500)
+      await requestHandler.onCompleted(request)
+      const expectedUrl = recoveryPageUrl('ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/')
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: expectedUrl, active: true }).calledOnce, 'tabs.update should open the recovery page')
+    })
+    it('should do nothing if broken subdomain request has Base58 CIDv0 label', async function () {
+      // base58 is case-sensitive, so a CIDv0 lost in DNS lowercasing is not a
+      // recognizable IPFS resource
       const request = urlRequestWithStatus('https://QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h.ipfs.dweb.link/wiki/', 500)
       await requestHandler.onCompleted(request)
       assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
@@ -80,10 +94,11 @@ describe('requestHandler.onCompleted:', function () { // HTTP-level errors
       await requestHandler.onCompleted(request)
       assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
-    it('should do nothing if broken request is to the default public gateway', async function () {
+    it('should show recovery page when broken request is to the configured path gateway and node is offline', async function () {
       const request = urlRequestWithStatus('https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500)
       await requestHandler.onCompleted(request)
-      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
+      const expectedUrl = recoveryPageUrl('ipfs://bafybeieym3tecwcvjhnsbc3rfmxck4yimrggclrwd5fav5q44o7xo7n3ky')
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: expectedUrl, active: true }).calledOnce, 'tabs.update should open the recovery page')
     })
     it('should do nothing if broken request is not a \'main_frame\' request', async function () {
       const request = urlRequestWithStatus('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', 500, 'stylesheet')
@@ -139,6 +154,7 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
     state = initState({ ...optionDefaults, publicGatewayUrl: 'https://ipfs.io', publicSubdomainGatewayUrl: 'https://dweb.link' })
     const getState = () => state
     const getIpfs = () => {}
+    browser.runtime.getURL.returns('chrome-extension://testid/')
     dnslinkResolver = createDnslinkResolver(getState)
     runtime = Object.assign({}, await createRuntimeChecks(browser)) // make it mutable for tests
     ipfsPathValidator = createIpfsPathValidator(getState, getIpfs, dnslinkResolver)
@@ -150,10 +166,11 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       state.recoverFailedHttpRequests = true
       state.dnslinkPolicy = false
     })
-    it('should do nothing if failed request is for the default subdomain gateway', async function () {
-      const request = urlRequestWithStatus('https://QmYzZgeWE7r8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h.ipfs.dweb.link/wiki/', 500)
+    it('should show recovery page when failed request is for the configured subdomain gateway and node is offline', async function () {
+      const request = urlRequestWithStatus('https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/', 500)
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
+      const expectedUrl = recoveryPageUrl('ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/')
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: expectedUrl, active: true }).calledOnce, 'tabs.update should open the recovery page')
     })
     it('should redirect to default subdomain gateway on failed subdomain gateway request', async function () {
       const request = urlRequestWithStatus('http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.brokenexample.com/wiki/', 500)
@@ -170,10 +187,11 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       await requestHandler.onErrorOccurred(request)
       assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
     })
-    it('should do nothing if failed request is to the default public gateway', async function () {
+    it('should show recovery page when failed request is to the configured path gateway and node is offline', async function () {
       const request = urlRequestWithNetworkError('https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
-      assert.ok(browser.tabs.update.notCalled, 'tabs.update should not be called')
+      const expectedUrl = recoveryPageUrl('ipfs://bafybeieym3tecwcvjhnsbc3rfmxck4yimrggclrwd5fav5q44o7xo7n3ky')
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: expectedUrl, active: true }).calledOnce, 'tabs.update should open the recovery page')
     })
     it('should do nothing if failed request is not a \'main_frame\' request', async function () {
       const requestType = 'stylesheet'
@@ -186,12 +204,35 @@ describe('requestHandler.onErrorOccurred:', function () { // network errors
       await requestHandler.onErrorOccurred(request)
       assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'https://ipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should be called with IPFS default public gateway URL')
     })
-    it('should recover on the local gateway when no public gateway is configured', async function () {
+    it('should recover on the local gateway when no public gateway is configured and node is online', async function () {
       // default config has empty public gateways, so recovery uses the local gateway
-      Object.assign(state, { pubGwURL: undefined, pubGwURLString: undefined, pubSubdomainGwURL: undefined, pubSubdomainGwURLString: undefined })
+      Object.assign(state, { pubGwURL: undefined, pubGwURLString: undefined, pubSubdomainGwURL: undefined, pubSubdomainGwURLString: undefined, peerCount: 1 })
       const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
       await requestHandler.onErrorOccurred(request)
       assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'http://localhost:8080/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h', active: true }).calledOnce, 'tabs.update should recover on the local gateway')
+    })
+    it('should show recovery page when no public gateway is configured and node is offline', async function () {
+      Object.assign(state, { pubGwURL: undefined, pubGwURLString: undefined, pubSubdomainGwURL: undefined, pubSubdomainGwURLString: undefined })
+      const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
+      await requestHandler.onErrorOccurred(request)
+      const expectedUrl = recoveryPageUrl('ipfs://bafybeieym3tecwcvjhnsbc3rfmxck4yimrggclrwd5fav5q44o7xo7n3ky')
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: expectedUrl, active: true }).calledOnce, 'tabs.update should open the recovery page')
+    })
+    it('should recover subdomain gateway request on the local gateway when no public subdomain gateway is configured and node is online', async function () {
+      // a subdomain request is never downgraded to a public path gateway (it
+      // lacks origin isolation); the local gateway preserves isolation via
+      // its own redirect to *.ipfs.localhost
+      Object.assign(state, { pubSubdomainGwURL: undefined, pubSubdomainGwURLString: undefined, peerCount: 1 })
+      const request = urlRequestWithNetworkError('http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.brokenexample.com/wiki/')
+      await requestHandler.onErrorOccurred(request)
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'http://localhost:8080/ipfs/bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/', active: true }).calledOnce, 'tabs.update should recover on the local gateway')
+    })
+    it('should recover path gateway request via the public subdomain gateway when only it is configured', async function () {
+      Object.assign(state, { pubGwURL: undefined, pubGwURLString: undefined })
+      const request = urlRequestWithNetworkError('https://nondefaultipfs.io/ipfs/QmYbZgeWE7y8HXkH8zbb8J9ddHQvp8LTqm6isL791eo14h')
+      await requestHandler.onErrorOccurred(request)
+      // CIDv0 is normalized to a base32 CIDv1 subdomain label
+      assert.ok(browser.tabs.update.withArgs(request.tabId, { url: 'https://bafybeieym3tecwcvjhnsbc3rfmxck4yimrggclrwd5fav5q44o7xo7n3ky.ipfs.dweb.link/', active: true }).calledOnce, 'tabs.update should recover on the public subdomain gateway')
     })
     it('should recover from unreachable HTTP server by reopening DNSLink on the active gateway', async function () {
       state.dnslinkPolicy = 'best-effort'

--- a/test/functional/lib/options.test.js
+++ b/test/functional/lib/options.test.js
@@ -3,8 +3,32 @@ import { describe, it, beforeEach, afterAll as after } from 'vitest'
 import { expect } from 'chai'
 import sinon from 'sinon'
 import browser from 'sinon-chrome'
-import { storeMissingOptions, optionDefaults, isHostname, hostTextToArray, hostArrayToText } from '../../../add-on/src/lib/options.js'
+import { storeMissingOptions, optionDefaults, guiURLString, isHostname, hostTextToArray, hostArrayToText } from '../../../add-on/src/lib/options.js'
 import { URL } from 'url'
+
+describe('optionDefaults', function () {
+  // Fresh installs share links via the public subdomain gateway; flipping the
+  // default to native URIs means changing the DEFAULT_* constants in
+  // options.js and this test together.
+  it('should prefill public gateways and share via them by default', () => {
+    expect(optionDefaults.publicGatewayUrl).to.equal('https://ipfs.io')
+    expect(optionDefaults.publicSubdomainGatewayUrl).to.equal('https://dweb.link')
+    expect(optionDefaults.usePublicGatewaysForShare).to.equal(true)
+  })
+})
+
+describe('guiURLString()', function () {
+  beforeEach(() => {
+    global.URL = URL
+  })
+  it('should normalize URL and drop trailing slash', () => {
+    expect(guiURLString('https://ipfs.io/')).to.equal('https://ipfs.io')
+  })
+  // clearing a public gateway URL in Preferences stores '' to opt out of it
+  it('should keep empty input empty', () => {
+    expect(guiURLString('')).to.equal('')
+  })
+})
 
 describe('storeMissingOptions()', function () {
   beforeEach(() => {


### PR DESCRIPTION
## Problem

"Copy Shareable Link" always produced a URL on a third-party gateway, and parts of the extension assumed a public gateway is always set. There was no way to copy a native ipfs:// or ipns:// address, or to stop routing people through ipfs.io and dweb.link.

## Fix

- defaults are unchanged: ipfs.io and dweb.link stay prefilled and share links are still built on dweb.link, matching ipfs/ipfs-webui#2482; a future flip to native-by-default only touches the `DEFAULT_*` constants in `lib/options.js` plus a migration
- clearing the gateway URLs (or the new "Use Public Gateways for Shareable Links" toggle) switches copied links to native ipfs:// and ipns:// addresses
- share links prefer the subdomain gateway, then the path gateway (e.g. when a CID is too long for a DNS label), then native, so they are never empty or broken
- with no public gateway, failed requests recover to the local gateway, or to a recovery page showing the native address and how to install a node
- the IPFS Node section explains Kubo RPC and hides the one-option node type select, plus a copy pass over the whole Preferences screen

## Preferences → Gateways

> <img width="2102" height="2070" alt="ipfs-companion-options-gateways" src="https://github.com/user-attachments/assets/08e4efd5-09ab-4fd7-9a92-6310e7847a0c" />



## Preferences → IPFS Node

> <img width="2102" height="482" alt="ipfs-companion-options-node" src="https://github.com/user-attachments/assets/9f17d3de-5506-4afe-aff3-e14bfd384ba9" />


## Recovery page

With no public gateway set and the node offline, the page shows the content's native address and offers to install a local node:

> <img width="2664" height="2002" alt="ipfs-companion-recovery-native" src="https://github.com/user-attachments/assets/af5d0a12-039d-4023-b3bd-5a712f41d3bb" />

With a public gateway configured, it is unchanged and still offers to continue to that gateway:

> <img width="2904" height="2002" alt="ipfs-companion-recovery-gateway" src="https://github.com/user-attachments/assets/0e389e2f-5da2-464c-9058-7ce74340028b" />

## Related

- ipfs/kubo#11375
- ipfs/ipfs-webui#2482