### PR TITLE
feat: explain broken ipfs:// addresses

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lidel @ipfs/gui-dev
+* @ipfs/gui-dev

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -890,5 +890,25 @@
   "invalid_address_page_learn_mutability": {
     "message": "Why changing content needs a mutable pointer",
     "description": "Link to the IPNS mutability docs, shown when an IPNS name was used with ipfs:// (invalid_address_page_learn_mutability)"
+  },
+  "invalid_address_page_unrecognized_header": {
+    "message": "This identifier does not look valid",
+    "description": "Header shown when the identifier matches no known form (invalid_address_page_unrecognized_header)"
+  },
+  "invalid_address_page_unrecognized_message": {
+    "message": "What follows ipfs:// or ipns:// names the thing to fetch: a CID for content that never changes, or a website name or IPNS key for a pointer that can be updated. This one does not match any of those, so it could not be looked up.",
+    "description": "Explanation shown when the identifier matches no known form (invalid_address_page_unrecognized_message)"
+  },
+  "invalid_address_page_unrecognized_advice": {
+    "message": "Check it for a typo first. Identifiers are long and easy to cut short when copied, so make sure you have the whole thing, and compare it against the original if you still have it.",
+    "description": "What to do about an unrecognized identifier (invalid_address_page_unrecognized_advice)"
+  },
+  "invalid_address_page_learn_cid": {
+    "message": "What a content identifier (CID) looks like",
+    "description": "Link to the CID spec (invalid_address_page_learn_cid)"
+  },
+  "invalid_address_page_learn_ipns_record": {
+    "message": "What an IPNS name looks like",
+    "description": "Link to the IPNS record spec (invalid_address_page_learn_ipns_record)"
   }
 }

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -826,5 +826,69 @@
   "request_permissions_page_learn_more": {
     "message": "Learn more about host permissions",
     "description": "Learn more link on the recovery screen (recovery_page_learn_more)"
+  },
+  "invalid_address_page_title": {
+    "message": "Address cannot be opened | IPFS Companion",
+    "description": "Title of the invalid address page (invalid_address_page_title)"
+  },
+  "invalid_address_page_sub_header": {
+    "message": "This address cannot be opened as written",
+    "description": "Sub-header on the invalid address page (invalid_address_page_sub_header)"
+  },
+  "invalid_address_page_opened_label": {
+    "message": "You opened",
+    "description": "Label above the address the user requested (invalid_address_page_opened_label)"
+  },
+  "invalid_address_page_correct_label": {
+    "message": "Correct address",
+    "description": "Label above the corrected address (invalid_address_page_correct_label)"
+  },
+  "invalid_address_page_button": {
+    "message": "Continue to $1",
+    "description": "Button that opens the corrected address, $1 is the corrected address (invalid_address_page_button)"
+  },
+  "invalid_address_page_learn_more": {
+    "message": "Learn more about IPFS addresses",
+    "description": "Learn more link on the invalid address page (invalid_address_page_learn_more)"
+  },
+  "invalid_address_page_wrong_namespace_header": {
+    "message": "This address needs ipns://",
+    "description": "Header shown when ipfs:// was used for a mutable pointer (invalid_address_page_wrong_namespace_header)"
+  },
+  "invalid_address_page_dnslink_message": {
+    "message": "You opened a website name with ipfs://. A website name resolves through DNSLink, and the owner of the domain can point it at different content whenever they like, so what it means today is not what it will mean tomorrow. That makes it a mutable pointer.",
+    "description": "Explanation for a DNSLink domain used with ipfs:// (invalid_address_page_dnslink_message)"
+  },
+  "invalid_address_page_ipns_key_message": {
+    "message": "You opened an IPNS name with ipfs://. Whoever holds the key behind an IPNS name can republish it to point at different content at any time, so what it means today is not what it will mean tomorrow. That makes it a mutable pointer.",
+    "description": "Explanation for an IPNS key used with ipfs:// (invalid_address_page_ipns_key_message)"
+  },
+  "invalid_address_page_namespace_advice": {
+    "message": "The ipfs:// namespace is only for immutable identifiers. A CID is derived from the content itself, so the data behind it is frozen like an insect in amber: it can never change, and anyone can check they received exactly the bytes that CID names. Anything whose owner can repoint it later is a mutable pointer, and mutable pointers live under ipns://.",
+    "description": "Shared advice about what ipfs:// is for (invalid_address_page_namespace_advice)"
+  },
+  "invalid_address_page_lowercased_header": {
+    "message": "Your browser changed this address",
+    "description": "Header shown when the browser lowercased a CIDv0 (invalid_address_page_lowercased_header)"
+  },
+  "invalid_address_page_lowercased_message": {
+    "message": "This address holds a CIDv0, the older kind of content identifier that starts with Qm and mixes upper and lower case letters. Your browser reads the part right after ipfs:// as a website name, and website names are always lowercased, so the identifier arrived here damaged. The original cannot be worked out from what is left.",
+    "description": "Explanation of a lowercased CIDv0 (invalid_address_page_lowercased_message)"
+  },
+  "invalid_address_page_lowercased_advice": {
+    "message": "Ask whoever shared this link for a CIDv1 in Base32: those are all lower case, so a browser cannot damage them. If you still have the original identifier with its capital letters intact, paste it into the CID inspector linked below and use the CIDv1 (Base32) address it produces.",
+    "description": "What to do about a lowercased CIDv0 (invalid_address_page_lowercased_advice)"
+  },
+  "invalid_address_page_convert_cid": {
+    "message": "Convert your identifier to CIDv1 (Base32) at cid.ipfs.tech",
+    "description": "Link to the CID inspector, shown when a CIDv0 was damaged by lowercasing (invalid_address_page_convert_cid)"
+  },
+  "invalid_address_page_learn_dnslink": {
+    "message": "How DNSLink connects a domain name to IPFS",
+    "description": "Link to the DNSLink concept docs, shown when a website name was used with ipfs:// (invalid_address_page_learn_dnslink)"
+  },
+  "invalid_address_page_learn_mutability": {
+    "message": "Why changing content needs a mutable pointer",
+    "description": "Link to the IPNS mutability docs, shown when an IPNS name was used with ipfs:// (invalid_address_page_learn_mutability)"
   }
 }

--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -856,27 +856,27 @@
     "description": "Header shown when ipfs:// was used for a mutable pointer (invalid_address_page_wrong_namespace_header)"
   },
   "invalid_address_page_dnslink_message": {
-    "message": "You opened a website name with ipfs://. A website name resolves through DNSLink, and the owner of the domain can point it at different content whenever they like, so what it means today is not what it will mean tomorrow. That makes it a mutable pointer.",
+    "message": "You opened a website name with ipfs://. Website names resolve through DNSLink, so the owner can publish new content while the address stays the same.",
     "description": "Explanation for a DNSLink domain used with ipfs:// (invalid_address_page_dnslink_message)"
   },
   "invalid_address_page_ipns_key_message": {
-    "message": "You opened an IPNS name with ipfs://. Whoever holds the key behind an IPNS name can republish it to point at different content at any time, so what it means today is not what it will mean tomorrow. That makes it a mutable pointer.",
+    "message": "You opened an IPNS name with ipfs://. Whoever holds the key behind it can republish new content while the address stays the same.",
     "description": "Explanation for an IPNS key used with ipfs:// (invalid_address_page_ipns_key_message)"
   },
   "invalid_address_page_namespace_advice": {
-    "message": "The ipfs:// namespace is only for immutable identifiers. A CID is derived from the content itself, so the data behind it is frozen like an insect in amber: it can never change, and anyone can check they received exactly the bytes that CID names. Anything whose owner can repoint it later is a mutable pointer, and mutable pointers live under ipns://.",
+    "message": "The ipfs:// namespace is only for immutable identifiers. A CID comes from the content itself, so the data behind it is frozen like an insect in amber: it never changes, and anyone can verify they got exactly those bytes. An address someone can repoint is mutable, and mutable addresses belong under ipns://.",
     "description": "Shared advice about what ipfs:// is for (invalid_address_page_namespace_advice)"
   },
   "invalid_address_page_lowercased_header": {
-    "message": "Your browser changed this address",
+    "message": "This address looks lowercased",
     "description": "Header shown when the browser lowercased a CIDv0 (invalid_address_page_lowercased_header)"
   },
   "invalid_address_page_lowercased_message": {
-    "message": "This address holds a CIDv0, the older kind of content identifier that starts with Qm and mixes upper and lower case letters. Your browser reads the part right after ipfs:// as a website name, and website names are always lowercased, so the identifier arrived here damaged. The original cannot be worked out from what is left.",
+    "message": "This address holds what looks like a CIDv0, the older kind of content identifier: it starts with Qm and mixes upper and lower case. This one arrived entirely lower case. That happens when something along the way treats the part after ipfs:// as a website name, because website names are case-insensitive. Nothing can recover the original from what is left.",
     "description": "Explanation of a lowercased CIDv0 (invalid_address_page_lowercased_message)"
   },
   "invalid_address_page_lowercased_advice": {
-    "message": "Ask whoever shared this link for a CIDv1 in Base32: those are all lower case, so a browser cannot damage them. If you still have the original identifier with its capital letters intact, paste it into the CID inspector linked below and use the CIDv1 (Base32) address it produces.",
+    "message": "Ask whoever shared this link for a CIDv1 in Base32: those are lower case already, so lowercasing cannot damage them. If you still have the original identifier, paste it into the CID inspector below and use the CIDv1 (Base32) it produces.",
     "description": "What to do about a lowercased CIDv0 (invalid_address_page_lowercased_advice)"
   },
   "invalid_address_page_convert_cid": {

--- a/add-on/manifest.common.json
+++ b/add-on/manifest.common.json
@@ -38,7 +38,8 @@
         "icons/ipfs-logo-off.svg",
         "dist/recovery/recovery.css",
         "dist/recovery/recovery.html",
-        "dist/recovery/recovery.js"
+        "dist/recovery/recovery.js",
+        "dist/landing-pages/invalid-address/index.html"
       ],
       "matches": [
         "<all_urls>"

--- a/add-on/src/landing-pages/invalid-address/index.html
+++ b/add-on/src/landing-pages/invalid-address/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Address cannot be opened</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlo89/56ZQ/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUjDu1lo89/6mhTP+zrVP/nplD/5+aRK8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHNiIS6Wjz3/ubFY/761W/+vp1D/urRZ/8vDZf/GvmH/nplD/1BNIm8AAAAAAAAAAAAAAAAAAAAAAAAAAJaPPf+knEj/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf+tpk7/nplD/wAAAAAAAAAAAAAAAJaPPf+2rVX/vrVb/761W/++tVv/vrVb/6+nUP+6tFn/y8Nl/8vDZf/Lw2X/y8Nl/8G6Xv+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/761W/+vp1D/urRZ/8vDZf/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf++tVv/vrVb/761W/++tVv/vbRa/5aPPf+emUP/y8Nl/8vDZf/Lw2X/y8Nl/8vDZf+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/5qTQP+inkb/op5G/6KdRv/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/sqlS/56ZQ//LxWb/0Mlp/9DJaf/Kw2X/oJtE/7+3XP/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf+9tFr/mJE+/7GsUv/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+xrFL/nplD/8vDZf+emUP/AAAAAAAAAACWjz3/op5G/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+inkb/nplD/wAAAAAAAAAAAAAAAKKeRv+3slb/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+1sFX/op5G/wAAAAAAAAAAAAAAAAAAAAAAAAAAop5GUKKeRv/Nxmf/0cpq/9HKav/Rymr/0cpq/83GZ/+inkb/op5GSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G16KeRv/LxWb/y8Vm/6KeRv+inkaPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G/6KeRtcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/n8AAPgfAADwDwAAwAMAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAwAMAAPAPAAD4HwAA/n8AAA==" />
+    <link rel="stylesheet" href="/dist/bundles/uiCommons.css">
+    <link rel="stylesheet" href="/dist/bundles/invalidAddressPage.css">
+  </head>
+  <body class="navy bg-white sans-serif">
+    <app class="flex flex-column transition-all vh-100">
+      <main class="bg-white flex-grow-1">
+          <div id="root"></div>
+      </main>
+      <script src="/dist/bundles/uiCommons.bundle.js"></script>
+      <script src="/dist/bundles/invalidAddressPage.bundle.js"></script>
+    </app>
+  </body>
+</html>

--- a/add-on/src/landing-pages/invalid-address/index.js
+++ b/add-on/src/landing-pages/invalid-address/index.js
@@ -76,14 +76,14 @@ app.route('*', () => {
   const { header, message, advice, links } = explanations[reason]
 
   return html`<div class="flex flex-column flex-row-l">
-    <div id="left-col" class="min-vh-100 flex flex-column justify-center items-center bg-navy white">
-      <div class="mb4 flex flex-column justify-center items-center">
+    <div id="left-col" class="flex flex-column justify-center items-center bg-navy white">
+      <div class="flex flex-column justify-center items-center">
         ${nodeOffSvg(200)}
-        <p class="mt0 mb0 f3 tc">${i18n.getMessage('invalid_address_page_sub_header')}</p>
+        <p class="mt3 mb0 f3 tc">${i18n.getMessage('invalid_address_page_sub_header')}</p>
       </div>
     </div>
 
-    <div id="right-col" class="pt5 mt5 w-100 flex flex-column justify-around items-start">
+    <div id="right-col" class="w-100 flex flex-column justify-around items-start">
       <h1 class="f3 fw5 mt0">${i18n.getMessage(header)}</h1>
       <p class="f5 fw4 lh-copy">${i18n.getMessage(message)}</p>
 

--- a/add-on/src/landing-pages/invalid-address/index.js
+++ b/add-on/src/landing-pages/invalid-address/index.js
@@ -7,6 +7,7 @@ import {
   DNSLINK_UNDER_IPFS,
   IPNS_KEY_UNDER_IPFS,
   LOWERCASED_CIDV0,
+  UNRECOGNIZED_IDENTIFIER,
   decodeDiagnosis
 } from '../../lib/invalid-address.js'
 import { nodeOffSvg } from '../welcome/page.js'
@@ -52,6 +53,17 @@ const explanations = {
       // original into a CIDv1 (Base32) the browser cannot damage
       { href: 'https://cid.ipfs.tech/', label: 'invalid_address_page_convert_cid' },
       addressingDocs
+    ]
+  },
+  [UNRECOGNIZED_IDENTIFIER]: {
+    header: 'invalid_address_page_unrecognized_header',
+    message: 'invalid_address_page_unrecognized_message',
+    advice: 'invalid_address_page_unrecognized_advice',
+    // we cannot say which form was meant, so show what each valid one looks like
+    links: [
+      { href: 'https://specs.ipfs.tech/cid/', label: 'invalid_address_page_learn_cid' },
+      { href: 'https://specs.ipfs.tech/ipns/ipns-record/', label: 'invalid_address_page_learn_ipns_record' },
+      { href: 'https://docs.ipfs.tech/concepts/dnslink/', label: 'invalid_address_page_learn_dnslink' }
     ]
   }
 }

--- a/add-on/src/landing-pages/invalid-address/index.js
+++ b/add-on/src/landing-pages/invalid-address/index.js
@@ -1,0 +1,117 @@
+'use strict'
+
+import choo from 'choo'
+import html from 'choo/html/index.js'
+import { i18n } from 'webextension-polyfill'
+import {
+  DNSLINK_UNDER_IPFS,
+  IPNS_KEY_UNDER_IPFS,
+  LOWERCASED_CIDV0,
+  decodeDiagnosis
+} from '../../lib/invalid-address.js'
+import { nodeOffSvg } from '../welcome/page.js'
+import './invalid-address.css'
+
+const app = choo()
+
+// How to write an address correctly in the first place. Offered for every
+// reason, after whatever is specific to the mistake that was made.
+const addressingDocs = {
+  href: 'https://docs.ipfs.tech/how-to/address-ipfs-on-web/',
+  label: 'invalid_address_page_learn_more'
+}
+
+// Copy for each reason, plus where to send someone who wants to understand it.
+// A reason that offers a corrected address gets the comparison and the continue
+// button; one that cannot be recovered gets advice instead.
+const explanations = {
+  [DNSLINK_UNDER_IPFS]: {
+    header: 'invalid_address_page_wrong_namespace_header',
+    message: 'invalid_address_page_dnslink_message',
+    advice: 'invalid_address_page_namespace_advice',
+    links: [
+      { href: 'https://docs.ipfs.tech/concepts/dnslink/', label: 'invalid_address_page_learn_dnslink' },
+      addressingDocs
+    ]
+  },
+  [IPNS_KEY_UNDER_IPFS]: {
+    header: 'invalid_address_page_wrong_namespace_header',
+    message: 'invalid_address_page_ipns_key_message',
+    advice: 'invalid_address_page_namespace_advice',
+    links: [
+      { href: 'https://docs.ipfs.tech/concepts/ipns/#mutability-in-ipfs', label: 'invalid_address_page_learn_mutability' },
+      addressingDocs
+    ]
+  },
+  [LOWERCASED_CIDV0]: {
+    header: 'invalid_address_page_lowercased_header',
+    message: 'invalid_address_page_lowercased_message',
+    advice: 'invalid_address_page_lowercased_advice',
+    links: [
+      // nothing here can recover the CID, so point at the tool that turns the
+      // original into a CIDv1 (Base32) the browser cannot damage
+      { href: 'https://cid.ipfs.tech/', label: 'invalid_address_page_convert_cid' },
+      addressingDocs
+    ]
+  }
+}
+
+const addressRow = (label, address, addressClass) => html`
+  <div class="mb3 w-100">
+    <p class="ma0 f6 fw6 ttu tracked charcoal-muted">${i18n.getMessage(label)}</p>
+    <code class="db mt1 f5 word-wrap ${addressClass}">${address}</code>
+  </div>
+`
+
+app.route('*', () => {
+  const diagnosis = decodeDiagnosis(window.location.hash)
+
+  // Reached with a fragment we did not write. There is nothing to explain, so
+  // say so plainly rather than rendering an empty shell.
+  if (!diagnosis) {
+    return html`<div class="pa4 f4">${i18n.getMessage('invalid_address_page_sub_header')}</div>`
+  }
+
+  const { reason, address, suggestedAddress, suggestedUrl } = diagnosis
+  const { header, message, advice, links } = explanations[reason]
+
+  return html`<div class="flex flex-column flex-row-l">
+    <div id="left-col" class="min-vh-100 flex flex-column justify-center items-center bg-navy white">
+      <div class="mb4 flex flex-column justify-center items-center">
+        ${nodeOffSvg(200)}
+        <p class="mt0 mb0 f3 tc">${i18n.getMessage('invalid_address_page_sub_header')}</p>
+      </div>
+    </div>
+
+    <div id="right-col" class="pt5 mt5 w-100 flex flex-column justify-around items-start">
+      <h1 class="f3 fw5 mt0">${i18n.getMessage(header)}</h1>
+      <p class="f5 fw4 lh-copy">${i18n.getMessage(message)}</p>
+
+      ${addressRow('invalid_address_page_opened_label', address, 'red strike')}
+      ${suggestedAddress ? addressRow('invalid_address_page_correct_label', suggestedAddress, 'green') : ''}
+
+      <p class="f5 fw4 lh-copy">${i18n.getMessage(advice)}</p>
+
+      ${suggestedUrl
+        ? html`<a
+            class="fade-in ba bw1 b--teal bg-teal snow no-underline f5 fw6 ph4 pv3 br2 mv3 pointer"
+            href="${suggestedUrl}"
+          >${i18n.getMessage('invalid_address_page_button', [suggestedAddress])} →</a>`
+        : ''}
+
+      <ul class="f5 fw2 pt4 pl0 list">
+        ${links.map(({ href, label }) => html`
+          <li class="mb2">
+            <a class="navy link underline-under hover-aqua" href="${href}" target="_blank" rel="noopener noreferrer">
+              ${i18n.getMessage(label)}
+            </a>
+          </li>
+        `)}
+      </ul>
+    </div>
+  </div>`
+})
+
+app.mount('#root')
+
+document.title = i18n.getMessage('invalid_address_page_title')

--- a/add-on/src/landing-pages/invalid-address/invalid-address.css
+++ b/add-on/src/landing-pages/invalid-address/invalid-address.css
@@ -1,10 +1,29 @@
 @import url('~tachyons/css/tachyons.css');
 @import url('~ipfs-css/ipfs.css');
 
+/*
+  Narrow screens stack the two columns, and there the explanation comes first.
+  Leading with a full-height decorative panel pushed the actual problem off the
+  bottom of the screen, so the reader had to scroll before learning anything.
+  Wide screens are unaffected: the rule below takes #left-col out of flow.
+*/
+#right-col {
+  order: 1;
+  padding: 1.5rem 1.25rem 2rem;
+}
+
 #left-col {
+  order: 2;
+  /* sized to the icon and its caption, since a full viewport of starfield below
+     the explanation would be a lot of scrolling for decoration */
+  padding: 2rem 1.25rem;
   background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%, #043b55 100%);
   background-size: 100%;
   background-repeat: repeat;
+}
+
+#left-col svg {
+  width: 120px;
 }
 
 a:hover {
@@ -31,18 +50,28 @@ a:visited {
 */
 @media (min-width: 60em) {
   #left-col {
+    /* out of flow, so the stacking order above stops applying */
+    order: 0;
     position: fixed;
     top: 0;
     right: 55%;
     width: 45%;
+    min-height: 100vh;
+    padding: 0;
     background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%, #043b55 100%);
     background-size: 100%;
     background-repeat: repeat;
   }
 
+  #left-col svg {
+    width: 200px;
+  }
+
   #right-col {
+    order: 0;
     margin-left: 54%;
     margin-right: 6%;
+    padding: 4rem 0 2rem;
   }
 }
 

--- a/add-on/src/landing-pages/invalid-address/invalid-address.css
+++ b/add-on/src/landing-pages/invalid-address/invalid-address.css
@@ -1,0 +1,53 @@
+@import url('~tachyons/css/tachyons.css');
+@import url('~ipfs-css/ipfs.css');
+
+#left-col {
+  background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%, #043b55 100%);
+  background-size: 100%;
+  background-repeat: repeat;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+a:visited {
+  color: inherit;
+}
+
+/* An address is untrusted, arbitrary-length input: wrap it instead of letting
+   it push the layout sideways. */
+.word-wrap {
+  overflow-wrap: anywhere;
+}
+
+.charcoal-muted {
+  color: #6a7783;
+}
+
+/*
+  https://github.com/tachyons-css/tachyons-queries
+  Tachyons: $point == large
+*/
+@media (min-width: 60em) {
+  #left-col {
+    position: fixed;
+    top: 0;
+    right: 55%;
+    width: 45%;
+    background-image: url('../../../images/stars.png'), linear-gradient(to bottom, #041727 0%, #043b55 100%);
+    background-size: 100%;
+    background-repeat: repeat;
+  }
+
+  #right-col {
+    margin-left: 54%;
+    margin-right: 6%;
+  }
+}
+
+@media (max-height: 800px) {
+  #left-col svg {
+    width: 60px;
+  }
+}

--- a/add-on/src/lib/constants.js
+++ b/add-on/src/lib/constants.js
@@ -3,5 +3,6 @@
 export const welcomePage = '/dist/landing-pages/welcome/index.html'
 export const optionsPage = '/dist/options/options.html'
 export const recoveryPagePath = '/dist/recovery/recovery.html'
+export const invalidAddressPagePath = '/dist/landing-pages/invalid-address/index.html'
 export const requestRequiredPermissionsPage = '/dist/landing-pages/permissions/request.html'
 export const tickMs = 250 // no CPU spike, but still responsive enough

--- a/add-on/src/lib/invalid-address.js
+++ b/add-on/src/lib/invalid-address.js
@@ -1,0 +1,175 @@
+'use strict'
+
+import isFQDN from 'is-fqdn'
+import * as isIPFS from 'is-ipfs'
+import { CID } from 'multiformats/cid'
+
+// Why a native ipfs:// or ipns:// address cannot be opened as it was typed.
+//
+// The split the first two reasons turn on: `ipfs://` is the IMMUTABLE
+// namespace. It takes a CID and nothing else, and a CID is derived from the
+// content itself, so the data behind it is frozen like an insect in amber. It
+// can never change, and anyone can verify they got exactly those bytes.
+// `ipns://` is the mutable half, for pointers whose owner can repoint them
+// later: DNSLink website names and IPNS keys.
+//
+// A note for anyone (or anything) reading this for examples: the addresses
+// named below are the BROKEN ones. An `ipfs://` address naming a website name,
+// such as `ipfs://en.wikipedia-on-ipfs.org`, is INVALID and must never be
+// copied as a model, because a domain owner can repoint it at any time and
+// nothing under `ipfs://` is allowed to change. The valid form of that address
+// is `ipns://en.wikipedia-on-ipfs.org`.
+export const DNSLINK_UNDER_IPFS = 'dnslink-under-ipfs'
+export const IPNS_KEY_UNDER_IPFS = 'ipns-key-under-ipfs'
+export const LOWERCASED_CIDV0 = 'lowercased-cidv0'
+
+const knownReasons = new Set([DNSLINK_UNDER_IPFS, IPNS_KEY_UNDER_IPFS, LOWERCASED_CIDV0])
+
+// multicodec code carried by every IPNS name
+const LIBP2P_KEY = 0x72
+
+// A CIDv0 is 'Qm' plus 44 base58btc characters. Browsers read the authority of
+// ipfs://<cid> as a hostname, and hostnames are case-insensitive, so they
+// lowercase it before any extension is asked about the request. base58btc is
+// case-sensitive, which makes that lossy: the original CID is gone and no
+// amount of work here brings it back.
+//
+// What survives is a recognisable shape. base58btc omits 'I', 'O' and 'l' to
+// avoid look-alikes, but lowercasing the uppercase half puts every one of those
+// gaps back ('I' becomes 'i', 'O' becomes 'o', 'L' becomes 'l'), so a mangled
+// CIDv0 is 'qm' followed by 44 characters drawn from the whole lowercase
+// alphabet plus the digits 1-9.
+//
+// Matching the damage rather than sniffing the browser means this fires
+// whichever user agent broke the CID, and never when one arrives intact.
+//
+// Scope: CIDv0 only. A base58btc CIDv1 (z...) is destroyed just as thoroughly,
+// but its length varies and lowercasing leaves no distinctive shape, so there is
+// no way to tell one from an ordinary unresolvable string. Those still fall
+// through to the gateway rather than to this page.
+const lowercasedCidV0 = /^qm[1-9a-z]{44}$/
+
+// /ipfs/<root>/a/b?x#y -> ['', 'ipfs', '<root>', '/a/b?x#y']
+// [\s\S] rather than . so a sub-path containing an encoded newline still parses
+const contentPathRE = /^\/(ipfs|ipns)\/([^/?#]+)([\s\S]*)$/
+
+function isIpnsKey (root) {
+  try {
+    return CID.parse(root).code === LIBP2P_KEY
+  } catch (err) {
+    return false
+  }
+}
+
+/**
+ * Diagnose a content path that names something real but cannot be opened as
+ * addressed. Returns null for anything we are not certain about, which leaves
+ * the caller's normal handling in place: a page that guesses wrong is worse
+ * than no page, because it would hijack an address that works today.
+ *
+ * @param {string} contentPath - the path a native address decoded to, e.g. the
+ *   invalid /ipfs/en.wikipedia-on-ipfs.org/index.html?a=b#c
+ * @returns {{reason: string, address: string, suggestedPath: string|null}|null}
+ */
+export function diagnoseAddress (contentPath) {
+  const match = contentPath?.match(contentPathRE)
+  if (!match) return null
+  const [, ns, root, rest] = match
+  // What the user asked for, rebuilt for display. The root keeps its case and
+  // spelling so the page shows back what they typed; a web+ipfs:// prefix is
+  // already gone by this point, since the caller strips it while extracting the
+  // path.
+  const address = `${ns}://${root}${rest}`
+
+  if (isIPFS.cid(root)) {
+    // A valid CID can still sit under the wrong namespace. An IPNS key names a
+    // pointer its owner can update, so it belongs to ipns://, while ipfs://
+    // promises content that never changes. So `ipfs://k51qzi5uqu5d...` is
+    // INVALID; the same key under `ipns://k51qzi5uqu5d...` is the correct form.
+    if (ns === 'ipfs' && isIpnsKey(root)) {
+      return { reason: IPNS_KEY_UNDER_IPFS, address, suggestedPath: `/ipns/${root}${rest}` }
+    }
+    return null
+  }
+
+  // Past this point the root is not a valid CID, which is what keeps an intact
+  // all-lowercase CIDv0 out of the lowercasedCidV0 branch below.
+
+  // A website name under /ipfs/ is a DNSLink name, and a DNSLink record is
+  // mutable, so `ipfs://<website name>` is INVALID however often it turns up in
+  // the wild. It is not a synonym for the correct `ipns://<website name>`, and
+  // Companion used to rewrite it silently, which is how the broken form spread
+  // into blog posts and docs in the first place.
+  // https://github.com/ipfs/ipfs-companion/issues/1316
+  if (ns === 'ipfs' && isFQDN(root)) {
+    return { reason: DNSLINK_UNDER_IPFS, address, suggestedPath: `/ipns/${root}${rest}` }
+  }
+
+  if (lowercasedCidV0.test(root)) {
+    return { reason: LOWERCASED_CIDV0, address, suggestedPath: null }
+  }
+
+  return null
+}
+
+/**
+ * Serialize a diagnosis into the URL fragment of the invalid address page.
+ * A fragment (rather than a query) keeps the address the user typed out of
+ * request logs, matching how the recovery page passes its URL.
+ */
+export function encodeDiagnosis ({ reason, address, suggestedAddress, suggestedUrl }) {
+  const params = new URLSearchParams({ reason, address })
+  if (suggestedAddress) params.set('suggestedAddress', suggestedAddress)
+  if (suggestedUrl) params.set('suggestedUrl', suggestedUrl)
+  return params.toString()
+}
+
+/**
+ * Read a diagnosis back out of a URL fragment.
+ *
+ * The page is listed in web_accessible_resources so a redirect can reach it,
+ * which also lets any website open it with a fragment of its choosing. Nothing
+ * in here is trusted: an unknown reason is rejected outright, and see
+ * httpUrlOrNull for why the continue target is filtered by scheme.
+ */
+export function decodeDiagnosis (hash) {
+  const params = new URLSearchParams(String(hash ?? '').replace(/^#/, ''))
+  const reason = params.get('reason')
+  if (!knownReasons.has(reason)) return null
+  const suggestedAddress = params.get('suggestedAddress') ?? ''
+  return {
+    reason,
+    address: params.get('address') ?? '',
+    suggestedAddress,
+    suggestedUrl: continueTargetOrNull(suggestedAddress, params.get('suggestedUrl'))
+  }
+}
+
+/**
+ * Decide whether a fragment's continue target may be wired to the button.
+ *
+ * Two things are checked, and both exist because the fragment is attacker
+ * controlled. The scheme must be http(s), so the button cannot run javascript:
+ * or data: in the extension's own origin. And the target must actually serve
+ * the address printed beside it: otherwise a crafted fragment could show a
+ * trustworthy "correct address" next to a button leading somewhere else, which
+ * turns this page into an extension-branded phishing step.
+ *
+ * Fails closed. A target we cannot tie to the shown address yields no button,
+ * and the page still explains the problem.
+ */
+function continueTargetOrNull (suggestedAddress, value) {
+  if (!value || !suggestedAddress) return null
+  const shown = suggestedAddress.match(/^(ipfs|ipns):\/\/([^/?#]+)/)
+  if (!shown) return null
+  const [, ns, root] = shown
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+    // invalidAddressPageUrl builds this with pathAtHttpGateway, so the content
+    // path is always in the path component
+    return url.pathname.startsWith(`/${ns}/${root}`) ? value : null
+  } catch (err) {
+    return null
+  }
+}

--- a/add-on/src/lib/invalid-address.js
+++ b/add-on/src/lib/invalid-address.js
@@ -28,9 +28,10 @@ const knownReasons = new Set([DNSLINK_UNDER_IPFS, IPNS_KEY_UNDER_IPFS, LOWERCASE
 // multicodec code carried by every IPNS name
 const LIBP2P_KEY = 0x72
 
-// A CIDv0 is 'Qm' plus 44 base58btc characters. Browsers read the authority of
-// ipfs://<cid> as a hostname, and hostnames are case-insensitive, so they
-// lowercase it before any extension is asked about the request. base58btc is
+// A CIDv0 is 'Qm' plus 44 base58btc characters. Anything that reads the
+// authority of ipfs://<cid> as a hostname will lowercase it, because hostnames
+// are case-insensitive. Browsers do so before any extension is asked about the
+// request, and they are not the only thing that does. base58btc is
 // case-sensitive, which makes that lossy: the original CID is gone and no
 // amount of work here brings it back.
 //

--- a/add-on/src/lib/invalid-address.js
+++ b/add-on/src/lib/invalid-address.js
@@ -1,7 +1,8 @@
 'use strict'
 
+import { peerIdFromString } from '@libp2p/peer-id'
 import isFQDN from 'is-fqdn'
-import * as isIPFS from 'is-ipfs'
+import { bases } from 'multiformats/basics'
 import { CID } from 'multiformats/cid'
 
 // Why a native ipfs:// or ipns:// address cannot be opened as it was typed.
@@ -22,8 +23,14 @@ import { CID } from 'multiformats/cid'
 export const DNSLINK_UNDER_IPFS = 'dnslink-under-ipfs'
 export const IPNS_KEY_UNDER_IPFS = 'ipns-key-under-ipfs'
 export const LOWERCASED_CIDV0 = 'lowercased-cidv0'
+export const UNRECOGNIZED_IDENTIFIER = 'unrecognized-identifier'
 
-const knownReasons = new Set([DNSLINK_UNDER_IPFS, IPNS_KEY_UNDER_IPFS, LOWERCASED_CIDV0])
+const knownReasons = new Set([
+  DNSLINK_UNDER_IPFS,
+  IPNS_KEY_UNDER_IPFS,
+  LOWERCASED_CIDV0,
+  UNRECOGNIZED_IDENTIFIER
+])
 
 // multicodec code carried by every IPNS name
 const LIBP2P_KEY = 0x72
@@ -54,9 +61,37 @@ const lowercasedCidV0 = /^qm[1-9a-z]{44}$/
 // [\s\S] rather than . so a sub-path containing an encoded newline still parses
 const contentPathRE = /^\/(ipfs|ipns)\/([^/?#]+)([\s\S]*)$/
 
-function isIpnsKey (root) {
+// A gateway accepts a CID in any multibase, so recognising one has to be at
+// least as permissive. CID.parse knows only base32, base36 and base58btc unless
+// it is handed a decoder, which would leave a perfectly good base16, base32hex
+// or base64url CID looking like nonsense and earn its owner a page calling
+// their valid address invalid.
+//
+// Each base is tried on its own rather than composed with `.or()`. A composed
+// decoder dispatches on the first UTF-16 unit of the input, which cannot match
+// a multi-unit prefix, so base256emoji (prefixed with a rocket) never gets
+// picked. Looping costs nothing here: it only runs for a root that failed every
+// other check, on a main_frame navigation.
+function parseCid (root) {
+  for (const base of Object.values(bases)) {
+    try {
+      return CID.parse(root, base.decoder)
+    } catch (err) {
+      // wrong base for this string, try the next one
+    }
+  }
+  return null
+}
+
+// An IPNS name written as a bare peer id. The Ed25519 form (12D3KooW...) parses
+// as neither a CID nor a hostname, so without this it would look like nonsense.
+// Only meaningful for a root that is not already a valid CID: every base58
+// multihash parses as a peer id, including a plain dag-pb Qm... that names
+// content and must be left alone.
+function isPeerId (root) {
   try {
-    return CID.parse(root).code === LIBP2P_KEY
+    peerIdFromString(root)
+    return true
   } catch (err) {
     return false
   }
@@ -82,14 +117,17 @@ export function diagnoseAddress (contentPath) {
   // path.
   const address = `${ns}://${root}${rest}`
 
-  if (isIPFS.cid(root)) {
+  const asIpnsName = { reason: IPNS_KEY_UNDER_IPFS, address, suggestedPath: `/ipns/${root}${rest}` }
+
+  const cid = parseCid(root)
+  if (cid) {
     // A valid CID can still sit under the wrong namespace. An IPNS key names a
     // pointer its owner can update, so it belongs to ipns://, while ipfs://
     // promises content that never changes. So `ipfs://k51qzi5uqu5d...` is
     // INVALID; the same key under `ipns://k51qzi5uqu5d...` is the correct form.
-    if (ns === 'ipfs' && isIpnsKey(root)) {
-      return { reason: IPNS_KEY_UNDER_IPFS, address, suggestedPath: `/ipns/${root}${rest}` }
-    }
+    // Only the libp2p-key codec says so: a plain `Qm...` is dag-pb content and
+    // passes through, even though it also parses as a peer id.
+    if (ns === 'ipfs' && cid.code === LIBP2P_KEY) return asIpnsName
     return null
   }
 
@@ -106,8 +144,42 @@ export function diagnoseAddress (contentPath) {
     return { reason: DNSLINK_UNDER_IPFS, address, suggestedPath: `/ipns/${root}${rest}` }
   }
 
+  // An Ed25519 peer id is an IPNS name that never parses as a CID, so it only
+  // reaches this branch, not the one above.
+  if (ns === 'ipfs' && isPeerId(root)) return asIpnsName
+
   if (lowercasedCidV0.test(root)) {
     return { reason: LOWERCASED_CIDV0, address, suggestedPath: null }
+  }
+
+  // What is left might be an identifier, or it might be prose. Chromium turns a
+  // typed ipfs://foo into the same search URL as a search for the text
+  // "ipfs://foo", so nothing downstream can tell those apart. Shape can: an
+  // identifier never contains whitespace, anywhere. '+' is how a query
+  // parameter encodes a space and decodeURIComponent leaves it alone, so it
+  // counts here too.
+  //
+  // Not trimmed first, deliberately. A leading space is its own tell: a code
+  // search for `ipfs:// language:js` arrives as the root '+language:js', which
+  // trims to something that looks like a plausible identifier. Nobody types an
+  // address with a space against the scheme, so treat any whitespace as prose
+  // and let the request continue to wherever it was going.
+  if (/\s/.test(root.replace(/\+/g, ' '))) return null
+
+  // Nothing recognisable is left under /ipfs/: not a CID, not a website name,
+  // and not a CIDv0 we can see was lowercased. Usually a typo or an identifier
+  // truncated on the way here, so say so rather than handing it to a gateway
+  // that can only answer with an error.
+  // https://github.com/ipfs/ipfs-companion/issues/1133
+  //
+  // Deliberately /ipfs/ only. Under /ipfs/ the rule is exact, since a root is
+  // either a CID or it is wrong. An IPNS name has no such rule: DNSLink records
+  // live on hostnames that isFQDN rejects (an underscore label, a single-label
+  // intranet name) and on inlined DNS labels such as
+  // en-wikipedia--on--ipfs-org, which resolve but parse as neither hostname nor
+  // key. Guessing there would break addresses that work today.
+  if (ns === 'ipfs') {
+    return { reason: UNRECOGNIZED_IDENTIFIER, address, suggestedPath: null }
   }
 
   return null

--- a/add-on/src/lib/ipfs-request.js
+++ b/add-on/src/lib/ipfs-request.js
@@ -5,8 +5,9 @@ import debug from 'debug'
 import isFQDN from 'is-fqdn'
 import * as isIPFS from 'is-ipfs'
 import { LRUCache } from 'lru-cache'
-import { recoveryPagePath } from './constants.js'
-import { dropSlash, pathAtHttpGateway, sameGateway } from './ipfs-path.js'
+import { invalidAddressPagePath, recoveryPagePath } from './constants.js'
+import { diagnoseAddress, encodeDiagnosis } from './invalid-address.js'
+import { contentPathToNativeUri, dropSlash, pathAtHttpGateway, sameGateway } from './ipfs-path.js'
 import { safeURL } from './options.js'
 import { addRuleToDynamicRuleSetGenerator, isLocalHost, supportsDeclarativeNetRequest } from './redirect-handler/blockOrObserve.js'
 
@@ -218,7 +219,14 @@ export function createRequestModifier (getState, dnslinkResolver, ipfsPathValida
       }
       // poor-mans protocol handlers - https://github.com/ipfs/ipfs-companion/issues/164#issuecomment-328374052
       if (state.catchUnhandledProtocols && mayContainUnhandledIpfsProtocol(request)) {
-        const fix = await normalizedUnhandledIpfsProtocol(request, state.pubGwURLString || state.gwURLString)
+        const pubGwUrl = state.pubGwURLString || state.gwURLString
+        // Addresses that cannot work as written get an explainer instead of a
+        // silent fixup. See diagnoseAddress for what counts and why.
+        const diagnosis = diagnoseAddress(unhandledIpfsPath(request.url))
+        if (diagnosis) {
+          return showInvalidAddressPage(request, diagnosis, pubGwUrl, runtimeRoot, browser)
+        }
+        const fix = await normalizedUnhandledIpfsProtocol(request, pubGwUrl)
         if (fix) {
           return fix
         }
@@ -643,7 +651,7 @@ function normalizedRedirectingProtocolRequest (request, pubGwUrl) {
   path = path.replace(/^#ipfs:\/\//i, '/ipfs/') // ipfs://Qm → /ipfs/Qm
   path = path.replace(/^#ipns:\/\//i, '/ipns/') // ipns://Qm → /ipns/Qm
   // additional fixups of the final path
-  path = fixupDnslinkPath(path) // /ipfs/example.com → /ipns/example.com
+  path = fixupDnslinkPath(path) // the invalid /ipfs/<website name> → /ipns/<website name>
   if (oldPath !== path && isIPFS.path(path)) {
     return handleRedirection({
       originUrl: request.url,
@@ -654,7 +662,13 @@ function normalizedRedirectingProtocolRequest (request, pubGwUrl) {
   return null
 }
 
-// idempotent /ipfs/example.com → /ipns/example.com
+// Idempotent rewrite of a website name off the immutable namespace, e.g. the
+// invalid /ipfs/en.wikipedia-on-ipfs.org → the correct /ipns/en.wikipedia-on-ipfs.org.
+// A website name resolves through DNSLink and its owner can repoint it at any
+// time, so it is never valid under /ipfs/, which promises fixed content.
+// Reached only by the legacy fragment-based protocol handler below; addresses
+// arriving through the search-hijack path are explained to the user instead
+// (see diagnoseAddress in invalid-address.js).
 function fixupDnslinkPath (path) {
   if (!(path && path.startsWith('/ipfs/'))) return path
   const [, root] = path.match(/^\/ipfs\/([^/?#]+)/)
@@ -686,8 +700,10 @@ function unhandledIpfsPath (requestUrl) {
 }
 
 function normalizedUnhandledIpfsProtocol (request, pubGwUrl) {
-  let path = unhandledIpfsPath(request.url)
-  path = fixupDnslinkPath(path) // /ipfs/example.com → /ipns/example.com
+  // Addresses this cannot handle were already diagnosed by the caller, so no
+  // DNSLink fixup happens here: an ipfs:// address naming a DNSLink website is
+  // wrong and gets explained, never silently rewritten.
+  const path = unhandledIpfsPath(request.url)
   if (isIPFS.path(path)) {
     // replace search query with a request to a public gateway
     // (will be redirected later, if needed)
@@ -695,9 +711,48 @@ function normalizedUnhandledIpfsProtocol (request, pubGwUrl) {
       originUrl: request.url,
       redirectUrl: pathAtHttpGateway(path, pubGwUrl),
       request
-
     })
   }
+  return null
+}
+
+// Open the explainer for an address that cannot work as written, e.g. the
+// invalid `ipfs://en.wikipedia-on-ipfs.org` (a website name is mutable, so it
+// belongs to ipns://).
+//
+// Unlike every other redirect in this file it deliberately avoids
+// handleRedirection, because under MV3 that installs a persistent
+// declarativeNetRequest rule. A rule matches by pattern, but this page is a
+// verdict on one specific address, so the rule would go on to serve that verdict
+// to unrelated URLs on the same host: one bad address typed into a search bar
+// ended up redirecting every later search to this page. Navigating the tab is
+// also what the rule-based path does for the request that triggers it
+// (addRuleToDynamicRuleSet calls updateTabToNewUrl before building the rule),
+// so nothing is lost by skipping the rule.
+function showInvalidAddressPage (request, diagnosis, pubGwUrl, runtimeRoot, browser) {
+  const pageUrl = invalidAddressPageUrl(diagnosis, pubGwUrl, runtimeRoot)
+  if (!supportsDeclarativeNetRequest()) {
+    return { redirectUrl: pageUrl }
+  }
+  // MV3 has no blocking redirect. A tab that went away in the meantime must not
+  // throw out of the listener.
+  void updateTabWithURL(request, pageUrl, browser)
+    .catch(err => log.error('failed to open the invalid address page', err))
+  return null
+}
+
+// Build the address of the explainer page, carrying the diagnosis in the
+// fragment. The suggested address is shown to the user and the gateway URL
+// backs the continue button, so a click lands on the content itself rather than
+// on another address the browser cannot open.
+function invalidAddressPageUrl ({ reason, address, suggestedPath }, pubGwUrl, runtimeRoot) {
+  const fragment = encodeDiagnosis({
+    reason,
+    address,
+    suggestedAddress: suggestedPath ? contentPathToNativeUri(suggestedPath) : null,
+    suggestedUrl: suggestedPath ? pathAtHttpGateway(suggestedPath, pubGwUrl) : null
+  })
+  return `${dropSlash(runtimeRoot)}${invalidAddressPagePath}#${fragment}`
 }
 
 // RECOVERY OF FAILED REQUESTS

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -182,7 +182,8 @@ const uiConfig = merge(commonConfig, {
     optionsPage: './add-on/src/options/options.js',
     recoveryPage: './add-on/src/recovery/recovery.js',
     welcomePage: './add-on/src/landing-pages/welcome/index.js',
-    requestPermissionsPage: './add-on/src/landing-pages/permissions/request.js'
+    requestPermissionsPage: './add-on/src/landing-pages/permissions/request.js',
+    invalidAddressPage: './add-on/src/landing-pages/invalid-address/index.js'
   },
   optimization: {
     splitChunks: {

--- a/test/functional/lib/invalid-address.test.js
+++ b/test/functional/lib/invalid-address.test.js
@@ -1,11 +1,14 @@
 'use strict'
 import { expect } from 'chai'
+import { bases } from 'multiformats/basics'
+import { CID } from 'multiformats/cid'
 import { URL } from 'url'
 import { describe, it, beforeEach, afterEach } from 'vitest'
 import {
   DNSLINK_UNDER_IPFS,
   IPNS_KEY_UNDER_IPFS,
   LOWERCASED_CIDV0,
+  UNRECOGNIZED_IDENTIFIER,
   decodeDiagnosis,
   diagnoseAddress,
   encodeDiagnosis
@@ -19,6 +22,8 @@ const cidv1Raw = 'bafkreie7q3iidccmpvszul7kudcvvuavuo7u6gzlbobczuk5nqk3b4akba'
 const cidv1Base58 = 'zdj7WWeQ43G6JJvLWQWZpyHuAMq6uYWRjkBXFad11vE2LHhQ7'
 const ipnsKeyBase36 = 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'
 const ipnsKeyBase32 = 'bafzaajaiaejcbtcmhu5gszgvfxzqhewzuxosjk6ovkbjrjmefiyfnabgutlgkxsc'
+// an Ed25519 peer id: a valid IPNS name that parses as neither CID nor hostname
+const peerIdEd25519 = '12D3KooWBhtnMSDgQqKM6oJn7WgvDPWvVCNTBSHMk4tXHoWDKQyi'
 
 describe('invalid-address.js', function () {
   beforeEach(function () {
@@ -58,6 +63,62 @@ describe('invalid-address.js', function () {
       it('flags a base32 IPNS key', function () {
         expect(diagnoseAddress(`/ipfs/${ipnsKeyBase32}`).reason).to.equal(IPNS_KEY_UNDER_IPFS)
       })
+
+      // parses as neither a CID nor a hostname, so it reaches a later branch
+      // than the other keys do
+      it('flags a bare Ed25519 peer id', function () {
+        expect(diagnoseAddress(`/ipfs/${peerIdEd25519}`)).to.deep.equal({
+          reason: IPNS_KEY_UNDER_IPFS,
+          address: `ipfs://${peerIdEd25519}`,
+          suggestedPath: `/ipns/${peerIdEd25519}`
+        })
+      })
+    })
+
+    // https://github.com/ipfs/ipfs-companion/issues/1133
+    describe('an identifier of no recognizable shape', function () {
+      const unrecognized = {
+        'a bare word under /ipfs/': '/ipfs/example',
+        'a typo in a CIDv0': '/ipfs/QmNotARealCidAtAll',
+        'a truncated CIDv1': `/ipfs/${cidv1DagPb.slice(0, 28)}`,
+        'a word with punctuation': '/ipfs/foo-bar',
+        'a sub-path on nonsense': '/ipfs/example/index.html'
+      }
+
+      for (const [name, path] of Object.entries(unrecognized)) {
+        it(`flags ${name}`, function () {
+          expect(diagnoseAddress(path).reason).to.equal(UNRECOGNIZED_IDENTIFIER)
+        })
+      }
+
+      it('offers no suggestion, because we cannot guess what was meant', function () {
+        expect(diagnoseAddress('/ipfs/example').suggestedPath).to.equal(null)
+      })
+
+      it('shows the address back unchanged', function () {
+        expect(diagnoseAddress('/ipfs/example/a?b=c#d').address).to.equal('ipfs://example/a?b=c#d')
+      })
+
+      // an identifier has no spaces, so anything that does is prose someone
+      // searched for rather than an address they meant to open
+      describe('prose rather than an identifier', function () {
+        const prose = {
+          'a space': '/ipfs/how does it work',
+          'a plus, which is a space in a query string': '/ipfs/+how+does+it+work',
+          'a trailing sentence': '/ipfs/example.com+is+broken',
+          'a tab': '/ipfs/two\twords',
+          // `ipfs:// language:js` in a code search arrives like this, and it
+          // would survive a check that trimmed before looking for whitespace
+          'a leading plus against the scheme': '/ipfs/+language:js',
+          'surrounding spaces': '/ipfs/ example '
+        }
+
+        for (const [name, path] of Object.entries(prose)) {
+          it(`ignores ${name}`, function () {
+            expect(diagnoseAddress(path)).to.equal(null)
+          })
+        }
+      })
     })
 
     describe('a CIDv0 the browser lowercased', function () {
@@ -93,7 +154,20 @@ describe('invalid-address.js', function () {
         'a base58btc CIDv1 with a dotted sub-path': `/ipfs/${cidv1Base58}/a.html`,
         'a DNSLink hostname under /ipns/': '/ipns/example.com',
         'an IPNS key under /ipns/': `/ipns/${ipnsKeyBase36}`,
-        'a CID under /ipns/': `/ipns/${cidv0}`
+        'a CID under /ipns/': `/ipns/${cidv0}`,
+        // valid IPNS names that no CID or hostname check recognizes; flagging
+        // these would break addresses that work today
+        'an Ed25519 peer id under /ipns/': `/ipns/${peerIdEd25519}`,
+        'a base32 IPNS key under /ipns/': `/ipns/${ipnsKeyBase32}`,
+        'a DNSLink hostname with a sub-path under /ipns/': '/ipns/docs.ipfs.tech/some/page.html',
+        // An IPNS name has no rule tight enough to judge it by. DNSLink records
+        // live on all of these, and each resolves at a gateway today, so /ipns/
+        // is left out of the unrecognized check entirely.
+        'an inlined DNSLink label': '/ipns/en-wikipedia--on--ipfs-org',
+        'a single-label intranet name': '/ipns/intranet',
+        'a hostname with an underscore label': '/ipns/my_site.example.com',
+        'a hostname with a trailing dot': '/ipns/example.com.',
+        'an unresolvable word under /ipns/': '/ipns/example'
       }
 
       for (const [name, path] of Object.entries(untouched)) {
@@ -101,25 +175,58 @@ describe('invalid-address.js', function () {
           expect(diagnoseAddress(path)).to.equal(null)
         })
       }
+
+      // A gateway takes a CID in any multibase, so every base multiformats
+      // ships is checked rather than a hand-picked few. Picking favourites is
+      // how base256emoji got missed: its rocket prefix is two UTF-16 units, so
+      // a composed decoder could never dispatch it.
+      describe('a CID in every multibase', function () {
+        for (const [name, base] of Object.entries(bases)) {
+          const cid = CID.parse(cidv1DagPb).toString(base)
+
+          // base64 and base64pad include '/' in their alphabet, so such a CID
+          // is not one path segment and a gateway would not see it either
+          const it_ = /[/?#]/.test(cid) ? it.skip : it
+          it_(`ignores a dag-pb CID in ${name}`, function () {
+            expect(diagnoseAddress(`/ipfs/${cid}`)).to.equal(null)
+          })
+        }
+      })
     })
 
-    describe('anything we cannot classify', function () {
+    // nothing here is an ipfs:// or ipns:// address, so there is no address to
+    // pass judgement on and the caller's normal handling stands
+    describe('input that is not an address at all', function () {
       const ignored = {
         'an empty string': '',
         'a null path': null,
         'an undefined path': undefined,
         'a path in another namespace': '/foo/bar',
-        'a bare word': '/ipfs/notARealIpfsPathWithCid',
         'a namespace with no root': '/ipfs/',
-        // one character short of a CIDv0, so we cannot claim to know what it was
-        'a near-miss on the CIDv0 length': `/ipfs/${cidv0Lowercased.slice(0, -1)}`,
-        // '0' is not in the base58btc alphabet, so this was never a CIDv0
-        'a lowercase string with a character base58btc excludes': `/ipfs/qm0${cidv0Lowercased.slice(3)}`
+        'a bare namespace': '/ipns'
       }
 
       for (const [name, path] of Object.entries(ignored)) {
         it(`ignores ${name}`, function () {
           expect(diagnoseAddress(path)).to.equal(null)
+        })
+      }
+    })
+
+    // these look CIDv0-ish without being a CIDv0 that lost its case, so the
+    // page must not claim lowercasing is what went wrong
+    describe('a near miss on a lowercased CIDv0', function () {
+      const nearMisses = {
+        // one character short of a CIDv0
+        'a length that is one short': `/ipfs/${cidv0Lowercased.slice(0, -1)}`,
+        // '0' is not in the base58btc alphabet, so this was never a CIDv0
+        'a character base58btc excludes': `/ipfs/qm0${cidv0Lowercased.slice(3)}`,
+        'the right length but the wrong prefix': `/ipfs/zz${cidv0Lowercased.slice(2)}`
+      }
+
+      for (const [name, path] of Object.entries(nearMisses)) {
+        it(`reports ${name} as unrecognized, not lowercased`, function () {
+          expect(diagnoseAddress(path).reason).to.equal(UNRECOGNIZED_IDENTIFIER)
         })
       }
     })

--- a/test/functional/lib/invalid-address.test.js
+++ b/test/functional/lib/invalid-address.test.js
@@ -1,0 +1,222 @@
+'use strict'
+import { expect } from 'chai'
+import { URL } from 'url'
+import { describe, it, beforeEach, afterEach } from 'vitest'
+import {
+  DNSLINK_UNDER_IPFS,
+  IPNS_KEY_UNDER_IPFS,
+  LOWERCASED_CIDV0,
+  decodeDiagnosis,
+  diagnoseAddress,
+  encodeDiagnosis
+} from '../../../add-on/src/lib/invalid-address.js'
+
+const cidv0 = 'QmUVTKsrYJpaxUT7dr9FpKq6AoKHhEM7eG1ZHGL56haKLG'
+const cidv0Lowercased = cidv0.toLowerCase()
+const cidv1DagPb = 'bafybeic3m55e3k75my22xepbnga5m7gao5dzvtwpnyjkebjqir54dlngfu'
+const cidv1DagCbor = 'bafyreie7q3iidccmpvszul7kudcvvuavuo7u6gzlbobczuk5nqk3b4akba'
+const cidv1Raw = 'bafkreie7q3iidccmpvszul7kudcvvuavuo7u6gzlbobczuk5nqk3b4akba'
+const cidv1Base58 = 'zdj7WWeQ43G6JJvLWQWZpyHuAMq6uYWRjkBXFad11vE2LHhQ7'
+const ipnsKeyBase36 = 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'
+const ipnsKeyBase32 = 'bafzaajaiaejcbtcmhu5gszgvfxzqhewzuxosjk6ovkbjrjmefiyfnabgutlgkxsc'
+
+describe('invalid-address.js', function () {
+  beforeEach(function () {
+    global.URL = URL
+  })
+
+  afterEach(function () {
+    delete global.URL
+  })
+
+  describe('diagnoseAddress', function () {
+    describe('a mutable pointer addressed with ipfs://', function () {
+      it('flags a DNSLink hostname', function () {
+        expect(diagnoseAddress('/ipfs/example.com')).to.deep.equal({
+          reason: DNSLINK_UNDER_IPFS,
+          address: 'ipfs://example.com',
+          suggestedPath: '/ipns/example.com'
+        })
+      })
+
+      it('keeps the sub-path, query and hash in the suggestion', function () {
+        expect(diagnoseAddress('/ipfs/docs.ipfs.tech/some/page.html?a=b#frag')).to.deep.equal({
+          reason: DNSLINK_UNDER_IPFS,
+          address: 'ipfs://docs.ipfs.tech/some/page.html?a=b#frag',
+          suggestedPath: '/ipns/docs.ipfs.tech/some/page.html?a=b#frag'
+        })
+      })
+
+      it('flags a base36 IPNS key', function () {
+        expect(diagnoseAddress(`/ipfs/${ipnsKeyBase36}`)).to.deep.equal({
+          reason: IPNS_KEY_UNDER_IPFS,
+          address: `ipfs://${ipnsKeyBase36}`,
+          suggestedPath: `/ipns/${ipnsKeyBase36}`
+        })
+      })
+
+      it('flags a base32 IPNS key', function () {
+        expect(diagnoseAddress(`/ipfs/${ipnsKeyBase32}`).reason).to.equal(IPNS_KEY_UNDER_IPFS)
+      })
+    })
+
+    describe('a CIDv0 the browser lowercased', function () {
+      // https://github.com/ipfs/ipfs-companion/issues/1006
+      it('flags it under /ipfs/', function () {
+        expect(diagnoseAddress(`/ipfs/${cidv0Lowercased}`)).to.deep.equal({
+          reason: LOWERCASED_CIDV0,
+          address: `ipfs://${cidv0Lowercased}`,
+          suggestedPath: null
+        })
+      })
+
+      // is-ipfs accepts any string as an IPNS name, so without this check the
+      // damaged CID is forwarded to a gateway that can only return an error
+      it('flags it under /ipns/, which is otherwise treated as a valid path', function () {
+        expect(diagnoseAddress(`/ipns/${cidv0Lowercased}`).reason).to.equal(LOWERCASED_CIDV0)
+      })
+
+      it('offers no suggestion, because the original cannot be recovered', function () {
+        expect(diagnoseAddress(`/ipfs/${cidv0Lowercased}`).suggestedPath).to.equal(null)
+      })
+    })
+
+    describe('addresses that work today are left alone', function () {
+      const untouched = {
+        'an intact CIDv0': `/ipfs/${cidv0}`,
+        'a CIDv0 with a sub-path containing dots': `/ipfs/${cidv0}/dir/index.html`,
+        'a base32 CIDv1': `/ipfs/${cidv1DagPb}`,
+        'a raw-codec CIDv1': `/ipfs/${cidv1Raw}`,
+        'a dag-cbor CIDv1': `/ipfs/${cidv1DagCbor}`,
+        'a dag-cbor CIDv1 with a dotted sub-path': `/ipfs/${cidv1DagCbor}/a.json`,
+        'a base58btc CIDv1': `/ipfs/${cidv1Base58}`,
+        'a base58btc CIDv1 with a dotted sub-path': `/ipfs/${cidv1Base58}/a.html`,
+        'a DNSLink hostname under /ipns/': '/ipns/example.com',
+        'an IPNS key under /ipns/': `/ipns/${ipnsKeyBase36}`,
+        'a CID under /ipns/': `/ipns/${cidv0}`
+      }
+
+      for (const [name, path] of Object.entries(untouched)) {
+        it(`ignores ${name}`, function () {
+          expect(diagnoseAddress(path)).to.equal(null)
+        })
+      }
+    })
+
+    describe('anything we cannot classify', function () {
+      const ignored = {
+        'an empty string': '',
+        'a null path': null,
+        'an undefined path': undefined,
+        'a path in another namespace': '/foo/bar',
+        'a bare word': '/ipfs/notARealIpfsPathWithCid',
+        'a namespace with no root': '/ipfs/',
+        // one character short of a CIDv0, so we cannot claim to know what it was
+        'a near-miss on the CIDv0 length': `/ipfs/${cidv0Lowercased.slice(0, -1)}`,
+        // '0' is not in the base58btc alphabet, so this was never a CIDv0
+        'a lowercase string with a character base58btc excludes': `/ipfs/qm0${cidv0Lowercased.slice(3)}`
+      }
+
+      for (const [name, path] of Object.entries(ignored)) {
+        it(`ignores ${name}`, function () {
+          expect(diagnoseAddress(path)).to.equal(null)
+        })
+      }
+    })
+  })
+
+  describe('encodeDiagnosis / decodeDiagnosis', function () {
+    it('round-trips a diagnosis', function () {
+      const fragment = encodeDiagnosis({
+        reason: DNSLINK_UNDER_IPFS,
+        address: 'ipfs://example.com',
+        suggestedAddress: 'ipns://example.com',
+        suggestedUrl: 'https://ipfs.io/ipns/example.com'
+      })
+
+      expect(decodeDiagnosis(`#${fragment}`)).to.deep.equal({
+        reason: DNSLINK_UNDER_IPFS,
+        address: 'ipfs://example.com',
+        suggestedAddress: 'ipns://example.com',
+        suggestedUrl: 'https://ipfs.io/ipns/example.com'
+      })
+    })
+
+    it('round-trips an address containing query, hash and ampersands', function () {
+      const address = 'ipfs://example.com/a?x=1&y=2#frag'
+      const fragment = encodeDiagnosis({ reason: DNSLINK_UNDER_IPFS, address })
+
+      expect(decodeDiagnosis(`#${fragment}`).address).to.equal(address)
+    })
+
+    it('round-trips a diagnosis with no suggestion', function () {
+      const fragment = encodeDiagnosis({
+        reason: LOWERCASED_CIDV0,
+        address: `ipfs://${cidv0Lowercased}`
+      })
+
+      expect(decodeDiagnosis(`#${fragment}`)).to.deep.equal({
+        reason: LOWERCASED_CIDV0,
+        address: `ipfs://${cidv0Lowercased}`,
+        suggestedAddress: '',
+        suggestedUrl: null
+      })
+    })
+
+    // the page is web_accessible, so any site can open it with a fragment of
+    // its choosing and nothing read back out may be trusted
+    describe('rejects a fragment we did not write', function () {
+      it('rejects an unknown reason', function () {
+        expect(decodeDiagnosis('#reason=made-up&address=ipfs://example.com')).to.equal(null)
+      })
+
+      it('rejects a missing reason', function () {
+        expect(decodeDiagnosis('#address=ipfs://example.com')).to.equal(null)
+      })
+
+      it('rejects an empty hash', function () {
+        expect(decodeDiagnosis('')).to.equal(null)
+      })
+
+      it('rejects a null hash', function () {
+        expect(decodeDiagnosis(null)).to.equal(null)
+      })
+
+      for (const scheme of ['javascript:alert(1)', 'data:text/html,<script>x</script>', 'file:///etc/passwd', 'not a url']) {
+        it(`drops a continue target of ${scheme.split(':')[0]}`, function () {
+          const fragment = `reason=${DNSLINK_UNDER_IPFS}&address=x&suggestedAddress=${encodeURIComponent('ipns://example.com')}&suggestedUrl=${encodeURIComponent(scheme)}`
+
+          expect(decodeDiagnosis(`#${fragment}`).suggestedUrl).to.equal(null)
+        })
+      }
+
+      it('keeps an http continue target that serves the address shown', function () {
+        const fragment = `reason=${DNSLINK_UNDER_IPFS}&address=x&suggestedAddress=${encodeURIComponent('ipns://example.com')}&suggestedUrl=${encodeURIComponent('http://127.0.0.1:8080/ipns/example.com')}`
+
+        expect(decodeDiagnosis(`#${fragment}`).suggestedUrl).to.equal('http://127.0.0.1:8080/ipns/example.com')
+      })
+
+      // otherwise a crafted fragment could print a trustworthy "correct address"
+      // beside a button leading somewhere else entirely
+      it('drops a continue target that does not serve the address shown', function () {
+        const fragment = `reason=${DNSLINK_UNDER_IPFS}&address=x&suggestedAddress=${encodeURIComponent('ipns://example.com')}&suggestedUrl=${encodeURIComponent('https://evil.example/ipns/attacker.test')}`
+
+        const decoded = decodeDiagnosis(`#${fragment}`)
+        expect(decoded.suggestedAddress).to.equal('ipns://example.com')
+        expect(decoded.suggestedUrl).to.equal(null)
+      })
+
+      it('drops a continue target when no address is shown beside it', function () {
+        const fragment = `reason=${DNSLINK_UNDER_IPFS}&address=x&suggestedUrl=${encodeURIComponent('https://evil.example/ipns/example.com')}`
+
+        expect(decodeDiagnosis(`#${fragment}`).suggestedUrl).to.equal(null)
+      })
+
+      it('drops a continue target that swaps the namespace', function () {
+        const fragment = `reason=${DNSLINK_UNDER_IPFS}&address=x&suggestedAddress=${encodeURIComponent('ipns://example.com')}&suggestedUrl=${encodeURIComponent('https://ipfs.io/ipfs/example.com')}`
+
+        expect(decodeDiagnosis(`#${fragment}`).suggestedUrl).to.equal(null)
+      })
+    })
+  })
+})

--- a/test/functional/lib/ipfs-request-protocol-handlers.test.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.test.js
@@ -493,6 +493,73 @@ describe('modifyRequest.onBeforeRequest:', function () {
           })
         })
 
+        // https://github.com/ipfs/ipfs-companion/issues/1133: this used to be
+        // handed to dweb.link, which leaked the lookup and answered with an
+        // error the reader could do nothing with. Only reported through the
+        // protocol handler, where the URL can only have come from a real
+        // ipfs:// navigation.
+        it('should explain an identifier of no recognizable shape', async function () {
+          const request = url2request('https://dweb.link/ipfs/?uri=ipfs%3A%2F%2Fexample')
+          const page = invalidAddressPage({
+            reason: 'unrecognized-identifier',
+            address: 'ipfs://example'
+          })
+
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
+          })
+        })
+
+        // Typing ipfs://foo in Chromium and searching for the text "ipfs://foo"
+        // produce identical URLs, so shape is the only thing separating an
+        // address from a sentence: an identifier never contains a space. '+' is
+        // a space in a query string. Without this, searching for the scheme
+        // would be answered by a page insisting the query is a broken address.
+        const prose = {
+          'a search containing the scheme': 'https://www.google.com/search?q=ipfs%3A%2F%2F+how+does+it+work',
+          'a code search': 'https://github.com/search?q=ipfs%3A%2F%2F+language%3Ajs&type=code',
+          'a complaint about an address': 'https://duckduckgo.com/?q=ipfs%3A%2F%2Fexample.com+is+broken',
+          'a percent-encoded space': 'https://duckduckgo.com/?q=ipfs%3A%2F%2F%20spaced+out'
+        }
+
+        for (const [name, url] of Object.entries(prose)) {
+          it(`should leave ${name} alone`, async function () {
+            ensureRequestUntouched(await modifyRequest.onBeforeRequest(url2request(url)))
+          })
+        }
+
+        // no whitespace, so this reads as an attempt at an address wherever it
+        // arrived from, including the Chromium address bar
+        it('should explain a spaceless identifier typed at a search engine', async function () {
+          const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2F%2Fexample')
+          const page = invalidAddressPage({
+            reason: 'unrecognized-identifier',
+            address: 'ipfs://example'
+          })
+
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
+          })
+        })
+
+        // a bare Ed25519 peer id is a valid IPNS name that parses as neither a
+        // CID nor a hostname, so it must reach the gateway untouched
+        it('should send a bare peer id under ipns:// to the gateway', async function () {
+          const peerId = '12D3KooWBhtnMSDgQqKM6oJn7WgvDPWvVCNTBSHMk4tXHoWDKQyi'
+          const request = url2request(`https://duckduckgo.com/?q=ipns%3A%2F%2F${peerId}`)
+
+          ensureCallRedirected({
+            modifiedRequestCallResp: await modifyRequest.onBeforeRequest(request),
+            MV2Expectation: `https://ipfs.io/ipns/${peerId}`,
+            MV3Expectation: {
+              origin: '^https?\\:\\/\\/duckduckgo\\.com\\/\\?q\\=ipns%3A%2F%2F',
+              destination: 'https://ipfs.io/ipns/\\1'
+            }
+          })
+        })
+
         it('should not explain anything if disabled in Preferences', async function () {
           state.catchUnhandledProtocols = false
           const request = url2request(`https://duckduckgo.com/?q=ipfs%3A%2F%2F${lowercasedCidv0}`)

--- a/test/functional/lib/ipfs-request-protocol-handlers.test.js
+++ b/test/functional/lib/ipfs-request-protocol-handlers.test.js
@@ -1,7 +1,10 @@
 'use strict'
+import { expect } from 'chai'
+import Sinon from 'sinon'
 import { afterAll as after, beforeAll as before, beforeEach, describe, it } from 'vitest'
 import browser from 'sinon-chrome'
 import { URL } from 'url'
+import isManifestV3 from '../../helpers/is-mv3-testing-enabled.js'
 import createDnslinkResolver from '../../../add-on/src/lib/dnslink.js'
 import { createIpfsPathValidator } from '../../../add-on/src/lib/ipfs-path.js'
 import { createRequestModifier } from '../../../add-on/src/lib/ipfs-request.js'
@@ -10,9 +13,34 @@ import createRuntimeChecks from '../../../add-on/src/lib/runtime-checks.js'
 import { initState } from '../../../add-on/src/lib/state.js'
 import { ensureCallRedirected, ensureRequestUntouched } from '../../helpers/mv3-test-helper.js'
 
+const testTabId = 20
 const url2request = (string) => {
-  return { url: string, type: 'main_frame' }
+  return { url: string, type: 'main_frame', tabId: testTabId }
 }
+
+// The explainer shown instead of silently fixing up an address, or forwarding
+// one to a gateway that can only answer with an error.
+const invalidAddressPage = (params) =>
+  `chrome-extension://testid/dist/landing-pages/invalid-address/index.html#${new URLSearchParams(params).toString()}`
+
+/**
+ * The explainer is a verdict on one address, so it must reach the user by
+ * navigating the tab and must NEVER become a declarativeNetRequest rule. A rule
+ * matches by pattern and would go on to serve this verdict to unrelated URLs on
+ * the same host, which once turned a single bad address into a redirect for
+ * every later search. Asserting no rule is installed is the regression guard.
+ */
+const ensureInvalidAddressPageShown = ({ resp, page }) => {
+  if (isManifestV3) {
+    Sinon.assert.notCalled(browser.declarativeNetRequest.updateDynamicRules)
+    Sinon.assert.calledWith(browser.tabs.update, testTabId, { active: true, url: page })
+  } else {
+    expect(resp.redirectUrl).to.equal(page)
+  }
+}
+
+const lowercasedCidv0 = 'QmUVTKsrYJpaxUT7dr9FpKq6AoKHhEM7eG1ZHGL56haKLG'.toLowerCase()
+const ipnsKey = 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'
 
 const nodeTypes = ['external']
 
@@ -94,16 +122,20 @@ describe('modifyRequest.onBeforeRequest:', function () {
             }
           })
         })
-        it('should be normalized if ipfs://{fqdn}', async function () {
+        // a DNSLink name under ipfs:// used to be corrected in silence, which
+        // let the wrong form spread: https://github.com/ipfs/ipfs-companion/issues/1316
+        it('should explain the mistake if ipfs://{fqdn}', async function () {
           const request = url2request('https://dweb.link/ipfs/?uri=ipfs%3A%2F%2Fipfs.io%3FargTest%23hashTest')
+          const page = invalidAddressPage({
+            reason: 'dnslink-under-ipfs',
+            address: 'ipfs://ipfs.io?argTest#hashTest',
+            suggestedAddress: 'ipns://ipfs.io?argTest#hashTest',
+            suggestedUrl: 'https://ipfs.io/ipns/ipfs.io?argTest#hashTest'
+          })
 
-          ensureCallRedirected({
-            modifiedRequestCallResp: await modifyRequest.onBeforeRequest(request),
-            MV2Expectation: 'https://ipfs.io/ipns/ipfs.io?argTest#hashTest',
-            MV3Expectation: {
-              origin: '^https?\\:\\/\\/dweb\\.link\\/ipfs\\/\\?uri\\=ipfs%3A%2F%2Fipfs\\.io%3FargTest%23',
-              destination: 'https://ipfs.io/ipns/ipfs.io?argTest#\\1'
-            }
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
           })
         })
         it('should be normalized if dweb:/ipfs/{CID}', async function () {
@@ -257,16 +289,18 @@ describe('modifyRequest.onBeforeRequest:', function () {
             }
           })
         })
-        it('should be normalized if ipfs://{fqdn}', async function () {
+        it('should explain the mistake if ipfs://{fqdn}', async function () {
           const request = url2request('https://duckduckgo.com/?q=ipfs%3A%2F%2Fipns.io%2Findex.html%3Farg%3Dfoo%26bar%3Dbuzz%23hashTest')
+          const page = invalidAddressPage({
+            reason: 'dnslink-under-ipfs',
+            address: 'ipfs://ipns.io/index.html?arg=foo&bar=buzz#hashTest',
+            suggestedAddress: 'ipns://ipns.io/index.html?arg=foo&bar=buzz#hashTest',
+            suggestedUrl: 'https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest'
+          })
 
-          ensureCallRedirected({
-            modifiedRequestCallResp: await modifyRequest.onBeforeRequest(request),
-            MV2Expectation: 'https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#hashTest',
-            MV3Expectation: {
-              origin: '^https?\\:\\/\\/duckduckgo\\.com\\/\\?q\\=ipfs%3A%2F%2Fipns\\.io%2Findex\\.html%3Farg%3Dfoo%26bar%3Dbuzz%23',
-              destination: 'https://ipfs.io/ipns/ipns.io/index.html?arg=foo&bar=buzz#\\1'
-            }
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
           })
         })
         it('should be normalized if dweb:/ipfs/{CID}', async function () {
@@ -395,6 +429,75 @@ describe('modifyRequest.onBeforeRequest:', function () {
           const mediaRequest = { url: 'https://duckduckgo.com/?q=ipfs%3A%2FQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR%3FargTest%23hashTest&foo=bar', type: 'media' }
 
           ensureRequestUntouched(await modifyRequest.onBeforeRequest(mediaRequest))
+        })
+      })
+
+      describe('explaining an address that cannot be opened as written', function () {
+        it('should explain an IPNS key addressed with ipfs://', async function () {
+          const request = url2request(`https://duckduckgo.com/?q=ipfs%3A%2F%2F${ipnsKey}`)
+          const page = invalidAddressPage({
+            reason: 'ipns-key-under-ipfs',
+            address: `ipfs://${ipnsKey}`,
+            suggestedAddress: `ipns://${ipnsKey}`,
+            suggestedUrl: `https://ipfs.io/ipns/${ipnsKey}`
+          })
+
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
+          })
+        })
+
+        // the browser lowercases the authority before we ever see the request,
+        // and base58btc cannot survive that: https://github.com/ipfs/ipfs-companion/issues/1006
+        it('should explain a CIDv0 the browser lowercased under ipfs://', async function () {
+          const request = url2request(`https://duckduckgo.com/?q=ipfs%3A%2F%2F${lowercasedCidv0}`)
+          const page = invalidAddressPage({
+            reason: 'lowercased-cidv0',
+            address: `ipfs://${lowercasedCidv0}`
+          })
+
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
+          })
+        })
+
+        it('should explain a CIDv0 the browser lowercased under ipns://', async function () {
+          const request = url2request(`https://duckduckgo.com/?q=ipns%3A%2F%2F${lowercasedCidv0}`)
+          const page = invalidAddressPage({
+            reason: 'lowercased-cidv0',
+            address: `ipns://${lowercasedCidv0}`
+          })
+
+          ensureInvalidAddressPageShown({
+            resp: await modifyRequest.onBeforeRequest(request),
+            page
+          })
+        })
+
+        // a CID that is merely unfamiliar must still reach the gateway: a
+        // base58btc CIDv1 with a dotted sub-path looks like a hostname to a
+        // naive check, and breaking it would be worse than showing nothing
+        it('should send an unusual but valid CID to the gateway untouched', async function () {
+          const cid = 'zdj7WWeQ43G6JJvLWQWZpyHuAMq6uYWRjkBXFad11vE2LHhQ7'
+          const request = url2request(`https://duckduckgo.com/?q=ipfs%3A%2F%2F${cid}%2Fdir%2Findex.html`)
+
+          ensureCallRedirected({
+            modifiedRequestCallResp: await modifyRequest.onBeforeRequest(request),
+            MV2Expectation: `https://ipfs.io/ipfs/${cid}/dir/index.html`,
+            MV3Expectation: {
+              origin: `^https?\\:\\/\\/duckduckgo\\.com\\/\\?q\\=ipfs%3A%2F%2F${cid}%2Fdir%2F`,
+              destination: `https://ipfs.io/ipfs/${cid}/dir/\\1`
+            }
+          })
+        })
+
+        it('should not explain anything if disabled in Preferences', async function () {
+          state.catchUnhandledProtocols = false
+          const request = url2request(`https://duckduckgo.com/?q=ipfs%3A%2F%2F${lowercasedCidv0}`)
+
+          ensureRequestUntouched(await modifyRequest.onBeforeRequest(request))
         })
       })
     })


### PR DESCRIPTION
## Problem

`ipfs://docs.ipfs.tech` is not a valid address. A website name is mutable, so it belongs under `ipns://`. Companion rewrote it to `/ipns/` in silence anyway, so the broken form kept spreading; I've had to email blog authors asking them to fix it by hand. Others failed worse: a lowercased `Qm…` CID, or a typo like `ipfs://exmaple`, went to a public gateway that leaked the lookup and returned an error nobody can act on.

## Fix

Each stops on an explainer page instead.

`ipfs://<website name>` and `ipfs://<IPNS key>` say why the namespace is wrong, then offer one click to the corrected address:

> <img width="1689" height="1107" alt="2026-07-20_16-13_1" src="https://github.com/user-attachments/assets/2618a598-a202-44bb-97e8-ada8f86409f5" />

A lowercased CIDv0 can't be recovered, so the page says so and points at cid.ipfs.tech for a Base32 CIDv1:

> <img width="1694" height="921" alt="2026-07-20_16-13" src="https://github.com/user-attachments/assets/2055cc6a-f5fc-4448-a29a-6cd824342e18" />

Anything else that can't resolve, a typo or an identifier truncated when copied, gets a plain "check this" page rather than a gateway error:

> <img width="1682" height="758" alt="2026-07-20_17-40" src="https://github.com/user-attachments/assets/8b12998f-0796-4492-8cb4-21748ee347d3" />


Detection matches the broken address, not the browser, so it only fires on addresses that were already going to fail. Valid addresses, in any CID base or IPNS form, are untouched.

- Closes #1316
- Closes #1006
- Closes #1133