### PR TITLE
feat: upload folders in quick upload

### DIFF
--- a/add-on/_locales/en/messages.json
+++ b/add-on/_locales/en/messages.json
@@ -607,6 +607,10 @@
     "message": "Pick a file",
     "description": "Text on the 'pick a file' button (quickImport_pick_file_button)"
   },
+  "quickImport_pick_folder_button": {
+    "message": "Pick a folder",
+    "description": "Text on the 'pick a folder' button that keeps directory structure (quickImport_pick_folder_button)"
+  },
   "quickImport_or": {
     "message": "or",
     "description": "seperates the pick a file button from the drop message (quickImport_or)"

--- a/add-on/src/lib/ipfs-import.js
+++ b/add-on/src/lib/ipfs-import.js
@@ -47,9 +47,12 @@ export function createIpfsImportHandler (getState, getIpfs, ipfsPathValidator, r
       const ipfs = getIpfs()
       // cp will fail if directory does not exist
       await ipfs.files.mkdir(importDir, { parents: true })
-      // remove directory from files API import files
-      const files = results.filter(file => (file.path !== ''))
-      for (const file of files) {
+      // Copy only the top-level entries. addAll returns an entry for every
+      // file and directory in the tree, but a directory's CID already contains
+      // its whole subtree; copying the top-level nodes pulls nested folders in
+      // and avoids cp'ing a nested file before its parent exists in MFS.
+      const topLevel = results.filter(file => file.path !== '' && !file.path.includes('/'))
+      for (const file of topLevel) {
         await ipfs.files.cp(`/ipfs/${file.cid}`, `${importDir}${file.path}`)
       }
       log(`created import dir at ${importDir}`)

--- a/add-on/src/lib/quick-import-sources.js
+++ b/add-on/src/lib/quick-import-sources.js
@@ -14,3 +14,55 @@ export async function * fileListSource (fileList) {
     yield { path: file.webkitRelativePath || file.name, file }
   }
 }
+
+// dataTransfer comes from a drop event. Its items expose FileSystemEntry via
+// webkitGetAsEntry(), which is the only cross-browser way to see a dropped
+// folder's contents; the flat dataTransfer.files list drops directories. When
+// no entry is available (e.g. content dragged from another app) we fall back
+// to the flat list.
+export async function * dataTransferSource (dataTransfer) {
+  const items = dataTransfer.items ? Array.from(dataTransfer.items) : []
+  let walkedEntries = false
+  for (const item of items) {
+    if (item.kind !== 'file') continue
+    const entry = typeof item.webkitGetAsEntry === 'function' ? item.webkitGetAsEntry() : null
+    if (entry) {
+      walkedEntries = true
+      yield * fileSystemEntrySource(entry)
+    }
+  }
+  if (!walkedEntries) {
+    yield * fileListSource(dataTransfer.files)
+  }
+}
+
+// FileSystemEntry is a node in the tree exposed by webkitGetAsEntry(). Files
+// are yielded directly; directories are read in full and walked recursively,
+// with each level prefixed onto the path so the tree is preserved.
+export async function * fileSystemEntrySource (entry, prefix = '') {
+  const path = prefix ? `${prefix}/${entry.name}` : entry.name
+  if (entry.isFile) {
+    yield { path, file: await fileFromEntry(entry) }
+  } else if (entry.isDirectory) {
+    const reader = entry.createReader()
+    for (const child of await readAllEntries(reader)) {
+      yield * fileSystemEntrySource(child, path)
+    }
+  }
+}
+
+function fileFromEntry (entry) {
+  return new Promise((resolve, reject) => entry.file(resolve, reject))
+}
+
+// readEntries returns the directory in batches (often capped around 100), so
+// it must be called until it reports an empty batch.
+async function readAllEntries (reader) {
+  const entries = []
+  let batch
+  do {
+    batch = await new Promise((resolve, reject) => reader.readEntries(resolve, reject))
+    entries.push(...batch)
+  } while (batch.length > 0)
+  return entries
+}

--- a/add-on/src/lib/quick-import-sources.js
+++ b/add-on/src/lib/quick-import-sources.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// Normalizers that turn the various browser file APIs into a single stream of
+// { path, file } entries ready for ipfs.addAll. `path` keeps the directory
+// structure the user picked (e.g. photos/2024/cat.jpg); `file` is a browser
+// File, so its contents are only read when addAll pulls them.
+
+// FileList comes from <input type="file"> (both single files and, with the
+// webkitdirectory attribute, whole folders). webkitRelativePath carries the
+// path within a picked folder; a plain multi-file selection leaves it empty,
+// so we fall back to the file name.
+export async function * fileListSource (fileList) {
+  for (const file of fileList) {
+    yield { path: file.webkitRelativePath || file.name, file }
+  }
+}

--- a/add-on/src/lib/quick-import-sources.js
+++ b/add-on/src/lib/quick-import-sources.js
@@ -16,23 +16,35 @@ export async function * fileListSource (fileList) {
 }
 
 // dataTransfer comes from a drop event. Its items expose FileSystemEntry via
-// webkitGetAsEntry(), which is the only cross-browser way to see a dropped
-// folder's contents; the flat dataTransfer.files list drops directories. When
-// no entry is available (e.g. content dragged from another app) we fall back
-// to the flat list.
-export async function * dataTransferSource (dataTransfer) {
+// webkitGetAsEntry(), the only cross-browser way to see a dropped folder's
+// contents; the flat dataTransfer.files list drops directories.
+//
+// This runs synchronously: DataTransferItem objects (and the entries they
+// hand out) are only valid during the drop event, so the entries have to be
+// grabbed now, before processFiles awaits anything. The FileSystemEntry
+// objects stay usable afterwards, so the tree is walked lazily below.
+export function dataTransferSource (dataTransfer) {
+  const entries = []
   const items = dataTransfer.items ? Array.from(dataTransfer.items) : []
-  let walkedEntries = false
   for (const item of items) {
     if (item.kind !== 'file') continue
     const entry = typeof item.webkitGetAsEntry === 'function' ? item.webkitGetAsEntry() : null
-    if (entry) {
-      walkedEntries = true
-      yield * fileSystemEntrySource(entry)
-    }
+    if (entry) entries.push(entry)
   }
-  if (!walkedEntries) {
-    yield * fileListSource(dataTransfer.files)
+  const files = Array.from(dataTransfer.files || [])
+  return walkDroppedItems(entries, files)
+}
+
+async function * walkDroppedItems (entries, files) {
+  if (entries.length) {
+    for (const entry of entries) yield * fileSystemEntrySource(entry)
+  } else if (files.length) {
+    // no FileSystemEntry (e.g. an older browser); use the flat file list
+    yield * fileListSource(files)
+  } else {
+    // dropped something that is neither files nor a folder (text, a link, an
+    // image from another tab). Tell the user rather than failing silently.
+    throw new Error('that drop is not a file or folder. Drop files or a folder from your file manager, or use the buttons above')
   }
 }
 

--- a/add-on/src/popup/quick-import.js
+++ b/add-on/src/popup/quick-import.js
@@ -4,14 +4,13 @@ import './quick-import.css'
 
 import choo from 'choo'
 import html from 'choo/html/index.js'
-import drop from 'drag-and-drop-files'
 import { filesize } from 'filesize'
 import all from 'it-all'
 import browser from 'webextension-polyfill'
 import * as externalApiClient from '../lib/ipfs-client/external.js'
 import createIpfsCompanion from '../lib/ipfs-companion.js'
 import { formatImportDirectory } from '../lib/ipfs-import.js'
-import { fileListSource } from '../lib/quick-import-sources.js'
+import { dataTransferSource, fileListSource } from '../lib/quick-import-sources.js'
 import logo from './logo.js'
 import { POSSIBLE_NODE_TYPES } from '../lib/state.js'
 
@@ -69,8 +68,15 @@ function quickImportStore (state, emitter) {
     browser.storage.local.set({ [key]: value })
   })
 
-  // drag & drop anywhere
-  drop(document.body, files => processFiles(state, emitter, fileListSource(files)))
+  // drag & drop anywhere; handle the event ourselves so dropped folders are
+  // walked via FileSystemEntry instead of being flattened to loose files
+  const stop = (event) => { event.stopPropagation(); event.preventDefault() }
+  document.body.addEventListener('dragenter', stop)
+  document.body.addEventListener('dragover', stop)
+  document.body.addEventListener('drop', (event) => {
+    stop(event)
+    processFiles(state, emitter, dataTransferSource(event.dataTransfer))
+  })
 }
 
 // Drain an async source of { path, file } entries into an array. Directory

--- a/add-on/src/popup/quick-import.js
+++ b/add-on/src/popup/quick-import.js
@@ -220,7 +220,6 @@ function quickImportOptions (state, emit) {
 function quickImportPage (state, emit) {
   const onFileInputChange = (e) => emit('fileInputChange', e)
   const onFolderInputChange = (e) => emit('folderInputChange', e)
-  const onPickFolder = () => document.getElementById('quickImportFolderInput').click()
   const { peerCount } = state
 
   return html`
@@ -241,28 +240,26 @@ function quickImportPage (state, emit) {
             </p>
           </div>
         </header>
-        <label for="quickImportInput" class='db relative mt5 hover-inner-shadow pointer' style="border:solid 2px #6ACAD1">
-          <input class="db pointer w-100 h-100 top-0 o-0" type="file" id="quickImportInput" multiple onchange=${onFileInputChange} />
-          <div class='dt dim' style='padding-left: 100px; height: 300px'>
-            <div class='dtc v-mid'>
-              <span class="f3 dim br1 ph4 pv3 dib navy" style="background: #6ACAD1">
+        <div class='db relative mt5 hover-inner-shadow' style="border:solid 2px #6ACAD1">
+          <div class='dt' style='height: 300px; width: 100%'>
+            <div class='dtc v-mid tc'>
+              <label class="f3 dim br1 ph4 pv3 dib navy pointer" style="background: #6ACAD1">
                 ${browser.i18n.getMessage('quickImport_pick_file_button')}
-              </span>
-              <span class='f3'>
-                <emph class='underline pl3 pr2 moon-gray'>
+                <input class="clip" type="file" id="quickImportInput" multiple onchange=${onFileInputChange} />
+              </label>
+              <label class="f3 dim br1 ph4 pv3 dib navy pointer ml3" style="background: #6ACAD1">
+                ${browser.i18n.getMessage('quickImport_pick_folder_button')}
+                <input class="clip" type="file" id="quickImportFolderInput" webkitdirectory multiple onchange=${onFolderInputChange} />
+              </label>
+              <p class='f3 mt4 mb0'>
+                <emph class='underline pr2 moon-gray'>
                   ${browser.i18n.getMessage('quickImport_or')}
                 </emph>
                 ${browser.i18n.getMessage('quickImport_drop_it_here')}
-              </span>
+              </p>
               <p class='f4 db'>${state.message}<span class='code db absolute fr pv2'>${state.progress}</span></p>
             </div>
           </div>
-        </label>
-        <div class='tc mt3'>
-          <input class='dn' type='file' id='quickImportFolderInput' webkitdirectory multiple onchange=${onFolderInputChange} />
-          <button class='f6 lh-copy link bn bg-transparent dib pa0 pointer' style='color: #6ACAD1' onclick=${onPickFolder}>
-            ${browser.i18n.getMessage('quickImport_pick_folder_button')} »
-          </button>
         </div>
         ${quickImportOptions(state, emit)}
       </div>

--- a/add-on/src/popup/quick-import.js
+++ b/add-on/src/popup/quick-import.js
@@ -11,6 +11,7 @@ import browser from 'webextension-polyfill'
 import * as externalApiClient from '../lib/ipfs-client/external.js'
 import createIpfsCompanion from '../lib/ipfs-companion.js'
 import { formatImportDirectory } from '../lib/ipfs-import.js'
+import { fileListSource } from '../lib/quick-import-sources.js'
 import logo from './logo.js'
 import { POSSIBLE_NODE_TYPES } from '../lib/state.js'
 
@@ -60,7 +61,8 @@ function quickImportStore (state, emitter) {
     })
   })
 
-  emitter.on('fileInputChange', event => processFiles(state, emitter, event.target.files))
+  emitter.on('fileInputChange', event => processFiles(state, emitter, fileListSource(event.target.files)))
+  emitter.on('folderInputChange', event => processFiles(state, emitter, fileListSource(event.target.files)))
 
   // update companion preference
   emitter.on('optionChange', ({ key, value }) => {
@@ -68,20 +70,31 @@ function quickImportStore (state, emitter) {
   })
 
   // drag & drop anywhere
-  drop(document.body, files => processFiles(state, emitter, files))
+  drop(document.body, files => processFiles(state, emitter, fileListSource(files)))
 }
 
-async function processFiles (state, emitter, files) {
-  console.log('Processing files', files)
+// Drain an async source of { path, file } entries into an array. Directory
+// walking only reads listings here, not file contents, so this stays cheap
+// even for large folders.
+async function collectEntries (source) {
+  const entries = []
+  for await (const entry of source) {
+    entries.push(entry)
+  }
+  return entries
+}
+
+async function processFiles (state, emitter, source) {
   const ipfsCompanion = await createIpfsCompanion(true)
   try {
-    console.log('importing files', files)
-    if (!files.length) {
-      // File list may be empty in some rare cases
+    const entries = await collectEntries(source)
+    if (!entries.length) {
+      // Source may be empty in some rare cases
       // eg. when user drags something from proprietary browser context
       // We just ignore those UI interactions.
       throw new Error('found no valid sources, try selecting a local file instead')
     }
+    console.log('importing files', entries)
     const {
       copyImportResultsToFiles,
       copyShareLink,
@@ -95,9 +108,9 @@ async function processFiles (state, emitter, files) {
 
     const data = []
     let total = 0
-    for (const file of files) {
+    for (const { path, file } of entries) {
       data.push({
-        path: file.name,
+        path,
         content: (httpStreaming ? file : file.stream())
       })
       total += file.size
@@ -138,7 +151,7 @@ async function processFiles (state, emitter, files) {
     await copyImportResultsToFiles(results, importDir)
     state.progress = 'Completed'
     emitter.emit('render')
-    console.log(`Successfully imported ${files.length} files`)
+    console.log(`Successfully imported ${entries.length} files`)
 
     // copy shareable URL & preload
     copyShareLink(results)
@@ -200,6 +213,8 @@ function quickImportOptions (state, emit) {
 
 function quickImportPage (state, emit) {
   const onFileInputChange = (e) => emit('fileInputChange', e)
+  const onFolderInputChange = (e) => emit('folderInputChange', e)
+  const onPickFolder = () => document.getElementById('quickImportFolderInput').click()
   const { peerCount } = state
 
   return html`
@@ -237,6 +252,12 @@ function quickImportPage (state, emit) {
             </div>
           </div>
         </label>
+        <div class='tc mt3'>
+          <input class='dn' type='file' id='quickImportFolderInput' webkitdirectory multiple onchange=${onFolderInputChange} />
+          <button class='f6 lh-copy link bn bg-transparent dib pa0 pointer' style='color: #6ACAD1' onclick=${onPickFolder}>
+            ${browser.i18n.getMessage('quickImport_pick_folder_button')} »
+          </button>
+        </div>
         ${quickImportOptions(state, emit)}
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@material/switch": "10.0.0",
         "choo": "7.1.0",
         "debug": "4.4.3",
-        "drag-and-drop-files": "0.0.1",
         "filesize": "11.0.19",
         "ipfs-css": "1.4.0",
         "is-fqdn": "2.0.1",
@@ -4951,12 +4950,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/drag-and-drop-files": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/drag-and-drop-files/-/drag-and-drop-files-0.0.1.tgz",
-      "integrity": "sha512-Tx3sLLMM93vXs70BkXY4W9FPK85td2TFM/7Vc5zzAOWM07MsmbyIijfTuol60g7W5lAXqE2aGH1DG6QRBgp+5w==",
-      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@material/switch": "10.0.0",
     "choo": "7.1.0",
     "debug": "4.4.3",
-    "drag-and-drop-files": "0.0.1",
     "filesize": "11.0.19",
     "ipfs-css": "1.4.0",
     "is-fqdn": "2.0.1",

--- a/test/functional/lib/ipfs-import.test.js
+++ b/test/functional/lib/ipfs-import.test.js
@@ -118,7 +118,7 @@ describe('ipfs-import.js', function () {
         const resultFiles = [
           {
             cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa',
-            path: '/tmp/test-file1'
+            path: 'test-file1'
           },
           {
             cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqb',
@@ -126,19 +126,47 @@ describe('ipfs-import.js', function () {
           },
           {
             cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqc',
-            path: '/tmp/test-file2'
+            path: 'test-file2'
           }
         ]
         getIpfs.returns(ipfs)
-        await ipfsImportHandler.copyImportResultsToFiles(resultFiles, '/my-directory')
-        sinon.assert.calledWith(mkdirSpy, '/my-directory')
+        await ipfsImportHandler.copyImportResultsToFiles(resultFiles, '/my-directory/')
+        sinon.assert.calledWith(mkdirSpy, '/my-directory/')
         expect(cpSpy.getCalls()[0].args).to.deep.equal([
           '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa',
-          '/my-directory/tmp/test-file1'
+          '/my-directory/test-file1'
         ])
         expect(cpSpy.getCalls()[1].args).to.deep.equal([
           '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqc',
-          '/my-directory/tmp/test-file2'
+          '/my-directory/test-file2'
+        ])
+      })
+
+      it('should copy only the top-level node when importing a folder', async function () {
+        const cpSpy = sandbox.spy()
+        const mkdirSpy = sandbox.spy()
+        const ipfs = { files: { cp: cpSpy, mkdir: mkdirSpy } }
+        // addAll output for a folder: a nested file, its parent dir, the root
+        const resultFiles = [
+          {
+            cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqa',
+            path: 'sad-cats/download.png'
+          },
+          {
+            cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqb',
+            path: 'sad-cats'
+          },
+          {
+            cid: 'bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqc',
+            path: ''
+          }
+        ]
+        getIpfs.returns(ipfs)
+        await ipfsImportHandler.copyImportResultsToFiles(resultFiles, '/my-directory/')
+        sinon.assert.calledOnce(cpSpy)
+        expect(cpSpy.getCall(0).args).to.deep.equal([
+          '/ipfs/bafybeicgmdpvw4duutrmdxl4a7gc52sxyuk7nz5gby77afwdteh3jc5bqb',
+          '/my-directory/sad-cats'
         ])
       })
     })

--- a/test/functional/lib/quick-import-sources.test.js
+++ b/test/functional/lib/quick-import-sources.test.js
@@ -101,13 +101,35 @@ describe('quick-import-sources.js', function () {
       expect(entries.map(e => e.path)).to.deep.equal(['root/a.txt', 'root/b.txt'])
     })
 
-    it('ignores non-file items', async function () {
+    it('rejects with a friendly error for an unsupported drop', async function () {
       const dataTransfer = {
         items: [{ kind: 'string', webkitGetAsEntry: () => null }],
         files: []
       }
-      const entries = await collect(dataTransferSource(dataTransfer))
-      expect(entries).to.deep.equal([])
+      let err
+      try {
+        await collect(dataTransferSource(dataTransfer))
+      } catch (e) {
+        err = e
+      }
+      expect(err).to.be.an('error')
+      expect(err.message).to.match(/not a file or folder/)
+    })
+
+    it('snapshots dropped entries synchronously, before iteration', async function () {
+      // DataTransferItem objects are only valid during the drop event, so
+      // webkitGetAsEntry must be called when dataTransferSource is invoked,
+      // not lazily when the returned source is later drained.
+      const tree = dirEntry('root', [fileEntry('a.txt')])
+      let called = false
+      const dataTransfer = {
+        items: [{ kind: 'file', webkitGetAsEntry: () => { called = true; return tree } }],
+        files: []
+      }
+      const source = dataTransferSource(dataTransfer)
+      expect(called).to.equal(true)
+      const entries = await collect(source)
+      expect(entries.map(e => e.path)).to.deep.equal(['root/a.txt'])
     })
 
     it('falls back to the flat file list when no entry is available', async function () {

--- a/test/functional/lib/quick-import-sources.test.js
+++ b/test/functional/lib/quick-import-sources.test.js
@@ -1,0 +1,44 @@
+'use strict'
+import { expect } from 'chai'
+import { describe, it } from 'vitest'
+import { fileListSource } from '../../../add-on/src/lib/quick-import-sources.js'
+
+async function collect (source) {
+  const out = []
+  for await (const entry of source) out.push(entry)
+  return out
+}
+
+// Minimal File stand-in: the sources only read name/webkitRelativePath and
+// pass the object straight through to addAll.
+function fakeFile (name, webkitRelativePath = '') {
+  return { name, webkitRelativePath, size: 1 }
+}
+
+describe('quick-import-sources.js', function () {
+  describe('fileListSource', function () {
+    it('uses file name as path for a flat selection', async function () {
+      const files = [fakeFile('a.txt'), fakeFile('b.txt')]
+      const entries = await collect(fileListSource(files))
+      expect(entries.map(e => e.path)).to.deep.equal(['a.txt', 'b.txt'])
+      expect(entries[0].file).to.equal(files[0])
+    })
+
+    it('keeps directory structure from webkitRelativePath', async function () {
+      const files = [
+        fakeFile('cat.jpg', 'photos/2024/cat.jpg'),
+        fakeFile('dog.jpg', 'photos/2024/dog.jpg')
+      ]
+      const entries = await collect(fileListSource(files))
+      expect(entries.map(e => e.path)).to.deep.equal([
+        'photos/2024/cat.jpg',
+        'photos/2024/dog.jpg'
+      ])
+    })
+
+    it('yields nothing for an empty list', async function () {
+      const entries = await collect(fileListSource([]))
+      expect(entries).to.deep.equal([])
+    })
+  })
+})

--- a/test/functional/lib/quick-import-sources.test.js
+++ b/test/functional/lib/quick-import-sources.test.js
@@ -1,7 +1,11 @@
 'use strict'
 import { expect } from 'chai'
 import { describe, it } from 'vitest'
-import { fileListSource } from '../../../add-on/src/lib/quick-import-sources.js'
+import {
+  dataTransferSource,
+  fileListSource,
+  fileSystemEntrySource
+} from '../../../add-on/src/lib/quick-import-sources.js'
 
 async function collect (source) {
   const out = []
@@ -13,6 +17,31 @@ async function collect (source) {
 // pass the object straight through to addAll.
 function fakeFile (name, webkitRelativePath = '') {
   return { name, webkitRelativePath, size: 1 }
+}
+
+// Mimic a FileSystemFileEntry: entry.file(cb) hands back the File.
+function fileEntry (name) {
+  return { name, isFile: true, isDirectory: false, file: (cb) => cb(fakeFile(name)) }
+}
+
+// Mimic a FileSystemDirectoryEntry whose reader yields children in one batch,
+// then an empty batch (the readEntries contract).
+function dirEntry (name, children) {
+  return {
+    name,
+    isFile: false,
+    isDirectory: true,
+    createReader () {
+      let done = false
+      return {
+        readEntries (cb) {
+          if (done) return cb([])
+          done = true
+          cb(children)
+        }
+      }
+    }
+  }
 }
 
 describe('quick-import-sources.js', function () {
@@ -39,6 +68,62 @@ describe('quick-import-sources.js', function () {
     it('yields nothing for an empty list', async function () {
       const entries = await collect(fileListSource([]))
       expect(entries).to.deep.equal([])
+    })
+  })
+
+  describe('fileSystemEntrySource', function () {
+    it('yields a single file entry at the top level', async function () {
+      const entries = await collect(fileSystemEntrySource(fileEntry('a.txt')))
+      expect(entries.map(e => e.path)).to.deep.equal(['a.txt'])
+    })
+
+    it('walks a nested directory and prefixes each level onto the path', async function () {
+      const tree = dirEntry('root', [
+        fileEntry('top.txt'),
+        dirEntry('sub', [fileEntry('deep.txt')])
+      ])
+      const entries = await collect(fileSystemEntrySource(tree))
+      expect(entries.map(e => e.path)).to.deep.equal([
+        'root/top.txt',
+        'root/sub/deep.txt'
+      ])
+    })
+  })
+
+  describe('dataTransferSource', function () {
+    it('walks dropped folders via webkitGetAsEntry', async function () {
+      const tree = dirEntry('root', [fileEntry('a.txt'), fileEntry('b.txt')])
+      const dataTransfer = {
+        items: [{ kind: 'file', webkitGetAsEntry: () => tree }],
+        files: []
+      }
+      const entries = await collect(dataTransferSource(dataTransfer))
+      expect(entries.map(e => e.path)).to.deep.equal(['root/a.txt', 'root/b.txt'])
+    })
+
+    it('ignores non-file items', async function () {
+      const dataTransfer = {
+        items: [{ kind: 'string', webkitGetAsEntry: () => null }],
+        files: []
+      }
+      const entries = await collect(dataTransferSource(dataTransfer))
+      expect(entries).to.deep.equal([])
+    })
+
+    it('falls back to the flat file list when no entry is available', async function () {
+      const files = [fakeFile('a.txt'), fakeFile('b.txt')]
+      const dataTransfer = {
+        items: [{ kind: 'file', webkitGetAsEntry: () => null }],
+        files
+      }
+      const entries = await collect(dataTransferSource(dataTransfer))
+      expect(entries.map(e => e.path)).to.deep.equal(['a.txt', 'b.txt'])
+    })
+
+    it('falls back to the flat file list when items are unavailable', async function () {
+      const files = [fakeFile('a.txt')]
+      const entries = await collect(dataTransferSource({ files }))
+      expect(entries.map(e => e.path)).to.deep.equal(['a.txt'])
     })
   })
 })


### PR DESCRIPTION


> <img width="1010" height="741" alt="2026-07-20_21-11" src="https://github.com/user-attachments/assets/a87bf379-2c8e-4b37-83a8-272f5499393c" />

## Problem

Quick Upload only handled loose files. Picking a folder flattened everything to bare filenames, so the folder tree was lost and two files with the same name in different subfolders overwrote each other. Dropping a folder added nothing at all.

## Fix

- a "Pick a folder" button, equal weight beside "Pick a file"
- picking or dropping a folder keeps its structure and imports as one directory
- a clear message when you drop something that isn't files or a folder, instead of quietly doing nothing

You can now share a whole folder in one action and get a single CID that mirrors your local layout. Single-file uploads work exactly as before.

Tested on the latest Firefox and Chrome.

- Closes #1355
- Closes #396
