### PR TITLE
docs: add changelog title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [3.3.0](https://github.com/ipfs/ipfs-companion/compare/v3.2.0...v3.3.0) (2025-09-27)
 
 ## What's Changed


### PR DESCRIPTION
release-please locates its insertion point with a regex that needs a newline before the first version header. Without a top-level title the first entry sits at the start of the file and gets skipped, so new releases land below it. The title fixes ordering for every future release.