### PR TITLE
docs: refresh outdated content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,25 @@
 
 IPFS Companion is a Manifest V3 browser extension for Chromium and Firefox. For build and run details start with the [developer notes](docs/DEVELOPER-NOTES.md); see [CONTRIBUTING.md](docs/CONTRIBUTING.md) for the contribution flow and [docs/MV3.md](docs/MV3.md) for the MV3 architecture.
 
+## Values that constrain changes
+
+IPFS Companion gives people local-first, content-addressed access to the web,
+with the user in control of their own machine and browsing. The rules below are
+hard constraints on every change, ahead of passing tests. The user-facing
+version lives in [PRIVACY-POLICY.md](PRIVACY-POLICY.md).
+
+- Never track the user. No analytics, telemetry, or phone-home. Outbound
+  requests belong to a feature the user asked for (a gateway fetch, an RPC call
+  to their own node), never measurement.
+- Never leak browsing activity. The extension sees every URL the user visits;
+  that data stays on the machine and goes to no third party.
+- Preserve user agency. Automatic behavior (redirects, gateway choice, node
+  connection) stays under the user's control with a visible off switch. Removing
+  one is a breaking change.
+- Never weaken security. Do not trust remote input (a site-controlled header, a
+  page's script) to change how traffic is routed or rendered, and keep per-site
+  origin isolation intact.
+
 ## Setup
 
 Node and npm versions come from `.nvmrc` and `engines` in `package.json`. Install with `npm ci`, or use `npm run dev-build` for an all-in-one install plus build.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">IPFS Companion Browser Extension</h1>
 
-<p align="center" style="font-size: 1.2rem;">Harness the power of <a href="https://ipfs.tech">IPFS</a> in your browser!</p>
+<p align="center" style="font-size: 1.2rem;">Use <a href="https://ipfs.tech">IPFS</a> directly in your browser</p>
 
 <p align="center">
   <a href="https://ipfs.tech"><img src="https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square" alt="Official Part of IPFS Project"></a>
@@ -43,7 +43,7 @@
 
 ## About IPFS Companion
 
-IPFS Companion harnesses the power of your locally running IPFS [Kubo](https://github.com/ipfs/kubo) node (either through the [IPFS Desktop](https://docs.ipfs.tech/install/ipfs-desktop/) app or the [command-line daemon](https://docs.ipfs.tech/install/command-line/)) directly inside your favorite Chromium-based or Firefox browser, enabling support for [`ipfs://` addresses](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#native-urls), redirecting content-addressed websites and file paths to your local [Gateway](https://docs.ipfs.tech/concepts/glossary/#gateway), easy IPFS file import and sharing, and more.
+IPFS Companion connects your browser to your local IPFS [Kubo](https://github.com/ipfs/kubo) node (either through the [IPFS Desktop](https://docs.ipfs.tech/install/ipfs-desktop/) app or the [command-line daemon](https://docs.ipfs.tech/install/command-line/)), running inside your Chromium-based or Firefox browser, with support for [`ipfs://` addresses](https://docs.ipfs.tech/how-to/address-ipfs-on-web/#native-urls), redirecting content-addressed websites and file paths to your local [Gateway](https://docs.ipfs.tech/concepts/glossary/#gateway), easy IPFS file import and sharing, and more.
 
 IPFS is a peer-to-peer hypermedia protocol designed to make the web faster, safer, more resilient, and more open. It enables completely distributed sites and applications that don’t rely on centralized hosting and stay true to the original vision of an open, flat web. Visit [the IPFS Project website](https://ipfs.tech) to learn more.
 
@@ -124,7 +124,7 @@ To temporarily suspend all IPFS integrations (redirects, API status content scri
 
 ![Turn IPFS Companion off and on again](https://gateway.ipfs.io/ipfs/QmZqyBnLY1jatj2ppJEbJqyj8oJecZt7chNB62jhhq8f9g)
 
-### Try out experiments!
+### Experiments
 
 IPFS Companion ships with a variety of experimental features. Some are disabled by default, so be sure to check out IPFS Companion's Preferences to see them all.
 
@@ -165,7 +165,7 @@ To work on IPFS Companion's code, you'll need to install it from source. Quick s
 
 [![](https://cdn.jsdelivr.net/gh/jbenet/contribute-ipfs-gif@master/img/contribute.gif)](./docs/CONTRIBUTING.md)
 
-All are welcome to help make IPFS Companion even better!
+Contributions are welcome.
 - Check out the [contribution guide](./docs/CONTRIBUTING.md) for how to get started as a developer
 - Open an [issue](https://github.com/ipfs/ipfs-companion/issues)
 - Make sure you read and abide by the [IPFS Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://discuss.ipfs.tech"><img alt="Discourse Forum" src="https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdiscuss.ipfs.tech&amp;color=blue"></a>
   <a href="https://matrix.to/#/#ipfs-space:ipfs.io"><img alt="Matrix Chat" src="https://img.shields.io/matrix/ipfs-space%3Aipfs.io?server_fqdn=matrix.org&amp;color=blue"></a>
   <a href="https://github.com/ipfs/ipfs-companion/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/ipfs/ipfs-companion?filter=!*rc*"></a>
-  <a href="https://github.com/ipfs-shipyard/ipfs-companion/blob/main/docs/LOCALIZATION-NOTES.md"><img src="https://img.shields.io/badge/i18n-translated-blue.svg" alt="i18n status"></a>
+  <a href="https://github.com/ipfs/ipfs-companion/blob/main/docs/LOCALIZATION-NOTES.md"><img src="https://img.shields.io/badge/i18n-translated-blue.svg" alt="i18n status"></a>
   <a href="https://github.com/ipfs/ipfs-companion/actions"><img src="https://img.shields.io/github/actions/workflow/status/ipfs/ipfs-companion/ci.yml?branch=main" alt="ci"></a>
 </p>
 
@@ -109,7 +109,7 @@ IPFS Companion enables you to quickly and easily access common actions from your
 - Choose the _Import_ option in the main menu for quick drag-and-drop import from a browser tab
 - Pin or unpin IPFS resources (via API) directly from the main menu
 - Copy shareable public gateway links, IPFS content paths, or CIDs of IPFS resources directly from the main menu
-- Launch the [IPFS Web UI dashboard](https://github.com/ipfs-shipyard/ipfs-webui) from the main menu with a single click
+- Launch the [IPFS Web UI dashboard](https://github.com/ipfs/ipfs-webui) from the main menu with a single click
 - Toggle gateway redirects or switch all IPFS Companion features on/off quickly and easily from the main menu (illustrations below)
 
 #### Toggle gateway redirects on a per-website basis
@@ -143,14 +143,14 @@ IPFS Companion ships with a variety of experimental features. Some are disabled 
 
 **Important!** Make sure you have [IPFS installed](https://docs.ipfs.tech/install/) on your computer as well. IPFS Companion requires a local IPFS [Kubo](https://github.com/ipfs/kubo) node running on your computer to function properly.
 
-It's also possible to grab [vendor-specific packages for each release](https://github.com/ipfs-shipyard/ipfs-companion/releases),
+It's also possible to grab [vendor-specific packages for each release](https://github.com/ipfs/ipfs-companion/releases),
 but these builds are not signed, nor will they automatically update. `.zip` bundles are meant only to be manually loaded via `chrome://extensions` (Chromium) or `about:debugging` (Firefox) for smoke-testing.
 
 ### Development
 
 To work on IPFS Companion's code, you'll need to install it from source. Quick steps are below, but see the full [developer notes](./docs/DEVELOPER-NOTES.md) for more detailed instructions and tips.
 
-1. Clone https://github.com/ipfs-shipyard/ipfs-companion.git
+1. Clone https://github.com/ipfs/ipfs-companion.git
 2. Run this all-in-one dev build to install dependencies, build, and launch in the browser of your choice:
     * Chromium
         ```console
@@ -184,7 +184,7 @@ The release process has been [documented here](./docs/RELEASE-PROCESS.md).
 ### Common troubleshooting steps
 These frequently encountered troubleshooting situations may be helpful:
 - **Import via right-click does not work in Firefox:** See [this workaround](https://github.com/ipfs/ipfs-companion/issues/227).
-- **HTTP-to-HTTPS redirects fail when using Ghostery:** [Ghostery](https://addons.mozilla.org/en-US/firefox/addon/ghostery/) is known to interfere with HTTP-to-HTTPS redirects, which in some setups breaks websites utilizing public gateways [(more details)](https://github.com/ipfs-shipyard/ipfs-companion/issues/466). Until this is fixed upstream, a workaround is to [allowlist](https://user-images.githubusercontent.com/157609/39089525-5834c104-45c9-11e8-9e17-4459a97e5676.png) affected sites.
+- **HTTP-to-HTTPS redirects fail when using Ghostery:** [Ghostery](https://addons.mozilla.org/en-US/firefox/addon/ghostery/) is known to interfere with HTTP-to-HTTPS redirects, which in some setups breaks websites utilizing public gateways [(more details)](https://github.com/ipfs/ipfs-companion/issues/466). Until this is fixed upstream, a workaround is to [allowlist](https://user-images.githubusercontent.com/157609/39089525-5834c104-45c9-11e8-9e17-4459a97e5676.png) affected sites.
 - **NoScript breaks IPFS Companion:** By default, [NoScript](https://addons.mozilla.org/en-US/firefox/addon/noscript/) breaks IPFS Companion by blocking assets loaded from an IPFS gateway running on localhost. To fix this, extend the SYSTEM ruleset and prepend it with IPFS whitelist (feel free to modify this, but get familiar with [ABE rule syntax](https://noscript.net/abe/) first):
 ```
 # Enable IPFS redirect to LOCAL

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To work on IPFS Companion's code, you'll need to install it from source. Quick s
 
 ## Contribute
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](./docs/CONTRIBUTING.md)
+[![](https://cdn.jsdelivr.net/gh/jbenet/contribute-ipfs-gif@master/img/contribute.gif)](./docs/CONTRIBUTING.md)
 
 All are welcome to help make IPFS Companion even better!
 - Check out the [contribution guide](./docs/CONTRIBUTING.md) for how to get started as a developer
@@ -185,7 +185,7 @@ The release process has been [documented here](./docs/RELEASE-PROCESS.md).
 These frequently encountered troubleshooting situations may be helpful:
 - **Import via right-click does not work in Firefox:** See [this workaround](https://github.com/ipfs/ipfs-companion/issues/227).
 - **HTTP-to-HTTPS redirects fail when using Ghostery:** [Ghostery](https://addons.mozilla.org/en-US/firefox/addon/ghostery/) is known to interfere with HTTP-to-HTTPS redirects, which in some setups breaks websites utilizing public gateways [(more details)](https://github.com/ipfs-shipyard/ipfs-companion/issues/466). Until this is fixed upstream, a workaround is to [allowlist](https://user-images.githubusercontent.com/157609/39089525-5834c104-45c9-11e8-9e17-4459a97e5676.png) affected sites.
-- **NoScript breaks IPFS Companion:** By default, [NoScript](https://addons.mozilla.org/en-US/firefox/addon/noscript/) breaks IPFS Companion by blocking assets loaded from an IPFS gateway running on localhost. To fix this, extend the SYSTEM ruleset and prepend it with IPFS whitelist (feel free to modify this, but get familiar with [ABE rule syntax](https://noscript.net/abe/abe_rules.pdf) first):
+- **NoScript breaks IPFS Companion:** By default, [NoScript](https://addons.mozilla.org/en-US/firefox/addon/noscript/) breaks IPFS Companion by blocking assets loaded from an IPFS gateway running on localhost. To fix this, extend the SYSTEM ruleset and prepend it with IPFS whitelist (feel free to modify this, but get familiar with [ABE rule syntax](https://noscript.net/abe/) first):
 ```
 # Enable IPFS redirect to LOCAL
 Site ^http://127.0.0.1:8080/(ipfs|ipns)*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,83 +1,32 @@
 # Security notes
 
-The IPFS protocol and its implementations are still in heavy development. This means that there may be problems in our protocols, or there may be mistakes in our implementations. And — though IPFS is not production-ready yet — many people are already running nodes on their machines, so we take security vulnerabilities very seriously.
-
 ## Reporting security issues
 
-If you discover a security issue in ipfs-companion, please bring it to our attention right away!
+If you find a security issue in ipfs-companion, report it privately to security@ipfs.io. **Please do not file a public issue** for anything that could affect people running the extension, for example a way to bypass redirect safety, leak browsing activity, or run code in a page's origin.
 
-If you find a vulnerability that may affect live deployments — for example, by exposing a remote execution exploit — please send your report privately to security@ipfs.io **Please do not file a public issue.**
+If the issue is a design weakness that cannot be exploited as-is, or covers something not yet released, it is fine to discuss it openly.
 
-If the issue is a protocol weakness that cannot be immediately exploited, or something not yet deployed, just discuss it openly.
+## Verifying a build against the source
 
-## Local build and source verification
+You can confirm that a published extension was built from the source at a given tag by rebuilding it yourself and comparing the result.
 
-Security-conscious users can confirm that downloaded package does match source code.
+1. Check out the [matching tag](https://github.com/ipfs/ipfs-companion/tags) for the version you want to verify.
+2. Build reproducibly in Docker:
 
-Required steps:
+   ```sh
+   npm run release-build
+   ```
 
-1. Download package version that is to be verified
-2. Check out sources of the [same tag](https://github.com/ipfs/ipfs-companion/tags)
-2. Build package from sources using `yarn dev-build` command.    
-   As a result, you will have freshly built packages in `build/` directory
-3. Unzip contents and compare manually or use handy one-liners below.
+   The build runs inside a pinned image for identical output across platforms. Afterwards `build/` holds `ipfs_companion-<version>_chromium.zip` and `ipfs_companion-<version>_firefox.zip`.
+3. Download the package you want to check, from the store or from the [GitHub release](https://github.com/ipfs/ipfs-companion/releases).
 
-Convention used in examples below:
-- `ipfs-firefox-addon1.xpi` and `ipfs-firefox-addon2.xpi` are equal and match Git sources
--  `ipfs-firefox-addon3.xpi` contains changes not present in current sources
+Extension packages are zip archives, so compare the files inside them rather than the archive bytes (zip metadata such as timestamps can differ):
 
-### Compare SHA-256
-
-Note that XPIs are unzipped before being piped to `sha256sum`:
-```bash
-$ diff -q <(unzip -p  ipfs-firefox-addon1.xpi|sha256sum|cut -f1 -d' ') <(unzip -p  ipfs-firefox-addon3.xpi|sha256sum|cut -f1 -d' ') && echo same || echo not_same
+```sh
+mkdir built published
+unzip -q build/ipfs_companion-<version>_chromium.zip -d built
+unzip -q downloaded.zip -d published
+diff -r built published && echo same || echo differs
 ```
 
-Sample output for files with matching contents:
-```bash
-$ diff <(unzip -v -l ipfs-firefox-addon1.xpi | cut -c 1-9,59-,49-57 | sort -k3) <(unzip -v -l ipfs-firefox-addon2.xpi | cut -c 1-9,59-,49-57 | sort -k3)  && echo same || echo not_same
-same
-
-```
-
-Sample output for files with different contents:
-```bash
-$ diff -q <(unzip -p  ipfs-firefox-addon1.xpi|sha256sum|cut -f1 -d' ') <(unzip -p  ipfs-firefox-addon3.xpi|sha256sum|cut -f1 -d' ') && echo same || echo not_same
-Files /proc/self/fd/11 and /proc/self/fd/12 differ
-not_same
-```
-
-### Inspect differences
-
-It is possible to list package contents with CRC-32 checksums provided by ZIP container:
-```bash
-$ unzip -v -l ipfs-firefox-addon1.xpi | cut -c 1-9,59-,49-57 | sort -k3
-```
-To compare two packages in one command:
-```bash
-$ diff <(unzip -v -l ipfs-firefox-addon1.xpi | cut -c 1-9,59-,49-57 | sort -k3) <(unzip -v -l ipfs-firefox-addon3.xpi | cut -c 1-9,59-,49-57 | sort -k3) && echo same || echo not_same
-```
-
-Sample output for two different versions of XPI:
-```diff
-$ diff <(unzip -v -l ipfs-firefox-addon1.xpi | cut -c 1-9,59-,49-57 | sort -k3) <(unzip -v -l ipfs-firefox-addon3.xpi | cut -c 1-9,59-,49-57 | sort -k3) && echo same || echo not_same
-5,7c5,7
-<      174 d991ba90 defaults/preferences/prefs.js
-<    37615          30 files
-<     2270 06d511c2 harness-options.json
----
->      225 5b287a38 defaults/preferences/prefs.js
->    38998          30 files
->     2315 6291e716 harness-options.json
-13c13
-<      385 c2c13711 options.xul
----
->      513 4f3e0732 options.xul
-33,34c33,34
-<     6376 45297f28 resources/ipfs-firefox-addon/lib/index.js
-<      966 e48f0540 resources/ipfs-firefox-addon/lib/package.json
----
->     7517 7565d9af resources/ipfs-firefox-addon/lib/index.js
->      984 83079aef resources/ipfs-firefox-addon/lib/package.json
-not_same
-```
+A clean `diff -r` means the package contents match what these sources produce.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,7 +20,7 @@ As a courtesy, please add a comment informing  about your intent. That way we wi
 ### Submitting Pull Requests
 
 Just make sure your PR comes with its own tests and does pass CI tests.
-See the [GitHub Flow Guide](https://guides.github.com/introduction/flow/) for details.
+See the [GitHub flow guide](https://docs.github.com/en/get-started/using-github/github-flow) for details.
 
 
 ## Translations
@@ -38,4 +38,4 @@ If you want to download translations from Transifex and run them locally, make s
 
 - https://github.com/ipfs/in-web-browsers
 - https://github.com/ipfs/community/blob/master/CONTRIBUTING.md
-  [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
+  [![](https://cdn.jsdelivr.net/gh/jbenet/contribute-ipfs-gif@master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)

--- a/docs/DEVELOPER-NOTES.md
+++ b/docs/DEVELOPER-NOTES.md
@@ -26,10 +26,10 @@ If you're looking to develop on IPFS Companion, you should build the project fro
 
 ### Clone and build
 
-First, clone the `ipfs-shipyard/ipfs-companion` [repository](https://github.com/ipfs-shipyard/ipfs-companion):
+First, clone the `ipfs/ipfs-companion` [repository](https://github.com/ipfs/ipfs-companion):
 
  ```bash
- git clone https://github.com/ipfs-shipyard/ipfs-companion.git
+ git clone https://github.com/ipfs/ipfs-companion.git
  ```
 
 Then, run this all-in-one dev build, which includes installing dependencies into the `node_modules` directory:
@@ -232,7 +232,7 @@ All channels are available at the Google Play Store:
 
 ### Install IPFS Companion
 
-For full installation instructions, see [`README/#install`](https://github.com/ipfs-shipyard/ipfs-companion#install) in the IPFS Companion repo.
+For full installation instructions, see [`README/#install`](https://github.com/ipfs/ipfs-companion#install) in the IPFS Companion repo.
 
 You can also test the latest code locally on an emulator, or via USB on your own device. See below for details.
 

--- a/docs/DEVELOPER-NOTES.md
+++ b/docs/DEVELOPER-NOTES.md
@@ -73,7 +73,8 @@ npm run dev-build chromium        # all-in-one
 You can also build it to manually install:
 
 ```bash
-npm run build bundle:chromium     # last part is important: it overwrites manifest
+npm run build            # build the extension
+npm run bundle:chromium  # overwrite add-on/manifest.json for Chromium
 ```
 
 Then load the extension manually:
@@ -157,7 +158,7 @@ You can run the tests against either release or dev builds of the extension.
 To download release builds of the extension, run:
 
 ```sh
-./ci/e2e/download-release-builds.sh
+./ci/download-release-artifacts.sh
 ```
 
 _NOTE_: When using release builds, you can control the version of the extension by setting the `IPFS_COMPANION_VERSION` environment variable:
@@ -180,43 +181,22 @@ npm run release-build
 
 ### Preparing the docker environment
 
-You need to pull docker images for [Kubo](https://github.com/ipfs/kubo), [Chromium](https://hub.docker.com/r/selenium/standalone-chrome/) and [Firefox](https://hub.docker.com/r/selenium/standalone-firefox/) before running the tests.
-
-You also need to build the docker image containing the e2e tests.
-
-To do all of this, run:
+The tests run a Kubo node in one container and Playwright with a headless Chromium in another. Pull the Kubo image and build the test image with:
 
 ```sh
 npm run compose:e2e:prepare
 ```
 
-_NOTE_: You can control the versions of Kubo, Chromium and Firefox by setting the following environment variables:
+_NOTE_: Pin the Kubo version with the `KUBO_VERSION` environment variable:
 
 ```sh
 export KUBO_VERSION=x.y.z
-export CHROMIUM_VERSION=x.y.z
-export FIREFOX_VERSION=x.y.z
-```
-
-**IMPORTANT**: If you are running the tests on a ARM machine, you need to use a different Chromium image. To do this, run:
-
-```sh
-export CHROMIUM_IMAGE=seleniarm/standalone-chromium
-export FIREFOX_IMAGE=seleniarm/standalone-firefox
 ```
 
 ### Running the tests
 
-To run the tests, run:
-
 ```sh
 npm run compose:e2e:test
-```
-
-_NOTE_: You can control whether the browsers operate in headless mode as follows:
-
-```sh
-export TEST_HEADLESS=true
 ```
 
 ### Stopping the docker environment
@@ -298,7 +278,7 @@ The remote debug port will be printed to the console right after successful depl
 You can connect to this Android device on TCP port <debug PORT>
 ```
 
-The fastest way to connect is to open `chrome://devtools/content/framework/connect/connect.xhtml` in Firefox on the same machine you run `web-ext` from.
+The fastest way to connect is to open `about:debugging` in Firefox on the same machine you run `web-ext` from, then connect to your device from the "Setup" tab.
 
 ### Further resources
 

--- a/docs/DEVELOPER-NOTES.md
+++ b/docs/DEVELOPER-NOTES.md
@@ -97,13 +97,9 @@ npm run watch     # watch for new changes
 
 ## Reproducible build in Docker
 
-Want to ensure prebuilt bundle does not include any additional code?
-Don't want to install JS dependencies such as NodeJS?
+To build without installing the JS toolchain locally, and to confirm the bundle carries no extra code, build inside Docker.
 
-Do an isolated build inside of Docker!
-
-Run the following command for ending up
-with a built extension inside the `build/` directory:
+Run this to produce a built extension in the `build/` directory:
 
 ```sh
 npm run release-build

--- a/docs/LOCALIZATION-NOTES.md
+++ b/docs/LOCALIZATION-NOTES.md
@@ -17,13 +17,13 @@ IPFS Companion supports running in specific locales, with translations provided 
 
 Chrome comes with locales out of the box, so it is enough to set the proper env:
 
-```go
+```bash
 LANGUAGE=pl chromium --user-data-dir=`mktemp -d`
 ```
 
 ### Further resources
 
-- [Language Codes in Chromium Project](https://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc)
+- [Supported locales in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:build/config/locales.gni)
 
 ## Running Firefox with a specific locale
 
@@ -53,7 +53,8 @@ If your language is not present in `add-on/_locales` yet, but is supported by ma
 
 Translations sync automatically from Transifex weekly via `.github/workflows/tx-pull.yml`:
 - Uses `--mode onlytranslated` to pull only translated strings
-- Empty strings fallback to English via browser's i18n API at runtime
-- Creates PR for review
+- Uses `--minimum-perc 40` so only locales that are at least 40% translated are pulled
+- Empty strings fall back to English via the browser's i18n API at runtime
+- Opens a PR for review
 
 **Note:** Edit translations only in Transifex. GitHub changes will be overwritten.

--- a/docs/MV3.md
+++ b/docs/MV3.md
@@ -135,4 +135,4 @@ Since the process is asynchronous, there are a few things that we need to keep i
 
 ## Other Thoughts
 
-Not intercepting requests synchronously has its quirks, but implementing a dynamic ruleset of possible redirects is even more complicated. We're expecting drastic improvements in load times from the second request (to the same host) onwards as the browser no longer relies on companion to intercept requests and redirect those. Instead declarative rule set allows for redirection to happen at the browser level, which is much faster in-theory. This also means that companion is no longer a bottleneck for the browser, which is a good thing.
+Not intercepting requests synchronously has its quirks, but maintaining a dynamic ruleset of possible redirects is more complicated. From the second request to a given host onwards, the browser applies the declarative rules itself, so Companion is no longer in the request path. That should cut load times and keep Companion from being a bottleneck.

--- a/docs/MV3.md
+++ b/docs/MV3.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This document describes the migration process from MV2 to MV3. MV3 is a new version of the extension manifest format that fundamentally changes the way extensions are loaded and run in the browser. A few notable changes have been discussed in this [thread](https://discuss.ipfs.tech/t/announcing-ipfs-companion-mv3-rc-beta/16442) and a detailed plan can be found [here](https://github.com/ipfs/ipfs-companion/issues/1152).
+This document describes the migration process from MV2 to MV3. MV3 is the extension manifest format that changes how extensions intercept and redirect network requests. A few notable changes have been discussed in this [thread](https://discuss.ipfs.tech/t/announcing-ipfs-companion-mv3-rc-beta/16442) and a detailed plan can be found [here](https://github.com/ipfs/ipfs-companion/issues/1152).
 
 ## Implementation
 
-The most important change that lead to this migration was how url request interception model was changed. In MV2, we used `webRequest.onBeforeRequest` to intercept requests and redirect them to the local gateway. That process looked something like:
+The change that drove this migration is how request interception works. In MV2, we used `webRequest.onBeforeRequest` to intercept requests and redirect them to the local gateway. That process looked something like:
 
 ```mermaid
 flowchart TD
@@ -53,7 +53,7 @@ The process is asynchronous, the browser allows "observation" of requests to com
   },
   condition: {
     '<regex filter>',                    // filter to match requests
-    '<filtered domains list>,
+    '<filtered domains list>',
     resourceTypes: [
       'csp_report',
       'font',

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,1 @@
-Content present in this directory was moved to [IPFS Docs](https://docs.ipfs.io).
+Content present in this directory was moved to [IPFS Docs](https://docs.ipfs.tech).

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -10,7 +10,7 @@ Releases are cut by [release-please](https://github.com/googleapis/release-pleas
 
 ## Cut the release
 
-release-please watches `main` and keeps an open pull request titled `chore: release ipfs-companion vX.Y.Z`. It bumps the version in `package.json` and `add-on/manifest.common.json` and updates `CHANGELOG.md` from the conventional-commit history.
+release-please watches `main` and keeps an open pull request titled `chore: release vX.Y.Z`. It bumps the version in `package.json` and `add-on/manifest.common.json` and updates `CHANGELOG.md` from the conventional-commit history.
 
 To ship:
 
@@ -48,12 +48,12 @@ If release-please or CI is down and a fix has to ship now, cut the release by ha
 ## Publish on Chrome Web Store
 
 All Chromium-based browsers support install from Chrome Web Store.
-Brave, Opera, and Edge do not require additional publishing step.
+Brave, Opera, and Edge do not require an additional publishing step.
 
 - IPFS Companion Chrome Webstore: https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch
 - Publishing requires your Google Account to belong to the IPFS Companion Maintainers Google Group (ask IPFS Stewards to be added).
 - Go to Developer Dashboard and select publisher in the top right: `IPFS Shipyard`
-- You should see `IPFS Companion` and `IPFS Companion (Beta @ xxxxxx). If not, select `Items` on the left menu.
+- You should see `IPFS Companion` and `IPFS Companion (Beta @ xxxxxx)`. If not, select `Items` on the left menu.
 - Select the correct extension you want to publish, usually `IPFS Companion`.
 - Select `Package` on the left menu (Under the Build category).
 - Upload the `ipfs_companion-<version>_chromium.zip` attached to the GitHub release.

--- a/docs/dnslink.md
+++ b/docs/dnslink.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs.ipfs.io/how-to/dnslink-companion/)
+Moved [here](https://docs.ipfs.tech/how-to/dnslink-companion/)

--- a/docs/node-types.md
+++ b/docs/node-types.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs.ipfs.io/how-to/companion-node-types/)
+Moved [here](https://docs.ipfs.tech/how-to/companion-node-types/)

--- a/docs/x-ipfs-path-header.md
+++ b/docs/x-ipfs-path-header.md
@@ -1,1 +1,1 @@
-Moved [here](https://docs.ipfs.io/how-to/companion-x-ipfs-path-header/)
+Moved [here](https://docs.ipfs.tech/how-to/companion-x-ipfs-path-header/)


### PR DESCRIPTION
Fix stale build steps, dead links, and factual drift across the markdown docs, and add a values section to AGENTS.md that guides every change to the extension's no-tracking and user-agency guarantees.