### PR TITLE
fix: clear firefox amo submission warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,10 @@ version lives in [PRIVACY-POLICY.md](PRIVACY-POLICY.md).
 
 - Never track the user. No analytics, telemetry, or phone-home. Outbound
   requests belong to a feature the user asked for (a gateway fetch, an RPC call
-  to their own node), never measurement.
+  to their own node), never measurement. If this ever changes, the data
+  collected must be spelled out in [PRIVACY-POLICY.md](PRIVACY-POLICY.md) and
+  declared in `data_collection_permissions` under `browser_specific_settings`
+  in `add-on/manifest.firefox.json` (`["none"]` today); keep the two in sync.
 - Never leak browsing activity. The extension sees every URL the user visits;
   that data stays on the machine and goes to no third party.
 - Preserve user agency. Automatic behavior (redirects, gateway choice, node

--- a/add-on/manifest.firefox.json
+++ b/add-on/manifest.firefox.json
@@ -11,7 +11,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "ipfs-firefox-addon@lidel.org",
-      "strict_min_version": "111.0"
+      "strict_min_version": "113.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     }
   },
   "permissions": [

--- a/add-on/src/utils/i18n.js
+++ b/add-on/src/utils/i18n.js
@@ -25,6 +25,9 @@ export const renderTranslatedLinks = (message, links, attributes) => {
     matchLink = regexLink.exec(str)
   }
 
+  // innerHTML is safe here: `output` is built only from our own bundled
+  // _locales messages, which deliberately carry markup (the <N> anchor/span
+  // markers and inline tags like <code>). No remote or user input reaches it.
   const template = document.createElement('template')
   template.innerHTML = output
 
@@ -54,6 +57,9 @@ export const renderTranslatedSpans = (message, values, attributes) => {
     matchSpan = regexSpan.exec(str)
   }
 
+  // innerHTML is safe here: `output` is built only from our own bundled
+  // _locales messages, which deliberately carry markup (the <N> anchor/span
+  // markers and inline tags like <code>). No remote or user input reaches it.
   const template = document.createElement('template')
   template.innerHTML = output
 


### PR DESCRIPTION
## Problem

Submitting the v3.4.0 Firefox build to addons.mozilla.org raised validator warnings. The required `data_collection_permissions` key was missing[^1], and `strict_min_version` was 111, below Firefox 113 where the `declarativeNetRequest` APIs the bundle references first exist.

## Fix

- declare no data collection: `data_collection_permissions.required` set to `["none"]`, matching our no-tracking privacy policy
- raise `strict_min_version` to 113, the floor for the `declarativeNetRequest` namespace (`getDynamicRules`)
- document why the i18n `innerHTML` is safe, since addons-linter keeps flagging it

The 113 bump drops Firefox 111-112 (March-April 2023); those `declarativeNetRequest` paths never run on Firefox anyway, which uses `webRequestBlocking`. Two validator warnings remain and are expected: the consent key is only recognized in Firefox 140+, so a lower min version draws an informational note and older Firefox ignores the key. The `innerHTML` warnings also remain by design; their input is our own bundled translations, and the code now says so inline.

[^1]: [Firefox built-in data consent](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/): the key is required for new extensions and, in future, new versions of existing ones.